### PR TITLE
fix(runtime): prevent dry-run payments from entering infinite polling loop

### DIFF
--- a/.changeset/fix-dry-run-payment-poll.md
+++ b/.changeset/fix-dry-run-payment-poll.md
@@ -1,0 +1,5 @@
+---
+"@fiber-pay/runtime": patch
+---
+
+Fix dry-run payments causing infinite polling. The payment executor now short-circuits dry_run payments to `DryRunSuccess` instead of entering the inflight polling loop, and the RPC proxy no longer auto-tracks dry_run payment hashes.

--- a/packages/runtime/src/jobs/executors/payment-executor.ts
+++ b/packages/runtime/src/jobs/executors/payment-executor.ts
@@ -100,6 +100,22 @@ export async function* runPaymentJob(
         }
 
         // Status is 'Created' or 'Inflight' — move to polling state
+        // Dry-run payments are never persisted by the node, so polling
+        // getPayment would loop forever with "Payment session not found".
+        if (current.params.sendPaymentParams.dry_run) {
+          current = transitionJobState(current, paymentStateMachine, 'payment_success', {
+            patch: {
+              result: {
+                paymentHash: sendResult.payment_hash,
+                status: 'DryRunSuccess',
+                fee: sendResult.fee,
+              },
+            },
+          });
+          yield current;
+          return;
+        }
+
         current = transitionJobState(current, paymentStateMachine, 'payment_inflight');
         if (paymentHash) {
           current = {

--- a/packages/runtime/src/proxy/jsonrpc-tracking.ts
+++ b/packages/runtime/src/proxy/jsonrpc-tracking.ts
@@ -3,22 +3,29 @@ import { isObject } from './json.js';
 interface JsonRpcMessage {
   id?: string | number;
   method?: string;
+  params?: unknown[];
   result?: unknown;
   error?: unknown;
 }
 
-export function collectJsonRpcMethods(requestBody: unknown): Map<string | number, string> {
-  const methods = new Map<string | number, string>();
+export interface RequestMeta {
+  method: string;
+  dryRun: boolean;
+}
+
+export function collectJsonRpcMethods(requestBody: unknown): Map<string | number, RequestMeta> {
+  const methods = new Map<string | number, RequestMeta>();
   for (const item of normalizeJsonRpcRequest(requestBody)) {
     if (item.id !== undefined && typeof item.method === 'string') {
-      methods.set(item.id, item.method);
+      const dryRun = isDryRunRequest(item);
+      methods.set(item.id, { method: item.method, dryRun });
     }
   }
   return methods;
 }
 
 export function captureTrackedHashes(
-  methodById: Map<string | number, string>,
+  methodById: Map<string | number, RequestMeta>,
   responseBody: unknown,
   handlers: {
     onInvoiceTracked: (paymentHash: string) => void;
@@ -31,19 +38,21 @@ export function captureTrackedHashes(
     if (message.error || message.id === undefined) {
       continue;
     }
-    const method = methodById.get(message.id);
-    if (!method) {
+    const meta = methodById.get(message.id);
+    if (!meta) {
       continue;
     }
 
-    if (method === 'new_invoice') {
+    if (meta.method === 'new_invoice') {
       const paymentHash = extractInvoicePaymentHash(message.result);
       if (paymentHash) {
         handlers.onInvoiceTracked(paymentHash);
       }
     }
 
-    if (method === 'send_payment') {
+    // Skip tracking dry-run payments — the node never persists them,
+    // so the tracker would poll getPayment forever.
+    if (meta.method === 'send_payment' && !meta.dryRun) {
       const paymentHash = extractPaymentHash(message.result);
       if (paymentHash) {
         handlers.onPaymentTracked(paymentHash);
@@ -101,4 +110,12 @@ function extractPaymentHash(result: unknown): string | undefined {
     return undefined;
   }
   return typeof result.payment_hash === 'string' ? result.payment_hash : undefined;
+}
+
+function isDryRunRequest(message: JsonRpcMessage): boolean {
+  if (!Array.isArray(message.params) || message.params.length === 0) {
+    return false;
+  }
+  const firstParam = message.params[0];
+  return isObject(firstParam) && firstParam.dry_run === true;
 }


### PR DESCRIPTION
## Problem

When `sendPayment` is called with `dry_run: true`, the Fiber node returns a `Created`/`Inflight` status but **never persists the payment session**. This causes two independent infinite polling loops:

1. **PaymentExecutor** (Job system path): enters the `inflight` state and polls `getPayment` forever — every poll returns "Payment session not found"
2. **RPC Proxy** (passthrough path): auto-captures the `payment_hash` from `send_payment` responses and adds it to the `PaymentTracker` tracked list, which also polls `getPayment` every 2 seconds indefinitely

This is a separate issue from #60 (which fixes the tracker's handling of not-found errors generically). Even with #60 merged, the executor would still enter the unnecessary inflight polling loop for dry-run payments, and the proxy would still add dry-run hashes to the tracker (though #60 ensures they get cleaned up quickly).

## Fix

### PaymentExecutor (`payment-executor.ts`)

When `sendPaymentParams.dry_run` is true and the node returns `Created`/`Inflight`, short-circuit immediately to `payment_success` with status `DryRunSuccess` instead of transitioning to the `inflight` polling state.

### RPC Proxy (`jsonrpc-tracking.ts`)

- Extended `collectJsonRpcMethods` to also detect `dry_run: true` in request params
- `captureTrackedHashes` now skips adding payment hashes for dry-run `send_payment` responses

## Changed Files

- `packages/runtime/src/jobs/executors/payment-executor.ts` — dry_run short-circuit
- `packages/runtime/src/proxy/jsonrpc-tracking.ts` — skip dry_run tracking

## Testing

All 220 existing tests pass (5 packages, 30 test files). Typecheck clean.
