### PR TITLE
feat(sdk): add browser-safe typed RPC client export in @fiber-pay/sdk/browser

### DIFF
--- a/.changeset/curly-toes-play.md
+++ b/.changeset/curly-toes-play.md
@@ -1,0 +1,11 @@
+---
+"@fiber-pay/sdk": patch
+---
+
+# @fiber-pay/sdk
+
+Add a browser-safe typed RPC client export in `@fiber-pay/sdk/browser`.
+
+- Export `FiberRpcClient` and `RpcClientConfig` from browser entry
+- Add `BrowserRpcClient` and `BrowserRpcClientConfig` aliases for clearer frontend DX
+- Document browser RPC client usage in SDK README

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -14,13 +14,30 @@ pnpm add @fiber-pay/sdk
 import { FiberRpcClient } from '@fiber-pay/sdk';
 
 const client = new FiberRpcClient({
-	url: 'http://127.0.0.1:8227',
-	biscuitToken: process.env.FIBER_RPC_BISCUIT_TOKEN,
+  url: 'http://127.0.0.1:8227',
+  biscuitToken: process.env.FIBER_RPC_BISCUIT_TOKEN,
 });
 
 const info = await client.nodeInfo();
 console.log(info.pubkey);
 ```
+
+## Browser Usage
+
+Use the browser subpath in frontend apps to avoid pulling Node-only modules:
+
+```ts
+import { BrowserRpcClient } from '@fiber-pay/sdk/browser';
+
+const client = new BrowserRpcClient({
+  url: 'http://127.0.0.1:8227',
+});
+
+const info = await client.nodeInfo();
+console.log(info.pubkey);
+```
+
+`@fiber-pay/sdk/browser` also exports `FiberRpcClient` for migration compatibility.
 
 ## RPC Authentication (Biscuit)
 
@@ -34,9 +51,9 @@ Generate token-side permission facts from RPC methods:
 import { renderBiscuitFactsForMethods } from '@fiber-pay/sdk';
 
 const facts = renderBiscuitFactsForMethods([
-	'list_peers',
-	'send_payment',
-	'get_payment',
+  'list_peers',
+  'send_payment',
+  'get_payment',
 ]);
 
 console.log(facts);

--- a/packages/sdk/src/browser/index.ts
+++ b/packages/sdk/src/browser/index.ts
@@ -58,7 +58,15 @@ export { FiberWasmAdapter } from './wasm-adapter.js';
 // =============================================================================
 
 export { scriptToAddress } from '../address.js';
-export { FiberRpcError } from '../rpc/client.js';
+export type {
+  RpcClientConfig,
+  RpcClientConfig as BrowserRpcClientConfig,
+} from '../rpc/client.js';
+export {
+  FiberRpcClient,
+  FiberRpcClient as BrowserRpcClient,
+  FiberRpcError,
+} from '../rpc/client.js';
 export type {
   AbandonChannelParams,
   AcceptChannelParams,

--- a/packages/sdk/tests/browser-rpc-client.test.ts
+++ b/packages/sdk/tests/browser-rpc-client.test.ts
@@ -1,0 +1,71 @@
+import {
+  BrowserRpcClient,
+  type BrowserRpcClientConfig,
+  FiberRpcClient,
+  FiberRpcError,
+} from '../src/browser/index.js';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('Browser RPC client exports', () => {
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it('should export BrowserRpcClient as FiberRpcClient-compatible alias', () => {
+    expect(BrowserRpcClient).toBe(FiberRpcClient);
+  });
+
+  it('should call node_info via browser entry client', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        jsonrpc: '2.0',
+        id: 1,
+        result: {
+          node_name: 'browser-node',
+        },
+      }),
+    });
+    globalThis.fetch = fetchMock;
+
+    const config: BrowserRpcClientConfig = { url: 'http://127.0.0.1:8227' };
+    const client = new BrowserRpcClient(config);
+    await client.nodeInfo();
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const requestInit = fetchMock.mock.calls[0][1] as RequestInit;
+    const body = JSON.parse(requestInit.body as string);
+    expect(body.method).toBe('node_info');
+    expect(body.params).toEqual([]);
+  });
+
+  it('should throw FiberRpcError on JSON-RPC error responses', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        jsonrpc: '2.0',
+        id: 1,
+        error: {
+          code: -32010,
+          message: 'permission denied',
+        },
+      }),
+    });
+    globalThis.fetch = fetchMock;
+
+    const client = new BrowserRpcClient({ url: 'http://127.0.0.1:8227' });
+
+    await expect(client.nodeInfo()).rejects.toBeInstanceOf(FiberRpcError);
+    await expect(client.nodeInfo()).rejects.toMatchObject({
+      code: -32010,
+      message: 'permission denied',
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #91 by adding a browser-safe typed HTTP RPC client export in @fiber-pay/sdk/browser to match root-entry FiberRpcClient ergonomics.

### What changed

- Export FiberRpcClient from @fiber-pay/sdk/browser
- Export RpcClientConfig from @fiber-pay/sdk/browser
- Add explicit browser aliases for DX clarity:
  - BrowserRpcClient (alias of FiberRpcClient)
  - BrowserRpcClientConfig (alias of RpcClientConfig)
- Add browser-entry tests for client availability and error behavior
- Update SDK README with browser import guidance
- Add changeset for @fiber-pay/sdk patch release

## Compatibility and DX

- This is additive and non-breaking for existing users.
- Frontend users can now migrate from root import to browser-safe import by only changing import path.
- Keeps method naming and behavior aligned with existing FiberRpcClient.

## Relation to #87

- This PR intentionally does **not** change root/node/browser export boundaries from #87.
- It keeps #87 independent by only improving browser entry parity now.
- When #87 is implemented, browser consumers using this PR API should not need additional code changes.

## Validation

- pnpm lint
- pnpm --filter @fiber-pay/sdk test
- pnpm --filter @fiber-pay/sdk typecheck
- pnpm --filter @fiber-pay/sdk build
- Commit hook full-suite checks passed (format:check, lint, build, typecheck, test)
