### PR TITLE
feat(sdk): split Node-only APIs into @fiber-pay/sdk/node

### DIFF
--- a/.changeset/little-comics-brake.md
+++ b/.changeset/little-comics-brake.md
@@ -1,0 +1,12 @@
+---
+"@fiber-pay/sdk": minor
+---
+
+# @fiber-pay/sdk
+
+Refine SDK entrypoint boundaries for better browser safety and developer experience.
+
+- Add `@fiber-pay/sdk/node` subpath export for Node-focused APIs
+- Move L402 server exports (`createL402Middleware`, `MacaroonService`, etc.) out of root entry
+- Keep root entry (`@fiber-pay/sdk`) focused on universal/browser-safe APIs
+- Update docs and internal usage examples to import L402 APIs from `@fiber-pay/sdk/node`

--- a/.changeset/little-comics-brake.md
+++ b/.changeset/little-comics-brake.md
@@ -1,5 +1,5 @@
 ---
-"@fiber-pay/sdk": minor
+"@fiber-pay/sdk": patch
 ---
 
 # @fiber-pay/sdk

--- a/docs/l402-agent-guide.md
+++ b/docs/l402-agent-guide.md
@@ -2,7 +2,7 @@
 
 This guide covers two features:
 
-1. **L402 SDK module** — build L402-gated APIs using `@fiber-pay/sdk`
+1. **L402 SDK module** — build L402-gated APIs using `@fiber-pay/sdk/node`
 2. **CLI agent commands** — one-command paid AI agent services
 
 ## Prerequisites
@@ -19,7 +19,7 @@ import {
   createL402Middleware,
   MacaroonService,
   FiberRpcClient,
-} from '@fiber-pay/sdk';
+} from '@fiber-pay/sdk/node';
 ```
 
 ### MacaroonService
@@ -92,6 +92,7 @@ fiber-pay agent serve \
 ```
 
 This starts an HTTP server on the default port `:8402` (configurable via `--port`) with:
+
 - `POST /` — accepts `{"prompt": "..."}`, invokes `acpx <agent> exec` and returns the response
 - L402 payment gate — every request requires payment before the agent runs
 
@@ -111,6 +112,7 @@ echo "review this" | fiber-pay agent call http://host:8402
 ```
 
 The call flow is fully automatic:
+
 1. Sends prompt → receives 402 challenge
 2. Pays the Fiber invoice
 3. Retries with L402 token → returns agent response

--- a/docs/migration/sdk-entrypoint-boundary-issue-87.md
+++ b/docs/migration/sdk-entrypoint-boundary-issue-87.md
@@ -1,0 +1,88 @@
+# SDK Entrypoint Migration: issue #87
+
+Date: 2026-04-09
+
+## Background
+
+To keep frontend usage safe by default, `@fiber-pay/sdk` now separates Node-only APIs from universal/browser-safe APIs.
+
+Before this change, root entry (`@fiber-pay/sdk`) also exported L402 middleware/server helpers, which can pull Node-only dependencies into browser bundling paths by mistake.
+
+## What Changed
+
+- Added a new Node subpath export: `@fiber-pay/sdk/node`
+- Root entry `@fiber-pay/sdk` is now universal/browser-safe focused
+- L402 server APIs moved to `@fiber-pay/sdk/node`
+
+Node-only APIs moved behind `@fiber-pay/sdk/node` include:
+
+- `createL402Middleware`
+- `L402Middleware`
+- `MacaroonService`
+- `DefaultResourceResolverRegistry`
+- Related L402 types
+
+## Migration Guide
+
+### 1) Update imports for L402/server APIs
+
+Before:
+
+```ts
+import { createL402Middleware, MacaroonService } from '@fiber-pay/sdk';
+```
+
+After:
+
+```ts
+import { createL402Middleware, MacaroonService } from '@fiber-pay/sdk/node';
+```
+
+### 2) Keep universal APIs on root entry
+
+No change needed for universal APIs such as:
+
+- `FiberRpcClient`
+- `FiberRpcError`
+- RPC types
+- conversion and utility helpers
+
+Example:
+
+```ts
+import { FiberRpcClient, ckbToShannons } from '@fiber-pay/sdk';
+```
+
+### 3) Browser projects should continue using browser entry
+
+Use:
+
+```ts
+import { FiberBrowserNode, BrowserRpcClient } from '@fiber-pay/sdk/browser';
+```
+
+Do not import Node-only L402 APIs in browser bundles.
+
+## Why This Improves DX
+
+- Clearer import intent: universal vs browser vs node
+- Lower chance of accidentally bundling Node-only modules into frontend apps
+- More predictable package behavior for tooling and bundlers
+
+## Validation Checklist
+
+- Build passes for SDK and CLI
+- Lint/typecheck/tests pass
+- Export-boundary regression test confirms:
+  - root and browser do not expose Node-only L402 exports
+  - node entry does expose L402 exports
+
+## FAQ
+
+### Is this a breaking change?
+
+Yes for consumers importing L402 APIs from `@fiber-pay/sdk` root. Update those imports to `@fiber-pay/sdk/node`.
+
+### Do I need to change browser code from issue #91?
+
+No. Browser RPC client usage via `@fiber-pay/sdk/browser` stays compatible.

--- a/packages/cli/src/lib/agent-serve.ts
+++ b/packages/cli/src/lib/agent-serve.ts
@@ -10,7 +10,7 @@
 import { execFileSync, spawn } from 'node:child_process';
 import { createServer, type Server } from 'node:http';
 import type { Currency } from '@fiber-pay/sdk';
-import { createL402Middleware, FiberRpcClient } from '@fiber-pay/sdk';
+import { createL402Middleware, FiberRpcClient } from '@fiber-pay/sdk/node';
 import express from 'express';
 import type { CliConfig } from './config.js';
 import { printJsonError, printJsonSuccess } from './format.js';

--- a/packages/cli/src/lib/l402-proxy.ts
+++ b/packages/cli/src/lib/l402-proxy.ts
@@ -8,7 +8,7 @@
 
 import { createServer, type Server } from 'node:http';
 import type { Currency } from '@fiber-pay/sdk';
-import { createL402Middleware, FiberRpcClient } from '@fiber-pay/sdk';
+import { createL402Middleware, FiberRpcClient } from '@fiber-pay/sdk/node';
 import express from 'express';
 import { createProxyMiddleware } from 'http-proxy-middleware';
 import type { CliConfig } from './config.js';

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -8,6 +8,12 @@ Core SDK for building Fiber Network applications on CKB Lightning.
 pnpm add @fiber-pay/sdk
 ```
 
+## Entrypoints
+
+- `@fiber-pay/sdk` - Universal APIs (browser-safe)
+- `@fiber-pay/sdk/browser` - Browser WASM node and browser credential providers
+- `@fiber-pay/sdk/node` - Node-focused APIs, including L402 middleware utilities
+
 ## Usage
 
 ```ts
@@ -67,7 +73,19 @@ and can be used to prepare `permissions.bc` inputs before signing tokens.
 
 ## L402 Protocol
 
-The SDK includes L402 payment-gating primitives for Express APIs:
+Use the Node entrypoint for L402 payment-gating primitives:
+
+```ts
+import {
+  createL402Middleware,
+  FiberRpcClient,
+  MacaroonService,
+} from '@fiber-pay/sdk/node';
+```
+
+Node entry includes the same universal APIs as root, plus L402 server helpers.
+
+L402 primitives include:
 
 - `MacaroonService` — mint and verify L402 tokens
 - `createL402Middleware()` — Express middleware for 402 challenge-response flow
@@ -78,4 +96,3 @@ See [docs/l402-agent-guide.md](../../docs/l402-agent-guide.md) for usage.
 
 - Node.js `>=20`
 - Fiber target: `v0.8.0`
-

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -10,6 +10,10 @@
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
     },
+    "./node": {
+      "import": "./dist/node/index.js",
+      "types": "./dist/node/index.d.ts"
+    },
     "./browser": {
       "import": "./dist/browser/index.js",
       "types": "./dist/browser/index.d.ts"

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -11,28 +11,6 @@ export { scriptToAddress } from './address.js';
 export type { LiquidityReport } from './funds/liquidity-analyzer.js';
 // Funds management
 export { LiquidityAnalyzer } from './funds/liquidity-analyzer.js';
-export type {
-  ChallengeStore,
-  L402Challenge,
-  L402Config,
-  L402Invoice,
-  L402MiddlewareConfig,
-  L402Request,
-  L402Token,
-  MacaroonCaveat,
-  MintParams,
-  ProtectedResourceInfo,
-  ResourceResolver,
-  ResourceResolverRegistry,
-  VerifyResult,
-} from './l402/index.js';
-// L402 protocol
-export {
-  createL402Middleware,
-  DefaultResourceResolverRegistry,
-  L402Middleware,
-  MacaroonService,
-} from './l402/index.js';
 // RPC client
 export { FiberRpcClient, FiberRpcError } from './rpc/index.js';
 export type {

--- a/packages/sdk/src/l402/middleware.ts
+++ b/packages/sdk/src/l402/middleware.ts
@@ -10,7 +10,7 @@
  *   Path B — client provides macaroon only; middleware checks invoice
  *            settlement via Fiber RPC (connected-node flow)
  *
- * Uses `FiberRpcClient` from `@fiber-pay/sdk` directly for invoice
+ * Uses `FiberRpcClient` from `@fiber-pay/sdk/node` directly for invoice
  * creation and settlement checks, eliminating the intermediate
  * InvoiceService abstraction from the upstream fiber-l402 SDK.
  */
@@ -325,7 +325,7 @@ export class L402Middleware {
  * @example
  * ```ts
  * import express from 'express';
- * import { createL402Middleware } from '@fiber-pay/sdk';
+ * import { createL402Middleware } from '@fiber-pay/sdk/node';
  *
  * const app = express();
  *

--- a/packages/sdk/src/node/index.ts
+++ b/packages/sdk/src/node/index.ts
@@ -1,0 +1,12 @@
+/**
+ * @fiber-pay/sdk/node
+ * Node-focused SDK entry point.
+ *
+ * Includes all universal APIs from the root entry plus Node-only
+ * server integrations such as the L402 middleware module.
+ *
+ * @packageDocumentation
+ */
+
+export * from '../index.js';
+export * from '../l402/index.js';

--- a/packages/sdk/tests/export-boundary.test.ts
+++ b/packages/sdk/tests/export-boundary.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import * as browserEntry from '../src/browser/index.js';
+import * as nodeEntry from '../src/node/index.js';
+import * as rootEntry from '../src/index.js';
+
+describe('SDK export boundaries', () => {
+  it('keeps root entry free of L402 Node-only exports', () => {
+    expect(rootEntry).not.toHaveProperty('createL402Middleware');
+    expect(rootEntry).not.toHaveProperty('MacaroonService');
+    expect(rootEntry).not.toHaveProperty('L402Middleware');
+    expect(rootEntry).not.toHaveProperty('DefaultResourceResolverRegistry');
+  });
+
+  it('exposes L402 server APIs from node entry', () => {
+    expect(nodeEntry).toHaveProperty('createL402Middleware');
+    expect(nodeEntry).toHaveProperty('MacaroonService');
+    expect(nodeEntry).toHaveProperty('L402Middleware');
+    expect(nodeEntry).toHaveProperty('DefaultResourceResolverRegistry');
+  });
+
+  it('keeps core RPC client available across entries', () => {
+    expect(rootEntry).toHaveProperty('FiberRpcClient');
+    expect(nodeEntry).toHaveProperty('FiberRpcClient');
+    expect(browserEntry).toHaveProperty('FiberRpcClient');
+  });
+});

--- a/packages/sdk/tests/export-boundary.test.ts
+++ b/packages/sdk/tests/export-boundary.test.ts
@@ -1,14 +1,19 @@
 import { describe, expect, it } from 'vitest';
-import * as browserEntry from '../src/browser/index.js';
-import * as nodeEntry from '../src/node/index.js';
-import * as rootEntry from '../src/index.js';
+import * as browserEntry from '@fiber-pay/sdk/browser';
+import * as nodeEntry from '@fiber-pay/sdk/node';
+import * as rootEntry from '@fiber-pay/sdk';
 
 describe('SDK export boundaries', () => {
-  it('keeps root entry free of L402 Node-only exports', () => {
+  it('keeps root and browser entries free of L402 Node-only exports', () => {
     expect(rootEntry).not.toHaveProperty('createL402Middleware');
     expect(rootEntry).not.toHaveProperty('MacaroonService');
     expect(rootEntry).not.toHaveProperty('L402Middleware');
     expect(rootEntry).not.toHaveProperty('DefaultResourceResolverRegistry');
+
+    expect(browserEntry).not.toHaveProperty('createL402Middleware');
+    expect(browserEntry).not.toHaveProperty('MacaroonService');
+    expect(browserEntry).not.toHaveProperty('L402Middleware');
+    expect(browserEntry).not.toHaveProperty('DefaultResourceResolverRegistry');
   });
 
   it('exposes L402 server APIs from node entry', () => {

--- a/packages/sdk/tsup.config.ts
+++ b/packages/sdk/tsup.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from 'tsup';
 export default defineConfig({
   entry: {
     index: 'src/index.ts',
+    'node/index': 'src/node/index.ts',
     'browser/index': 'src/browser/index.ts',
   },
   format: ['esm'],

--- a/skills/fiber-pay/references/l402-agent.md
+++ b/skills/fiber-pay/references/l402-agent.md
@@ -4,7 +4,7 @@ fiber-pay supports L402 payment-gated APIs and paid AI agent services.
 
 ## SDK: L402 Module
 
-`@fiber-pay/sdk` exports L402 primitives:
+`@fiber-pay/sdk/node` exports L402 primitives:
 
 - `MacaroonService` — mint/verify L402 tokens with configurable caveats
 - `createL402Middleware(config)` — Express middleware for 402 challenge-response


### PR DESCRIPTION
## Summary

Fixes #87 by clarifying SDK export boundaries and introducing a dedicated Node subpath.

### What changed

- Added new Node entrypoint: `@fiber-pay/sdk/node`
- Moved Node-only L402 exports out of root `@fiber-pay/sdk`
- Kept root entry focused on universal/browser-safe APIs
- Kept browser entry (`@fiber-pay/sdk/browser`) unchanged for frontend use cases (including #91 additions)
- Updated internal CLI imports to use `@fiber-pay/sdk/node` for L402 middleware
- Added export-boundary regression tests in SDK
- Updated docs for new import guidance

## Export Model

- `@fiber-pay/sdk`: universal/browser-safe APIs
- `@fiber-pay/sdk/browser`: browser WASM + browser credential providers
- `@fiber-pay/sdk/node`: node-focused APIs (L402 middleware + universal APIs)

## Compatibility

This is a **breaking API boundary change** for users importing L402 APIs from root.

Migration:

- Before: `import { createL402Middleware } from '@fiber-pay/sdk'`
- After: `import { createL402Middleware } from '@fiber-pay/sdk/node'`

## Validation

- `pnpm lint`
- `pnpm --filter @fiber-pay/sdk test`
- `pnpm --filter @fiber-pay/sdk typecheck`
- `pnpm --filter @fiber-pay/sdk build`
- `pnpm --filter @fiber-pay/cli typecheck`
- `pnpm --filter @fiber-pay/cli build`
- Commit hook full-suite checks passed (`format:check`, `lint`, `build`, `typecheck`, `test`)
