### PR TITLE
feat(passkey): allow non-platform authenticators on linux

### DIFF
--- a/.changeset/green-rivers-warn.md
+++ b/.changeset/green-rivers-warn.md
@@ -1,5 +1,5 @@
 ---
-"@fiber-pay/sdk": minor
+"@fiber-pay/sdk": patch
 ---
 
 Relax browser passkey policy to allow non-platform authenticators (including Linux setups) while still requiring secure context, WebAuthn support, and PRF capability.

--- a/.changeset/green-rivers-warn.md
+++ b/.changeset/green-rivers-warn.md
@@ -1,0 +1,7 @@
+---
+"@fiber-pay/sdk": minor
+---
+
+Relax browser passkey policy to allow non-platform authenticators (including Linux setups) while still requiring secure context, WebAuthn support, and PRF capability.
+
+Also remove forced `authenticatorSelection.authenticatorAttachment = "platform"` during passkey registration.

--- a/apps/browser-wallet/src/App.tsx
+++ b/apps/browser-wallet/src/App.tsx
@@ -79,6 +79,7 @@ function App() {
     nodeInfo,
     node,
     isPasskeySupported,
+    passkeyUnavailableReason,
     hasPasskeyConfigured,
   } = useFiberNode(preferredNetwork);
   const {
@@ -324,6 +325,17 @@ function App() {
                         Register Passkey
                       </button>
                     )}
+                  </div>
+                )}
+
+                {!isPasskeySupported && (
+                  <div className="auth-group auth-card auth-card-disabled">
+                    <p className="field-label">Passkey</p>
+                    <p className="auth-note">Browser Passkey mode requires secure context, WebAuthn, and PRF support.</p>
+                    <div className="alert alert-warning">
+                      <XCircle size={16} />
+                      <span>{passkeyUnavailableReason ?? 'Passkey is unavailable in this browser/environment.'}</span>
+                    </div>
                   </div>
                 )}
 

--- a/apps/browser-wallet/src/hooks/useFiberNode.ts
+++ b/apps/browser-wallet/src/hooks/useFiberNode.ts
@@ -5,6 +5,7 @@ import {
   PasskeyCredentialProvider,
   type BrowserNodeState,
   type NodeInfoResult,
+  type PasskeySupportStatus,
 } from '@fiber-pay/sdk/browser';
 
 export interface UseFiberNodeResult {
@@ -18,7 +19,27 @@ export interface UseFiberNodeResult {
   stop: () => Promise<void>;
   node: FiberBrowserNode | null;
   isPasskeySupported: boolean;
+  passkeyUnavailableReason: string | null;
   hasPasskeyConfigured: boolean;
+}
+
+function getPasskeyUnavailableReason(status: PasskeySupportStatus): string | null {
+  if (status.supported) {
+    return null;
+  }
+
+  switch (status.reason) {
+    case 'insecure-context':
+      return 'This page is not in a secure context. Browser Passkey mode requires HTTPS or localhost.';
+    case 'webauthn-unavailable':
+      return 'WebAuthn is unavailable in this browser.';
+    case 'prf-unsupported':
+      return 'WebAuthn PRF extension is not available in this browser/authenticator.';
+    case 'window-unavailable':
+      return 'Passkey checks require a browser window environment.';
+    default:
+      return 'Browser Passkey requirements are not met in this environment.';
+  }
 }
 
 export function useFiberNode(network: 'testnet' | 'mainnet'): UseFiberNodeResult {
@@ -26,13 +47,22 @@ export function useFiberNode(network: 'testnet' | 'mainnet'): UseFiberNodeResult
   const [nodeInfo, setNodeInfo] = useState<NodeInfoResult | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [isPasskeySupported, setIsPasskeySupported] = useState(false);
+  const [passkeyUnavailableReason, setPasskeyUnavailableReason] = useState<string | null>(null);
   const [hasPasskeyConfigured, setHasPasskeyConfigured] = useState(false);
 
   const nodeRef = useRef<FiberBrowserNode | null>(null);
 
   useEffect(() => {
     // Check support
-    PasskeyCredentialProvider.isSupported().then(setIsPasskeySupported).catch(() => {});
+    PasskeyCredentialProvider.getSupportStatus()
+      .then((status) => {
+        setIsPasskeySupported(status.supported);
+        setPasskeyUnavailableReason(getPasskeyUnavailableReason(status));
+      })
+      .catch(() => {
+        setIsPasskeySupported(false);
+        setPasskeyUnavailableReason('Unable to detect passkey capabilities in this browser.');
+      });
     
     // Check if configured
     const pkProvider = new PasskeyCredentialProvider(`wallet-demo-${network}`);
@@ -132,6 +162,7 @@ export function useFiberNode(network: 'testnet' | 'mainnet'): UseFiberNodeResult
     stop,
     node: nodeRef.current,
     isPasskeySupported,
+    passkeyUnavailableReason,
     hasPasskeyConfigured,
   };
 }

--- a/apps/browser-wallet/src/hooks/useFiberNode.ts
+++ b/apps/browser-wallet/src/hooks/useFiberNode.ts
@@ -35,6 +35,8 @@ function getPasskeyUnavailableReason(status: PasskeySupportStatus): string | nul
       return 'WebAuthn is unavailable in this browser.';
     case 'prf-unsupported':
       return 'WebAuthn PRF extension is not available in this browser/authenticator.';
+    case 'unknown':
+      return 'Unable to verify WebAuthn PRF capability in this browser.';
     case 'window-unavailable':
       return 'Passkey checks require a browser window environment.';
     default:
@@ -63,7 +65,7 @@ export function useFiberNode(network: 'testnet' | 'mainnet'): UseFiberNodeResult
         setIsPasskeySupported(false);
         setPasskeyUnavailableReason('Unable to detect passkey capabilities in this browser.');
       });
-    
+
     // Check if configured
     const pkProvider = new PasskeyCredentialProvider(`wallet-demo-${network}`);
     setHasPasskeyConfigured(pkProvider.isConfigured());

--- a/apps/browser-wallet/src/index.css
+++ b/apps/browser-wallet/src/index.css
@@ -306,6 +306,10 @@ h3 {
   padding: 12px;
 }
 
+.auth-card-disabled {
+  opacity: 0.92;
+}
+
 .auth-note {
   color: var(--text-secondary);
   font-size: 0.82rem;

--- a/packages/sdk/src/browser/passkey-credential-provider.ts
+++ b/packages/sdk/src/browser/passkey-credential-provider.ts
@@ -20,6 +20,23 @@ interface AuthenticationExtensionsClientOutputsWithPRF
   };
 }
 
+export type PasskeySupportReason =
+  | 'supported'
+  | 'window-unavailable'
+  | 'insecure-context'
+  | 'webauthn-unavailable'
+  | 'prf-unsupported'
+  | 'unknown';
+
+export interface PasskeySupportStatus {
+  supported: boolean;
+  reason: PasskeySupportReason;
+  isSecureContext: boolean;
+  hasPublicKeyCredential: boolean;
+  hasPlatformAuthenticator: boolean | null;
+  prfCapable: boolean | null;
+}
+
 export class PasskeyCredentialProvider implements CredentialProvider {
   private identifier: string;
   private fiberKey: Uint8Array | null = null;
@@ -34,14 +51,56 @@ export class PasskeyCredentialProvider implements CredentialProvider {
   /**
    * Check if the current browser environment supports Passkeys with the PRF extension.
    */
-  static async isSupported(): Promise<boolean> {
-    if (typeof window === 'undefined' || typeof PublicKeyCredential === 'undefined') return false;
-
-    // Check for platform authenticator (e.g., Face ID / Touch ID)
-    if (PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable) {
-      const isAvailable = await PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable();
-      if (!isAvailable) return false;
+  static async getSupportStatus(): Promise<PasskeySupportStatus> {
+    if (typeof window === 'undefined') {
+      return {
+        supported: false,
+        reason: 'window-unavailable',
+        isSecureContext: false,
+        hasPublicKeyCredential: false,
+        hasPlatformAuthenticator: null,
+        prfCapable: null,
+      };
     }
+
+    const isSecureContext = window.isSecureContext;
+    if (!isSecureContext) {
+      return {
+        supported: false,
+        reason: 'insecure-context',
+        isSecureContext,
+        hasPublicKeyCredential: typeof PublicKeyCredential !== 'undefined',
+        hasPlatformAuthenticator: null,
+        prfCapable: null,
+      };
+    }
+
+    if (typeof PublicKeyCredential === 'undefined') {
+      return {
+        supported: false,
+        reason: 'webauthn-unavailable',
+        isSecureContext,
+        hasPublicKeyCredential: false,
+        hasPlatformAuthenticator: null,
+        prfCapable: null,
+      };
+    }
+
+    let hasPlatformAuthenticator: boolean | null = null;
+
+    // Probe platform authenticator availability for diagnostics only.
+    // It is not a hard requirement because some Linux environments use
+    // non-platform authenticators with WebAuthn + PRF successfully.
+    if (PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable) {
+      try {
+        hasPlatformAuthenticator =
+          await PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable();
+      } catch {
+        hasPlatformAuthenticator = null;
+      }
+    }
+
+    let prfCapable: boolean | null = null;
 
     // Check for PRF extension support capability
     if (
@@ -57,15 +116,38 @@ export class PasskeyCredentialProvider implements CredentialProvider {
           capabilitiesResult instanceof Promise ? await capabilitiesResult : capabilitiesResult
         ) as Record<string, boolean> | undefined;
 
-        if (capabilities && capabilities.prf === false) {
-          return false;
+        if (capabilities && typeof capabilities.prf === 'boolean') {
+          prfCapable = capabilities.prf;
+        }
+
+        if (prfCapable === false) {
+          return {
+            supported: false,
+            reason: 'prf-unsupported',
+            isSecureContext,
+            hasPublicKeyCredential: true,
+            hasPlatformAuthenticator,
+            prfCapable,
+          };
         }
       } catch {
         // Ignore fallback
       }
     }
 
-    return true;
+    return {
+      supported: true,
+      reason: 'supported',
+      isSecureContext,
+      hasPublicKeyCredential: true,
+      hasPlatformAuthenticator,
+      prfCapable,
+    };
+  }
+
+  static async isSupported(): Promise<boolean> {
+    const status = await PasskeyCredentialProvider.getSupportStatus();
+    return status.supported;
   }
 
   getIdentifier(): string {
@@ -182,7 +264,6 @@ export class PasskeyCredentialProvider implements CredentialProvider {
         { type: 'public-key', alg: -257 }, // RS256
       ],
       authenticatorSelection: {
-        authenticatorAttachment: 'platform', // Enforce local device (FaceID/TouchID)
         userVerification: 'required',
         residentKey: 'required',
       },

--- a/packages/sdk/src/browser/passkey-credential-provider.ts
+++ b/packages/sdk/src/browser/passkey-credential-provider.ts
@@ -119,20 +119,20 @@ export class PasskeyCredentialProvider implements CredentialProvider {
         if (capabilities && typeof capabilities.prf === 'boolean') {
           prfCapable = capabilities.prf;
         }
-
-        if (prfCapable === false) {
-          return {
-            supported: false,
-            reason: 'prf-unsupported',
-            isSecureContext,
-            hasPublicKeyCredential: true,
-            hasPlatformAuthenticator,
-            prfCapable,
-          };
-        }
       } catch {
-        // Ignore fallback
+        // Probe failed; treat as unknown capability below.
       }
+    }
+
+    if (prfCapable !== true) {
+      return {
+        supported: false,
+        reason: prfCapable === false ? 'prf-unsupported' : 'unknown',
+        isSecureContext,
+        hasPublicKeyCredential: true,
+        hasPlatformAuthenticator,
+        prfCapable,
+      };
     }
 
     return {

--- a/packages/sdk/tests/passkey-support-status.test.ts
+++ b/packages/sdk/tests/passkey-support-status.test.ts
@@ -1,0 +1,130 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { PasskeyCredentialProvider } from '../src/browser/passkey-credential-provider.js';
+
+const originalWindowDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'window');
+const originalPublicKeyCredentialDescriptor = Object.getOwnPropertyDescriptor(
+  globalThis,
+  'PublicKeyCredential',
+);
+
+function restoreGlobal(name: 'window' | 'PublicKeyCredential', descriptor?: PropertyDescriptor) {
+  if (descriptor) {
+    Object.defineProperty(globalThis, name, descriptor);
+    return;
+  }
+
+  Reflect.deleteProperty(globalThis, name);
+}
+
+function setWindowSecureContext(isSecureContext: boolean) {
+  Object.defineProperty(globalThis, 'window', {
+    configurable: true,
+    writable: true,
+    value: { isSecureContext },
+  });
+}
+
+function setPublicKeyCredential(value: unknown) {
+  Object.defineProperty(globalThis, 'PublicKeyCredential', {
+    configurable: true,
+    writable: true,
+    value,
+  });
+}
+
+afterEach(() => {
+  restoreGlobal('window', originalWindowDescriptor);
+  restoreGlobal('PublicKeyCredential', originalPublicKeyCredentialDescriptor);
+});
+
+describe('PasskeyCredentialProvider.getSupportStatus', () => {
+  it('returns window-unavailable when window is missing', async () => {
+    Reflect.deleteProperty(globalThis, 'window');
+    Reflect.deleteProperty(globalThis, 'PublicKeyCredential');
+
+    const status = await PasskeyCredentialProvider.getSupportStatus();
+
+    expect(status.supported).toBe(false);
+    expect(status.reason).toBe('window-unavailable');
+    expect(status.hasPublicKeyCredential).toBe(false);
+  });
+
+  it('returns insecure-context when not in secure context', async () => {
+    setWindowSecureContext(false);
+    setPublicKeyCredential({});
+
+    const status = await PasskeyCredentialProvider.getSupportStatus();
+
+    expect(status.supported).toBe(false);
+    expect(status.reason).toBe('insecure-context');
+    expect(status.hasPublicKeyCredential).toBe(true);
+  });
+
+  it('returns webauthn-unavailable when PublicKeyCredential is missing', async () => {
+    setWindowSecureContext(true);
+    Reflect.deleteProperty(globalThis, 'PublicKeyCredential');
+
+    const status = await PasskeyCredentialProvider.getSupportStatus();
+
+    expect(status.supported).toBe(false);
+    expect(status.reason).toBe('webauthn-unavailable');
+  });
+
+  it('returns prf-unsupported when PRF capability is explicitly false', async () => {
+    setWindowSecureContext(true);
+    setPublicKeyCredential({
+      getClientCapabilities: () => ({ prf: false }),
+      isUserVerifyingPlatformAuthenticatorAvailable: async () => false,
+    });
+
+    const status = await PasskeyCredentialProvider.getSupportStatus();
+
+    expect(status.supported).toBe(false);
+    expect(status.reason).toBe('prf-unsupported');
+    expect(status.prfCapable).toBe(false);
+    expect(status.hasPlatformAuthenticator).toBe(false);
+  });
+
+  it('returns unknown when PRF capability API is missing', async () => {
+    setWindowSecureContext(true);
+    setPublicKeyCredential({
+      isUserVerifyingPlatformAuthenticatorAvailable: async () => true,
+    });
+
+    const status = await PasskeyCredentialProvider.getSupportStatus();
+
+    expect(status.supported).toBe(false);
+    expect(status.reason).toBe('unknown');
+    expect(status.prfCapable).toBeNull();
+  });
+
+  it('returns unknown when capability probing throws', async () => {
+    setWindowSecureContext(true);
+    setPublicKeyCredential({
+      getClientCapabilities: () => {
+        throw new Error('probe failed');
+      },
+    });
+
+    const status = await PasskeyCredentialProvider.getSupportStatus();
+
+    expect(status.supported).toBe(false);
+    expect(status.reason).toBe('unknown');
+    expect(status.prfCapable).toBeNull();
+  });
+
+  it('returns supported when PRF capability is explicitly true', async () => {
+    setWindowSecureContext(true);
+    setPublicKeyCredential({
+      getClientCapabilities: () => ({ prf: true }),
+      isUserVerifyingPlatformAuthenticatorAvailable: async () => true,
+    });
+
+    const status = await PasskeyCredentialProvider.getSupportStatus();
+
+    expect(status.supported).toBe(true);
+    expect(status.reason).toBe('supported');
+    expect(status.prfCapable).toBe(true);
+    expect(status.hasPlatformAuthenticator).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- make platform authenticator (UVPAA) diagnostic-only instead of a hard gate
- keep passkey gating on secure context + WebAuthn + PRF support
- remove authenticatorSelection.authenticatorAttachment=platform to allow Linux/non-platform authenticators
- update browser-wallet unsupported message to match new policy

## Validation
- pnpm --filter @fiber-pay/sdk build
- pnpm --filter browser-wallet build