### PR TITLE
chore(changesets): include react in fixed release group

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -5,6 +5,7 @@
   "fixed": [
     [
       "@fiber-pay/sdk",
+      "@fiber-pay/react",
       "@fiber-pay/node",
       "@fiber-pay/runtime",
       "@fiber-pay/cli",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fiber-pay/react",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "React hooks and components for Fiber browser payments",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary\n- include @fiber-pay/react in changesets fixed group\n- ensure core publishable packages follow unified version bumps\n- keep repository-wide tagging strategy consistent going forward\n\n## Verification\n- pnpm changeset:status (shows fixed group packages bump together when react changeset is present)