### PR TITLE
ci(release): auto-publish all @fiber-pay packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,31 +42,15 @@ jobs:
         env:
           TAG: ${{ github.ref_name }}
         run: |
+          export PACKAGES_JSON="$(node scripts/discover-publishable-packages.mjs --json)"
           node -e '
-            const fs = require("fs");
-            const path = require("path");
             const tag = process.env.TAG;
+            const pkgVersions = JSON.parse(process.env.PACKAGES_JSON || "[]");
             if (!/^v\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(tag)) {
               console.error(`Invalid tag format: ${tag}. Expected vX.Y.Z or vX.Y.Z-prerelease`);
               process.exit(1);
             }
             const version = tag.slice(1);
-            const packagesRoot = path.join(process.cwd(), "packages");
-            const pkgVersions = fs
-              .readdirSync(packagesRoot, { withFileTypes: true })
-              .filter((entry) => entry.isDirectory())
-              .map((entry) => {
-                const pkgPath = path.join("packages", entry.name, "package.json");
-                const fullPath = path.join(process.cwd(), pkgPath);
-                if (!fs.existsSync(fullPath)) return null;
-                const pkg = JSON.parse(fs.readFileSync(fullPath, "utf8"));
-                if (typeof pkg.name !== "string") return null;
-                if (!pkg.name.startsWith("@fiber-pay/")) return null;
-                if (pkg.private === true) return null;
-                return { name: pkg.name, version: pkg.version, path: pkgPath };
-              })
-              .filter(Boolean)
-              .sort((a, b) => a.name.localeCompare(b.name));
             if (pkgVersions.length === 0) {
               console.error("No publishable @fiber-pay/* packages found under packages/*");
               process.exit(1);
@@ -108,25 +92,8 @@ jobs:
             echo "NPM_TOKEN is not configured"
             exit 1
           fi
-          mapfile -t PACKAGES < <(node -e '
-            const fs = require("fs");
-            const path = require("path");
-            const packagesRoot = path.join(process.cwd(), "packages");
-            const names = fs
-              .readdirSync(packagesRoot, { withFileTypes: true })
-              .filter((entry) => entry.isDirectory())
-              .map((entry) => path.join(packagesRoot, entry.name, "package.json"))
-              .filter((pkgPath) => fs.existsSync(pkgPath))
-              .map((pkgPath) => JSON.parse(fs.readFileSync(pkgPath, "utf8")))
-              .filter((pkg) => typeof pkg.name === "string")
-              .filter((pkg) => pkg.name.startsWith("@fiber-pay/"))
-              .filter((pkg) => pkg.private !== true)
-              .map((pkg) => pkg.name)
-              .sort((a, b) => a.localeCompare(b));
-            for (const name of names) {
-              console.log(name);
-            }
-          ')
+          PACKAGES_OUTPUT="$(node scripts/discover-publishable-packages.mjs)"
+          mapfile -t PACKAGES <<< "$PACKAGES_OUTPUT"
 
           if [[ "${#PACKAGES[@]}" -eq 0 ]]; then
             echo "No publishable @fiber-pay/* packages found under packages/*"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,19 +51,26 @@ jobs:
               process.exit(1);
             }
             const version = tag.slice(1);
-            const pkgPaths = [
-              "packages/sdk/package.json",
-              "packages/react/package.json",
-              "packages/node/package.json",
-              "packages/runtime/package.json",
-              "packages/agent/package.json",
-              "packages/cli/package.json"
-            ];
-            const pkgVersions = pkgPaths.map((pkgPath) => {
-              const fullPath = path.join(process.cwd(), pkgPath);
-              const pkg = JSON.parse(fs.readFileSync(fullPath, "utf8"));
-              return { name: pkg.name, version: pkg.version, path: pkgPath };
-            });
+            const packagesRoot = path.join(process.cwd(), "packages");
+            const pkgVersions = fs
+              .readdirSync(packagesRoot, { withFileTypes: true })
+              .filter((entry) => entry.isDirectory())
+              .map((entry) => {
+                const pkgPath = path.join("packages", entry.name, "package.json");
+                const fullPath = path.join(process.cwd(), pkgPath);
+                if (!fs.existsSync(fullPath)) return null;
+                const pkg = JSON.parse(fs.readFileSync(fullPath, "utf8"));
+                if (typeof pkg.name !== "string") return null;
+                if (!pkg.name.startsWith("@fiber-pay/")) return null;
+                if (pkg.private === true) return null;
+                return { name: pkg.name, version: pkg.version, path: pkgPath };
+              })
+              .filter(Boolean)
+              .sort((a, b) => a.name.localeCompare(b.name));
+            if (pkgVersions.length === 0) {
+              console.error("No publishable @fiber-pay/* packages found under packages/*");
+              process.exit(1);
+            }
             const mismatched = pkgVersions.filter((pkg) => pkg.version !== version);
             if (mismatched.length > 0) {
               console.error("Version mismatch with git tag:");
@@ -72,7 +79,7 @@ jobs:
               }
               process.exit(1);
             }
-            console.log(`All package versions match tag ${tag}`);
+            console.log(`All ${pkgVersions.length} package versions match tag ${tag}`);
           '
 
       - name: Build
@@ -101,11 +108,32 @@ jobs:
             echo "NPM_TOKEN is not configured"
             exit 1
           fi
-          pnpm -r \
-            --filter @fiber-pay/sdk \
-            --filter @fiber-pay/react \
-            --filter @fiber-pay/node \
-            --filter @fiber-pay/runtime \
-            --filter @fiber-pay/agent \
-            --filter @fiber-pay/cli \
-            publish --access public --no-git-checks --tag "${{ steps.dist_tag.outputs.value }}"
+          mapfile -t PACKAGES < <(node -e '
+            const fs = require("fs");
+            const path = require("path");
+            const packagesRoot = path.join(process.cwd(), "packages");
+            const names = fs
+              .readdirSync(packagesRoot, { withFileTypes: true })
+              .filter((entry) => entry.isDirectory())
+              .map((entry) => path.join(packagesRoot, entry.name, "package.json"))
+              .filter((pkgPath) => fs.existsSync(pkgPath))
+              .map((pkgPath) => JSON.parse(fs.readFileSync(pkgPath, "utf8")))
+              .filter((pkg) => typeof pkg.name === "string")
+              .filter((pkg) => pkg.name.startsWith("@fiber-pay/"))
+              .filter((pkg) => pkg.private !== true)
+              .map((pkg) => pkg.name)
+              .sort((a, b) => a.localeCompare(b));
+            for (const name of names) {
+              console.log(name);
+            }
+          ')
+
+          if [[ "${#PACKAGES[@]}" -eq 0 ]]; then
+            echo "No publishable @fiber-pay/* packages found under packages/*"
+            exit 1
+          fi
+
+          for pkg in "${PACKAGES[@]}"; do
+            echo "Publishing ${pkg} with dist-tag ${{ steps.dist_tag.outputs.value }}"
+            pnpm --filter "$pkg" publish --access public --no-git-checks --tag "${{ steps.dist_tag.outputs.value }}"
+          done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,7 @@ jobs:
             const version = tag.slice(1);
             const pkgPaths = [
               "packages/sdk/package.json",
+              "packages/react/package.json",
               "packages/node/package.json",
               "packages/runtime/package.json",
               "packages/agent/package.json",
@@ -102,6 +103,7 @@ jobs:
           fi
           pnpm -r \
             --filter @fiber-pay/sdk \
+            --filter @fiber-pay/react \
             --filter @fiber-pay/node \
             --filter @fiber-pay/runtime \
             --filter @fiber-pay/agent \

--- a/scripts/discover-publishable-packages.mjs
+++ b/scripts/discover-publishable-packages.mjs
@@ -1,0 +1,71 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const outputJson = process.argv.includes("--json");
+const workspaceRoot = process.cwd();
+const packagesRoot = path.join(workspaceRoot, "packages");
+
+if (!fs.existsSync(packagesRoot)) {
+  console.error(`Expected packages directory does not exist: ${packagesRoot}`);
+  process.exit(1);
+}
+
+if (!fs.statSync(packagesRoot).isDirectory()) {
+  console.error(`Expected packages path to be a directory: ${packagesRoot}`);
+  process.exit(1);
+}
+
+const discovered = fs
+  .readdirSync(packagesRoot, { withFileTypes: true })
+  .filter((entry) => entry.isDirectory())
+  .map((entry) => {
+    const pkgPath = path.join("packages", entry.name, "package.json");
+    const fullPath = path.join(workspaceRoot, pkgPath);
+
+    if (!fs.existsSync(fullPath)) {
+      return null;
+    }
+
+    let pkg;
+    try {
+      pkg = JSON.parse(fs.readFileSync(fullPath, "utf8"));
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      console.error(`Failed to parse package manifest ${pkgPath}: ${detail}`);
+      process.exit(1);
+    }
+
+    if (typeof pkg.name !== "string") {
+      return null;
+    }
+
+    if (!pkg.name.startsWith("@fiber-pay/")) {
+      return null;
+    }
+
+    if (pkg.private === true) {
+      return null;
+    }
+
+    return {
+      name: pkg.name,
+      version: pkg.version,
+      path: pkgPath,
+    };
+  })
+  .filter(Boolean)
+  .sort((a, b) => a.name.localeCompare(b.name));
+
+if (discovered.length === 0) {
+  console.error("No publishable @fiber-pay/* packages found under packages/*");
+  process.exit(1);
+}
+
+if (outputJson) {
+  process.stdout.write(`${JSON.stringify(discovered)}\n`);
+  process.exit(0);
+}
+
+for (const pkg of discovered) {
+  process.stdout.write(`${pkg.name}\n`);
+}


### PR DESCRIPTION
## Summary
- replace hardcoded package list in release workflow with automatic package discovery under packages/*
- validate versions for all publishable @fiber-pay/* packages against the release tag
- publish all discovered @fiber-pay/* packages instead of maintaining manual --filter entries

## Why
- prevent missing new packages (for example @fiber-pay/react) during tag-based releases
- reduce CI maintenance burden when adding new packages

## Scope
- .github/workflows/release.yml only
