### PR TITLE
feat(examples): reorganize examples and add react-quick-card demo

### DIFF
--- a/apps/react-quick-card/.gitignore
+++ b/apps/react-quick-card/.gitignore
@@ -1,0 +1,3 @@
+dist
+node_modules
+*.local

--- a/apps/react-quick-card/README.md
+++ b/apps/react-quick-card/README.md
@@ -1,0 +1,23 @@
+# React Quick Card Demo
+
+A minimal Vite + React app demonstrating the `FiberPayQuickCard` component from `@fiber-pay/react`.
+
+## Run
+
+```bash
+pnpm -C apps/react-quick-card dev
+```
+
+Then open `http://localhost:5174`.
+
+## What it demonstrates
+
+- One-line integration: `import { FiberPayQuickCard } from '@fiber-pay/react'`
+- Node startup with password or passkey
+- Create invoice and pay invoice directly in the card UI
+- Event hooks: `onInvoiceCreated`, `onPaymentResult`, `onError`
+
+## Notes
+
+- Cross-Origin Isolation headers are enabled in `vite.config.ts` for SharedArrayBuffer (required by the browser WASM node).
+- This demo targets `testnet` by default.

--- a/apps/react-quick-card/eslint.config.js
+++ b/apps/react-quick-card/eslint.config.js
@@ -1,0 +1,23 @@
+import js from '@eslint/js';
+import globals from 'globals';
+import reactHooks from 'eslint-plugin-react-hooks';
+import reactRefresh from 'eslint-plugin-react-refresh';
+import tseslint from 'typescript-eslint';
+import { defineConfig, globalIgnores } from 'eslint/config';
+
+export default defineConfig([
+  globalIgnores(['dist']),
+  {
+    files: ['**/*.{ts,tsx}'],
+    extends: [
+      js.configs.recommended,
+      tseslint.configs.recommended,
+      reactHooks.configs.flat.recommended,
+      reactRefresh.configs.vite,
+    ],
+    languageOptions: {
+      ecmaVersion: 2020,
+      globals: globals.browser,
+    },
+  },
+]);

--- a/apps/react-quick-card/eslint.config.js
+++ b/apps/react-quick-card/eslint.config.js
@@ -7,14 +7,12 @@ import { defineConfig, globalIgnores } from 'eslint/config';
 
 export default defineConfig([
   globalIgnores(['dist']),
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+  reactHooks.configs.flat.recommended,
+  reactRefresh.configs.vite,
   {
     files: ['**/*.{ts,tsx}'],
-    extends: [
-      js.configs.recommended,
-      tseslint.configs.recommended,
-      reactHooks.configs.flat.recommended,
-      reactRefresh.configs.vite,
-    ],
     languageOptions: {
       ecmaVersion: 2020,
       globals: globals.browser,

--- a/apps/react-quick-card/index.html
+++ b/apps/react-quick-card/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Fiber Pay Quick Card</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/react-quick-card/package.json
+++ b/apps/react-quick-card/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "react-quick-card",
+  "private": true,
+  "version": "0.0.1",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "lint": "eslint .",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@fiber-pay/react": "workspace:*",
+    "@fiber-pay/sdk": "workspace:*",
+    "@nervosnetwork/fiber-js": "~0.8.0",
+    "react": "^19.2.4",
+    "react-dom": "^19.2.4"
+  },
+  "devDependencies": {
+    "@eslint/js": "^9.39.4",
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^4.7.0",
+    "eslint": "^9.39.4",
+    "eslint-plugin-react-hooks": "^7.0.1",
+    "eslint-plugin-react-refresh": "^0.5.2",
+    "globals": "^17.4.0",
+    "typescript": "~5.9.3",
+    "typescript-eslint": "^8.57.0",
+    "vite": "^6.0.0"
+  }
+}

--- a/apps/react-quick-card/src/App.tsx
+++ b/apps/react-quick-card/src/App.tsx
@@ -1,0 +1,36 @@
+import type { GetPaymentResult } from '@fiber-pay/sdk/browser';
+import { FiberPayQuickCard } from '@fiber-pay/react';
+
+export function App() {
+  const handleInvoiceCreated = (invoice: string) => {
+    // eslint-disable-next-line no-console
+    console.log('Invoice created:', invoice);
+  };
+
+  const handlePaymentResult = (result: GetPaymentResult) => {
+    // eslint-disable-next-line no-console
+    console.log('Payment result:', result);
+  };
+
+  const handleError = (error: { scope: 'node' | 'payment' | 'invoice'; message: string }) => {
+    // eslint-disable-next-line no-console
+    console.error('FiberPay error:', error);
+  };
+
+  return (
+    <div style={{ padding: 24, fontFamily: 'system-ui, sans-serif' }}>
+      <h1>Fiber Pay Quick Card Demo</h1>
+      <p>
+        This is a minimal demo of the <code>FiberPayQuickCard</code> component from{' '}
+        <code>@fiber-pay/react</code>.
+      </p>
+      <FiberPayQuickCard
+        network="testnet"
+        title="Quick Card"
+        onInvoiceCreated={handleInvoiceCreated}
+        onPaymentResult={handlePaymentResult}
+        onError={handleError}
+      />
+    </div>
+  );
+}

--- a/apps/react-quick-card/src/App.tsx
+++ b/apps/react-quick-card/src/App.tsx
@@ -3,17 +3,14 @@ import { FiberPayQuickCard } from '@fiber-pay/react';
 
 export function App() {
   const handleInvoiceCreated = (invoice: string) => {
-    // eslint-disable-next-line no-console
     console.log('Invoice created:', invoice);
   };
 
   const handlePaymentResult = (result: GetPaymentResult) => {
-    // eslint-disable-next-line no-console
     console.log('Payment result:', result);
   };
 
   const handleError = (error: { scope: 'node' | 'payment' | 'invoice'; message: string }) => {
-    // eslint-disable-next-line no-console
     console.error('FiberPay error:', error);
   };
 

--- a/apps/react-quick-card/src/main.tsx
+++ b/apps/react-quick-card/src/main.tsx
@@ -1,0 +1,14 @@
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import { App } from './App.tsx';
+
+const rootElement = document.getElementById('root');
+if (!rootElement) {
+  throw new Error('Root element not found');
+}
+
+createRoot(rootElement).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/apps/react-quick-card/tsconfig.app.json
+++ b/apps/react-quick-card/tsconfig.app.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
+    "target": "ES2023",
+    "useDefineForClassFields": true,
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "types": ["vite/client"],
+    "skipLibCheck": true,
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+
+    /* Linting */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "erasableSyntaxOnly": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true
+  },
+  "include": ["src"]
+}

--- a/apps/react-quick-card/tsconfig.json
+++ b/apps/react-quick-card/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "files": [],
+  "references": [{ "path": "./tsconfig.app.json" }, { "path": "./tsconfig.node.json" }]
+}

--- a/apps/react-quick-card/tsconfig.node.json
+++ b/apps/react-quick-card/tsconfig.node.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
+    "target": "ES2023",
+    "lib": ["ES2023"],
+    "module": "ESNext",
+    "types": ["node"],
+    "skipLibCheck": true,
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+
+    /* Linting */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "erasableSyntaxOnly": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/apps/react-quick-card/vite.config.ts
+++ b/apps/react-quick-card/vite.config.ts
@@ -1,3 +1,4 @@
+import type { IncomingMessage, ServerResponse } from 'node:http';
 import { defineConfig, type Plugin } from 'vite';
 import react from '@vitejs/plugin-react';
 
@@ -9,7 +10,7 @@ function crossOriginIsolation(): Plugin {
   return {
     name: 'cross-origin-isolation',
     configureServer(server) {
-      server.middlewares.use((_req: any, res: any, next: () => void) => {
+      server.middlewares.use((_req: IncomingMessage, res: ServerResponse, next: () => void) => {
         res.setHeader('Cross-Origin-Opener-Policy', 'same-origin');
         res.setHeader('Cross-Origin-Embedder-Policy', 'require-corp');
         next();

--- a/apps/react-quick-card/vite.config.ts
+++ b/apps/react-quick-card/vite.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig, type Plugin } from 'vite';
+import react from '@vitejs/plugin-react';
+
+/**
+ * Vite plugin to set Cross-Origin Isolation headers on all responses.
+ * Required for SharedArrayBuffer support in WASM threads.
+ */
+function crossOriginIsolation(): Plugin {
+  return {
+    name: 'cross-origin-isolation',
+    configureServer(server) {
+      server.middlewares.use((_req: any, res: any, next: () => void) => {
+        res.setHeader('Cross-Origin-Opener-Policy', 'same-origin');
+        res.setHeader('Cross-Origin-Embedder-Policy', 'require-corp');
+        next();
+      });
+    },
+  };
+}
+
+export default defineConfig({
+  plugins: [react(), crossOriginIsolation()],
+  server: {
+    port: 5174,
+  },
+});

--- a/examples/README.md
+++ b/examples/README.md
@@ -2,6 +2,8 @@
 
 Runnable TypeScript examples demonstrating common Fiber Network payment flows.
 
+- `node/` — Node.js / CLI script examples using `@fiber-pay/sdk`
+
 ## Prerequisites
 
 1. **Running Fiber node** — Either start one via `fiber-pay node start` or connect to an existing node
@@ -13,30 +15,30 @@ Runnable TypeScript examples demonstrating common Fiber Network payment flows.
 
 ```bash
 # From the repo root
-npx tsx examples/basic-payment.ts
+npx tsx examples/node/basic-payment.ts
 
 # Or with environment variables
-FIBER_RPC_URL=http://127.0.0.1:8227 npx tsx examples/basic-payment.ts
+FIBER_RPC_URL=http://127.0.0.1:8227 npx tsx examples/node/basic-payment.ts
 ```
 
 ## Examples
 
-### [basic-payment.ts](basic-payment.ts)
+### [basic-payment.ts](node/basic-payment.ts)
 Connect to a node, check balance, create an invoice, and send a payment.
 Demonstrates `waitForPayment()` to poll until the payment settles.
 
-### [hold-invoice.ts](hold-invoice.ts)
+### [hold-invoice.ts](node/hold-invoice.ts)
 Create a hold invoice (escrow pattern) where funds are locked until the
 receiver reveals the preimage. Demonstrates:
 - Creating an invoice with `payment_hash` (no preimage upfront)
 - Waiting for `Accepted` status
 - Settling with `settle_invoice`
 
-### [channel-lifecycle.ts](channel-lifecycle.ts)
+### [channel-lifecycle.ts](node/channel-lifecycle.ts)
 Open a channel, wait for it to become ready using `waitForChannelReady()`,
 send a test payment, then cooperatively close the channel.
 
-### [watch-incoming.ts](watch-incoming.ts)
+### [watch-incoming.ts](node/watch-incoming.ts)
 Watch for incoming payments using `watchIncomingPayments()` with
 `AbortController` for graceful shutdown.
 

--- a/examples/node/basic-payment.ts
+++ b/examples/node/basic-payment.ts
@@ -7,7 +7,7 @@
  * - Running Fiber node with at least one ChannelReady channel
  * - Testnet CKB funded
  *
- * Run: npx tsx examples/basic-payment.ts
+ * Run: npx tsx examples/node/basic-payment.ts
  */
 
 import { ckbToShannons, FiberRpcClient, randomBytes32, shannonsToCkb, toHex } from '@fiber-pay/sdk';

--- a/examples/node/channel-lifecycle.ts
+++ b/examples/node/channel-lifecycle.ts
@@ -12,7 +12,7 @@
  * - Running Fiber node with on-chain CKB for funding
  * - A reachable peer to connect to
  *
- * Run: PEER_ADDR="/ip4/x.x.x.x/tcp/8228/p2p/QmXXX" npx tsx examples/channel-lifecycle.ts
+ * Run: PEER_ADDR="/ip4/x.x.x.x/tcp/8228/p2p/QmXXX" npx tsx examples/node/channel-lifecycle.ts
  */
 
 import { ckbToShannons, ensureHexPrefix, FiberRpcClient, shannonsToCkb } from '@fiber-pay/sdk';

--- a/examples/node/hold-invoice.ts
+++ b/examples/node/hold-invoice.ts
@@ -13,7 +13,7 @@
  * Prerequisites:
  * - Two connected Fiber nodes with a funded channel between them
  *
- * Run: npx tsx examples/hold-invoice.ts
+ * Run: npx tsx examples/node/hold-invoice.ts
  */
 
 import { createHash, randomBytes } from 'node:crypto';

--- a/examples/node/watch-incoming.ts
+++ b/examples/node/watch-incoming.ts
@@ -12,7 +12,7 @@
  * Prerequisites:
  * - Running Fiber node with at least one open channel
  *
- * Run: npx tsx examples/watch-incoming.ts
+ * Run: npx tsx examples/node/watch-incoming.ts
  */
 
 import { ckbToShannons, FiberRpcClient, randomBytes32, shannonsToCkb, toHex } from '@fiber-pay/sdk';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,6 +97,58 @@ importers:
         specifier: ^6.0.0
         version: 6.4.1(@types/node@24.12.0)(yaml@2.8.2)
 
+  apps/react-quick-card:
+    dependencies:
+      '@fiber-pay/react':
+        specifier: workspace:*
+        version: link:../../packages/react
+      '@fiber-pay/sdk':
+        specifier: workspace:*
+        version: link:../../packages/sdk
+      '@nervosnetwork/fiber-js':
+        specifier: ~0.8.0
+        version: 0.8.0
+      react:
+        specifier: ^19.2.4
+        version: 19.2.4
+      react-dom:
+        specifier: ^19.2.4
+        version: 19.2.4(react@19.2.4)
+    devDependencies:
+      '@eslint/js':
+        specifier: ^9.39.4
+        version: 9.39.4
+      '@types/react':
+        specifier: ^19.2.14
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.14)
+      '@vitejs/plugin-react':
+        specifier: ^4.7.0
+        version: 4.7.0(vite@6.4.1(@types/node@25.1.0)(yaml@2.8.2))
+      eslint:
+        specifier: ^9.39.4
+        version: 9.39.4
+      eslint-plugin-react-hooks:
+        specifier: ^7.0.1
+        version: 7.0.1(eslint@9.39.4)
+      eslint-plugin-react-refresh:
+        specifier: ^0.5.2
+        version: 0.5.2(eslint@9.39.4)
+      globals:
+        specifier: ^17.4.0
+        version: 17.4.0
+      typescript:
+        specifier: ~5.9.3
+        version: 5.9.3
+      typescript-eslint:
+        specifier: ^8.57.0
+        version: 8.58.0(eslint@9.39.4)(typescript@5.9.3)
+      vite:
+        specifier: ^6.0.0
+        version: 6.4.1(@types/node@25.1.0)(yaml@2.8.2)
+
   e2e/wasm-smoke:
     dependencies:
       '@nervosnetwork/fiber-js':
@@ -3597,6 +3649,18 @@ snapshots:
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
       vite: 6.4.1(@types/node@24.12.0)(yaml@2.8.2)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@vitejs/plugin-react@4.7.0(vite@6.4.1(@types/node@25.1.0)(yaml@2.8.2))':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.29.0)
+      '@rolldown/pluginutils': 1.0.0-beta.27
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.17.0
+      vite: 6.4.1(@types/node@25.1.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
## Summary

- Moved existing Node.js SDK examples into `examples/node/` for a cleaner, extensible structure.
- Updated all README paths and inline script comments to reflect the new locations.
- Added `apps/react-quick-card/`, a minimal Vite + React app that demonstrates the `FiberPayQuickCard` component from `@fiber-pay/react`.

## What's new

- `apps/react-quick-card/` — One-line component demo with event hooks (`onInvoiceCreated`, `onPaymentResult`, `onError`)
- `examples/node/` — Existing TypeScript examples reorganized from `examples/` root

## Verification

- `pnpm -C apps/react-quick-card exec tsc -b` ✅
- `pnpm -C apps/react-quick-card build` ✅
- Full monorepo build, typecheck, and test suite pass via pre-commit hooks ✅