### PR TITLE
fix(cli): support pubkey in peer connect and unify pubkey terminology for v0.8.0

### DIFF
--- a/.changeset/fix-connect-pubkey.md
+++ b/.changeset/fix-connect-pubkey.md
@@ -1,5 +1,5 @@
 ---
-"@fiber-pay/cli": minor
+"@fiber-pay/cli": patch
 ---
 
 fix(cli): support pubkey in peer connect and unify pubkey terminology for v0.8.0

--- a/.changeset/fix-connect-pubkey.md
+++ b/.changeset/fix-connect-pubkey.md
@@ -1,5 +1,5 @@
 ---
-"@fiber-pay/cli": patch
+"@fiber-pay/cli": minor
 ---
 
 fix(cli): support pubkey in peer connect and unify pubkey terminology for v0.8.0

--- a/.changeset/fix-connect-pubkey.md
+++ b/.changeset/fix-connect-pubkey.md
@@ -1,0 +1,11 @@
+---
+"@fiber-pay/cli": patch
+---
+
+fix(cli): support pubkey in peer connect and unify pubkey terminology for v0.8.0
+
+- `peer connect` now accepts both pubkey and multiaddr
+- removed peerId display from peer connect output
+- renamed peerId -> pubkey in formatChannel JSON fields
+- removed peerId from node-status output, show Pubkey instead
+- updated rebalance error messages/details to use pubkey terminology

--- a/packages/cli/src/commands/peer.ts
+++ b/packages/cli/src/commands/peer.ts
@@ -6,9 +6,14 @@ import { createReadyRpcClient } from '../lib/rpc.js';
 
 function isPubkey(value: string): boolean {
   const trimmed = value.trim();
-  if (!trimmed.startsWith('0x')) return false;
-  const hex = trimmed.slice(2);
-  return /^[0-9a-fA-F]+$/.test(hex) && hex.length === 66;
+  const withoutPrefix = trimmed.replace(/^0x/i, '');
+  return /^[0-9a-fA-F]+$/.test(withoutPrefix) && withoutPrefix.length === 66;
+}
+
+function normalizePubkey(value: string): string {
+  const trimmed = value.trim();
+  const withoutPrefix = trimmed.replace(/^0x/i, '');
+  return `0x${withoutPrefix.toLowerCase()}`;
 }
 
 function extractPeerIdFromMultiaddr(address: string): string | undefined {
@@ -21,9 +26,11 @@ async function findPeerByTarget(
   target: string,
 ) {
   const peers = await rpc.listPeers();
+  const targetIsPubkey = isPubkey(target);
+  const normalizedTarget = targetIsPubkey ? normalizePubkey(target) : target;
   for (const peer of peers.peers) {
-    if (isPubkey(target)) {
-      if (peer.pubkey === target) {
+    if (targetIsPubkey) {
+      if (normalizePubkey(peer.pubkey) === normalizedTarget) {
         return peer;
       }
       continue;
@@ -87,8 +94,9 @@ export function createPeerCommand(config: CliConfig): Command {
       let targetForWait: string;
 
       if (isPubkey(trimmedInput)) {
-        connectParams = { pubkey: trimmedInput as HexString };
-        targetForWait = trimmedInput;
+        const normalized = normalizePubkey(trimmedInput) as HexString;
+        connectParams = { pubkey: normalized };
+        targetForWait = normalized;
       } else if (trimmedInput.startsWith('/')) {
         const peerId = extractPeerIdFromMultiaddr(trimmedInput);
         if (!peerId) {
@@ -98,7 +106,7 @@ export function createPeerCommand(config: CliConfig): Command {
         targetForWait = peerId;
       } else {
         throw new Error(
-          'Invalid argument: expected a pubkey (0x-prefixed 66 hex chars) or a multiaddr starting with "/"',
+          'Invalid argument: expected a pubkey (66 hex chars) or a multiaddr starting with "/"',
         );
       }
 
@@ -131,13 +139,14 @@ export function createPeerCommand(config: CliConfig): Command {
     .option('--json')
     .action(async (pubkey, options) => {
       const rpc = await createReadyRpcClient(config);
-      await rpc.disconnectPeer({ pubkey: pubkey as HexString });
+      const normalized = normalizePubkey(pubkey) as HexString;
+      await rpc.disconnectPeer({ pubkey: normalized });
 
       if (options.json) {
-        printJsonSuccess({ pubkey, message: 'Disconnected' });
+        printJsonSuccess({ pubkey: normalized, message: 'Disconnected' });
       } else {
         console.log('✅ Disconnected peer');
-        console.log(`  Peer Pubkey: ${pubkey}`);
+        console.log(`  Peer Pubkey: ${normalized}`);
       }
     });
 

--- a/packages/cli/src/commands/peer.ts
+++ b/packages/cli/src/commands/peer.ts
@@ -1,25 +1,38 @@
-import { nodeIdToPeerId } from '@fiber-pay/sdk';
+import { type HexString, nodeIdToPeerId } from '@fiber-pay/sdk';
 import { Command } from 'commander';
 import type { CliConfig } from '../lib/config.js';
 import { printJsonSuccess, printPeerListHuman } from '../lib/format.js';
 import { createReadyRpcClient } from '../lib/rpc.js';
+
+function isPubkey(value: string): boolean {
+  const trimmed = value.trim();
+  if (!trimmed.startsWith('0x')) return false;
+  const hex = trimmed.slice(2);
+  return /^[0-9a-fA-F]+$/.test(hex) && hex.length === 66;
+}
 
 function extractPeerIdFromMultiaddr(address: string): string | undefined {
   const match = address.match(/\/p2p\/([^/]+)$/);
   return match?.[1];
 }
 
-async function findPeerByPeerId(
+async function findPeerByTarget(
   rpc: Awaited<ReturnType<typeof createReadyRpcClient>>,
-  expectedPeerId: string,
+  target: string,
 ) {
   const peers = await rpc.listPeers();
   for (const peer of peers.peers) {
-    if (extractPeerIdFromMultiaddr(peer.address) === expectedPeerId) {
+    if (isPubkey(target)) {
+      if (peer.pubkey === target) {
+        return peer;
+      }
+      continue;
+    }
+    if (extractPeerIdFromMultiaddr(peer.address) === target) {
       return peer;
     }
     try {
-      if ((await nodeIdToPeerId(peer.pubkey)) === expectedPeerId) {
+      if ((await nodeIdToPeerId(peer.pubkey)) === target) {
         return peer;
       }
     } catch {
@@ -29,14 +42,14 @@ async function findPeerByPeerId(
   return undefined;
 }
 
-async function waitForPeerConnected(
+async function waitForPeerConnectedByTarget(
   rpc: Awaited<ReturnType<typeof createReadyRpcClient>>,
-  expectedPeerId: string,
+  target: string,
   timeoutMs: number,
 ): Promise<{ pubkey: string; address: string } | undefined> {
   const start = Date.now();
   while (Date.now() - start < timeoutMs) {
-    const match = await findPeerByPeerId(rpc, expectedPeerId);
+    const match = await findPeerByTarget(rpc, target);
     if (match) {
       return { pubkey: match.pubkey, address: match.address };
     }
@@ -63,37 +76,51 @@ export function createPeerCommand(config: CliConfig): Command {
 
   peer
     .command('connect')
-    .argument('<multiaddr>')
+    .argument('<multiaddrOrPubkey>')
     .option('--timeout <sec>', 'Wait timeout for peer to appear in peer list', '8')
     .option('--json')
-    .action(async (address, options) => {
+    .action(async (input, options) => {
       const rpc = await createReadyRpcClient(config);
-      const expectedPeerId = extractPeerIdFromMultiaddr(address);
-      if (!expectedPeerId) {
-        throw new Error('Invalid multiaddr: missing /p2p/<peerId> suffix');
+      const trimmedInput = input.trim();
+
+      let connectParams: { address: string } | { pubkey: HexString };
+      let targetForWait: string;
+
+      if (isPubkey(trimmedInput)) {
+        connectParams = { pubkey: trimmedInput as HexString };
+        targetForWait = trimmedInput;
+      } else if (trimmedInput.startsWith('/')) {
+        const peerId = extractPeerIdFromMultiaddr(trimmedInput);
+        if (!peerId) {
+          throw new Error('Invalid multiaddr: missing /p2p/<peerId> suffix');
+        }
+        connectParams = { address: trimmedInput };
+        targetForWait = peerId;
+      } else {
+        throw new Error(
+          'Invalid argument: expected a pubkey (0x-prefixed 66 hex chars) or a multiaddr starting with "/"',
+        );
       }
 
-      await rpc.connectPeer({ address });
+      await rpc.connectPeer(connectParams);
       const timeoutMs = Math.max(1, Number.parseInt(String(options.timeout), 10) || 8) * 1000;
-      const connected = await waitForPeerConnected(rpc, expectedPeerId, timeoutMs);
+      const connected = await waitForPeerConnectedByTarget(rpc, targetForWait, timeoutMs);
 
       if (!connected) {
         throw new Error(
-          `connect_peer accepted but peer not found in list within ${Math.floor(timeoutMs / 1000)}s (${expectedPeerId})`,
+          `connect_peer accepted but peer not found in list within ${Math.floor(timeoutMs / 1000)}s (${trimmedInput})`,
         );
       }
 
       if (options.json) {
         printJsonSuccess({
-          address,
-          peerId: expectedPeerId,
+          address: connected.address,
           pubkey: connected.pubkey,
           message: 'Connected',
         });
       } else {
         console.log('✅ Connected to peer');
-        console.log(`  Address: ${address}`);
-        console.log(`  Peer ID: ${expectedPeerId}`);
+        console.log(`  Address: ${connected.address}`);
         console.log(`  Peer Pubkey: ${connected.pubkey}`);
       }
     });
@@ -104,7 +131,7 @@ export function createPeerCommand(config: CliConfig): Command {
     .option('--json')
     .action(async (pubkey, options) => {
       const rpc = await createReadyRpcClient(config);
-      await rpc.disconnectPeer({ pubkey });
+      await rpc.disconnectPeer({ pubkey: pubkey as HexString });
 
       if (options.json) {
         printJsonSuccess({ pubkey, message: 'Disconnected' });

--- a/packages/cli/src/commands/rebalance.ts
+++ b/packages/cli/src/commands/rebalance.ts
@@ -250,11 +250,11 @@ export function registerChannelRebalanceCommand(parent: Command, config: CliConf
               code: 'CHANNEL_REBALANCE_INPUT_INVALID',
               message,
               recoverable: true,
-              suggestion: 'Select channels with different peer ids for guided rebalance.',
+              suggestion: 'Select channels with different pubkeys for guided rebalance.',
               details: {
                 fromChannel: fromChannelId,
                 toChannel: toChannelId,
-                peerId: fromChannel.pubkey,
+                pubkey: fromChannel.pubkey,
               },
             });
           } else {
@@ -278,8 +278,8 @@ export function registerChannelRebalanceCommand(parent: Command, config: CliConf
               details: {
                 fromChannel: fromChannelId,
                 toChannel: toChannelId,
-                fromPeerId: fromChannel.pubkey,
-                toPeerId: toChannel.pubkey,
+                fromPubkey: fromChannel.pubkey,
+                toPubkey: toChannel.pubkey,
               },
             });
           } else {

--- a/packages/cli/src/lib/format.ts
+++ b/packages/cli/src/lib/format.ts
@@ -162,8 +162,8 @@ export function formatChannel(channel: Channel): Record<string, unknown> {
   return {
     channelId: channel.channel_id,
     channelIdShort: truncateMiddle(channel.channel_id, 10, 8),
-    peerId: channel.pubkey,
-    peerIdShort: truncateMiddle(channel.pubkey, 10, 8),
+    pubkey: channel.pubkey,
+    pubkeyShort: truncateMiddle(channel.pubkey, 10, 8),
     state: channel.state.state_name,
     stateLabel: stateLabel(channel.state.state_name),
     stateFlags: channel.state.state_flags,

--- a/packages/cli/src/lib/node-status.ts
+++ b/packages/cli/src/lib/node-status.ts
@@ -41,9 +41,7 @@ export async function runNodeStatusCommand(
   let addresses: string[] = [];
   let chainHash: string | null = null;
   let version: string | null = null;
-  let peerId: string | null = null;
   let peersCount = 0;
-  let peerIdError: string | null = null;
   let multiaddr: string | null = null;
   let multiaddrError: string | null = null;
   let multiaddrInferred = false;
@@ -72,11 +70,6 @@ export async function runNodeStatusCommand(
       chainHash = nodeInfo.chain_hash;
       version = nodeInfo.version;
       peersCount = parseInt(nodeInfo.peers_count, 16);
-      try {
-        peerId = await nodeIdToPeerId(nodeInfo.pubkey);
-      } catch (error) {
-        peerIdError = error instanceof Error ? error.message : String(error);
-      }
 
       const baseAddress = nodeInfo.addresses[0];
       if (baseAddress) {
@@ -85,9 +78,10 @@ export async function runNodeStatusCommand(
         } catch (error) {
           multiaddrError = error instanceof Error ? error.message : String(error);
         }
-      } else if (peerId) {
+      } else {
         try {
-          multiaddr = buildMultiaddrFromRpcUrl(config.rpcUrl, peerId);
+          const inferredPeerId = await nodeIdToPeerId(nodeInfo.pubkey);
+          multiaddr = buildMultiaddrFromRpcUrl(config.rpcUrl, inferredPeerId);
           multiaddrInferred = true;
         } catch (error) {
           const reason = error instanceof Error ? error.message : String(error);
@@ -152,9 +146,7 @@ export async function runNodeStatusCommand(
     addresses,
     chainHash,
     version,
-    peerId,
     peersCount,
-    peerIdError,
     multiaddr,
     multiaddrError,
     multiaddrInferred,
@@ -212,7 +204,7 @@ export async function runNodeStatusCommand(
   if (output.running) {
     console.log(`✅ Node is running (PID: ${output.pid})`);
     if (output.rpcResponsive) {
-      console.log(`   Node ID: ${String(output.nodeId)}`);
+      console.log(`   Pubkey: ${String(output.nodeId)}`);
       if (output.nodeName) {
         console.log(`   Name: ${sanitizeForTerminal(output.nodeName)}`);
       }
@@ -222,16 +214,11 @@ export async function runNodeStatusCommand(
       if (output.chainHash) {
         console.log(`   Chain Hash: ${String(output.chainHash)}`);
       }
-      if (output.peerId) {
-        console.log(`   Peer ID: ${String(output.peerId)}`);
-      } else if (output.peerIdError) {
-        console.log(`   Peer ID: unavailable (${String(output.peerIdError)})`);
-      }
       console.log(`   RPC: ${String(output.rpcUrl)}`);
       console.log(`   RPC Client: ${String(output.rpcTarget)} (${String(output.resolvedRpcUrl)})`);
       if (output.multiaddr) {
         const inferredSuffix = output.multiaddrInferred
-          ? ' (inferred from RPC + peerId; no advertised addresses)'
+          ? ' (inferred from RPC + pubkey; no advertised addresses)'
           : '';
         console.log(`   Multiaddr: ${String(output.multiaddr)}${inferredSuffix}`);
       } else if (output.multiaddrError) {


### PR DESCRIPTION
## Summary

Fiber v0.8.0 之后 RPC 统一使用 `pubkey` 替换了 `peer_id`。CLI 里还有一些命令和输出字段仍使用旧术语，导致 `peer connect` 传入 pubkey 时会报错。

## Changes

- `peer connect` 现在同时接受 **pubkey** 和 **multiaddr**
  - pubkey: `0x` 前缀、66 位 hex → 直接调用 `connect_peer({ pubkey })`
  - multiaddr: `/` 开头 → 保持原有逻辑
  - 连接成功后的输出移除 `Peer ID`，统一显示 `Peer Pubkey`
- `formatChannel` JSON 字段：`peerId` → `pubkey`，`peerIdShort` → `pubkeyShort`
- `node status` 输出移除 `Peer ID` 显示，改为 `Pubkey`
- `rebalance` 错误信息中的 `peer ids` 改为 `pubkeys`，details 字段同步更名

## Verification

- Build ✅
- Typecheck ✅
- Lint ✅
- Tests ✅ (354 passed)

Fixes #103