### PR TITLE
chore: migrate examples/node to apps/node-examples

### DIFF
--- a/apps/node-examples/README.md
+++ b/apps/node-examples/README.md
@@ -1,8 +1,8 @@
-# Examples
+# Node Examples
 
 Runnable TypeScript examples demonstrating common Fiber Network payment flows.
 
-- `node/` — Node.js / CLI script examples using `@fiber-pay/sdk`
+These examples use `@fiber-pay/sdk` and target Node.js / CLI environments.
 
 ## Prerequisites
 
@@ -15,30 +15,30 @@ Runnable TypeScript examples demonstrating common Fiber Network payment flows.
 
 ```bash
 # From the repo root
-npx tsx examples/node/basic-payment.ts
+npx tsx apps/node-examples/basic-payment.ts
 
 # Or with environment variables
-FIBER_RPC_URL=http://127.0.0.1:8227 npx tsx examples/node/basic-payment.ts
+FIBER_RPC_URL=http://127.0.0.1:8227 npx tsx apps/node-examples/basic-payment.ts
 ```
 
 ## Examples
 
-### [basic-payment.ts](node/basic-payment.ts)
+### [basic-payment.ts](basic-payment.ts)
 Connect to a node, check balance, create an invoice, and send a payment.
 Demonstrates `waitForPayment()` to poll until the payment settles.
 
-### [hold-invoice.ts](node/hold-invoice.ts)
+### [hold-invoice.ts](hold-invoice.ts)
 Create a hold invoice (escrow pattern) where funds are locked until the
 receiver reveals the preimage. Demonstrates:
 - Creating an invoice with `payment_hash` (no preimage upfront)
 - Waiting for `Accepted` status
 - Settling with `settle_invoice`
 
-### [channel-lifecycle.ts](node/channel-lifecycle.ts)
+### [channel-lifecycle.ts](channel-lifecycle.ts)
 Open a channel, wait for it to become ready using `waitForChannelReady()`,
 send a test payment, then cooperatively close the channel.
 
-### [watch-incoming.ts](node/watch-incoming.ts)
+### [watch-incoming.ts](watch-incoming.ts)
 Watch for incoming payments using `watchIncomingPayments()` with
 `AbortController` for graceful shutdown.
 

--- a/apps/node-examples/basic-payment.ts
+++ b/apps/node-examples/basic-payment.ts
@@ -7,7 +7,7 @@
  * - Running Fiber node with at least one ChannelReady channel
  * - Testnet CKB funded
  *
- * Run: npx tsx examples/node/basic-payment.ts
+ * Run: npx tsx apps/node-examples/basic-payment.ts
  */
 
 import { ckbToShannons, FiberRpcClient, randomBytes32, shannonsToCkb, toHex } from '@fiber-pay/sdk';

--- a/apps/node-examples/channel-lifecycle.ts
+++ b/apps/node-examples/channel-lifecycle.ts
@@ -12,7 +12,7 @@
  * - Running Fiber node with on-chain CKB for funding
  * - A reachable peer to connect to
  *
- * Run: PEER_ADDR="/ip4/x.x.x.x/tcp/8228/p2p/QmXXX" npx tsx examples/node/channel-lifecycle.ts
+ * Run: PEER_ADDR="/ip4/x.x.x.x/tcp/8228/p2p/QmXXX" npx tsx apps/node-examples/channel-lifecycle.ts
  */
 
 import { ckbToShannons, ensureHexPrefix, FiberRpcClient, shannonsToCkb } from '@fiber-pay/sdk';
@@ -52,7 +52,7 @@ async function main() {
     console.log('✓ Already connected to peer\n');
   }
 
-  const discovered = await client.listPeers({});
+  const discovered = await client.listPeers();
   const connectedPeer = discovered.peers.find((peer) => peer.address === PEER_ADDR);
   const targetPubkey = process.env.PEER_PUBKEY ?? connectedPeer?.pubkey;
 

--- a/apps/node-examples/hold-invoice.ts
+++ b/apps/node-examples/hold-invoice.ts
@@ -13,7 +13,7 @@
  * Prerequisites:
  * - Two connected Fiber nodes with a funded channel between them
  *
- * Run: npx tsx examples/node/hold-invoice.ts
+ * Run: npx tsx apps/node-examples/hold-invoice.ts
  */
 
 import { createHash, randomBytes } from 'node:crypto';

--- a/apps/node-examples/package.json
+++ b/apps/node-examples/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "node-examples",
+  "private": true,
+  "version": "0.0.1",
+  "type": "module",
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@fiber-pay/sdk": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^25.1.0",
+    "tsx": "^4.19.0",
+    "typescript": "~5.9.3"
+  }
+}

--- a/apps/node-examples/tsconfig.json
+++ b/apps/node-examples/tsconfig.json
@@ -7,6 +7,6 @@
     "noEmit": true,
     "types": ["node"]
   },
-  "include": ["*.ts"],
+  "include": ["**/*.ts"],
   "exclude": ["node_modules", "dist"]
 }

--- a/apps/node-examples/tsconfig.json
+++ b/apps/node-examples/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": ".",
+    "lib": ["ES2022"],
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/apps/node-examples/watch-incoming.ts
+++ b/apps/node-examples/watch-incoming.ts
@@ -12,7 +12,7 @@
  * Prerequisites:
  * - Running Fiber node with at least one open channel
  *
- * Run: npx tsx examples/node/watch-incoming.ts
+ * Run: npx tsx apps/node-examples/watch-incoming.ts
  */
 
 import { ckbToShannons, FiberRpcClient, randomBytes32, shannonsToCkb, toHex } from '@fiber-pay/sdk';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,13 +25,13 @@ importers:
         version: 16.2.7
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(postcss@8.5.6)(typescript@5.9.3)(yaml@2.8.2)
+        version: 8.5.1(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(@types/node@25.1.0)(yaml@2.8.2)
+        version: 4.0.18(@types/node@25.1.0)(tsx@4.21.0)(yaml@2.8.2)
 
   apps/browser-wallet:
     dependencies:
@@ -74,7 +74,7 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: ^4.7.0
-        version: 4.7.0(vite@6.4.1(@types/node@24.12.0)(yaml@2.8.2))
+        version: 4.7.0(vite@6.4.1(@types/node@24.12.0)(tsx@4.21.0)(yaml@2.8.2))
       eslint:
         specifier: ^9.39.4
         version: 9.39.4
@@ -95,7 +95,23 @@ importers:
         version: 8.58.0(eslint@9.39.4)(typescript@5.9.3)
       vite:
         specifier: ^6.0.0
-        version: 6.4.1(@types/node@24.12.0)(yaml@2.8.2)
+        version: 6.4.1(@types/node@24.12.0)(tsx@4.21.0)(yaml@2.8.2)
+
+  apps/node-examples:
+    dependencies:
+      '@fiber-pay/sdk':
+        specifier: workspace:*
+        version: link:../../packages/sdk
+    devDependencies:
+      '@types/node':
+        specifier: ^25.1.0
+        version: 25.1.0
+      tsx:
+        specifier: ^4.19.0
+        version: 4.21.0
+      typescript:
+        specifier: ~5.9.3
+        version: 5.9.3
 
   apps/react-quick-card:
     dependencies:
@@ -126,7 +142,7 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: ^4.7.0
-        version: 4.7.0(vite@6.4.1(@types/node@25.1.0)(yaml@2.8.2))
+        version: 4.7.0(vite@6.4.1(@types/node@25.1.0)(tsx@4.21.0)(yaml@2.8.2))
       eslint:
         specifier: ^9.39.4
         version: 9.39.4
@@ -147,7 +163,7 @@ importers:
         version: 8.58.0(eslint@9.39.4)(typescript@5.9.3)
       vite:
         specifier: ^6.0.0
-        version: 6.4.1(@types/node@25.1.0)(yaml@2.8.2)
+        version: 6.4.1(@types/node@25.1.0)(tsx@4.21.0)(yaml@2.8.2)
 
   e2e/wasm-smoke:
     dependencies:
@@ -157,7 +173,7 @@ importers:
     devDependencies:
       vite:
         specifier: ^6.3.5
-        version: 6.4.1(@types/node@25.1.0)(yaml@2.8.2)
+        version: 6.4.1(@types/node@25.1.0)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/agent:
     dependencies:
@@ -1748,6 +1764,9 @@ packages:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
 
+  get-tsconfig@4.14.0:
+    resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
+
   github-from-package@0.0.0:
     resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
 
@@ -2307,6 +2326,9 @@ packages:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
 
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
   restore-cursor@5.1.0:
     resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
     engines: {node: '>=18'}
@@ -2563,6 +2585,11 @@ packages:
         optional: true
       typescript:
         optional: true
+
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   tunnel-agent@0.6.0:
     resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
@@ -3640,7 +3667,7 @@ snapshots:
       '@typescript-eslint/types': 8.58.0
       eslint-visitor-keys: 5.0.1
 
-  '@vitejs/plugin-react@4.7.0(vite@6.4.1(@types/node@24.12.0)(yaml@2.8.2))':
+  '@vitejs/plugin-react@4.7.0(vite@6.4.1(@types/node@24.12.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
@@ -3648,11 +3675,11 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 6.4.1(@types/node@24.12.0)(yaml@2.8.2)
+      vite: 6.4.1(@types/node@24.12.0)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-react@4.7.0(vite@6.4.1(@types/node@25.1.0)(yaml@2.8.2))':
+  '@vitejs/plugin-react@4.7.0(vite@6.4.1(@types/node@25.1.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
@@ -3660,7 +3687,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 6.4.1(@types/node@25.1.0)(yaml@2.8.2)
+      vite: 6.4.1(@types/node@25.1.0)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -3673,13 +3700,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@25.1.0)(yaml@2.8.2))':
+  '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@25.1.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@vitest/spy': 4.0.18
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@25.1.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@25.1.0)(tsx@4.21.0)(yaml@2.8.2)
 
   '@vitest/pretty-format@4.0.18':
     dependencies:
@@ -4293,6 +4320,10 @@ snapshots:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
 
+  get-tsconfig@4.14.0:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
   github-from-package@0.0.0: {}
 
   glob-parent@5.1.2:
@@ -4674,11 +4705,12 @@ snapshots:
 
   pngjs@5.0.0: {}
 
-  postcss-load-config@6.0.1(postcss@8.5.6)(yaml@2.8.2):
+  postcss-load-config@6.0.1(postcss@8.5.6)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       postcss: 8.5.6
+      tsx: 4.21.0
       yaml: 2.8.2
 
   postcss@8.5.6:
@@ -4781,6 +4813,8 @@ snapshots:
   resolve-from@4.0.0: {}
 
   resolve-from@5.0.0: {}
+
+  resolve-pkg-maps@1.0.0: {}
 
   restore-cursor@5.1.0:
     dependencies:
@@ -5057,7 +5091,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsup@8.5.1(postcss@8.5.6)(typescript@5.9.3)(yaml@2.8.2):
+  tsup@8.5.1(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.2)
       cac: 6.7.14
@@ -5068,7 +5102,7 @@ snapshots:
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(postcss@8.5.6)(yaml@2.8.2)
+      postcss-load-config: 6.0.1(postcss@8.5.6)(tsx@4.21.0)(yaml@2.8.2)
       resolve-from: 5.0.0
       rollup: 4.57.1
       source-map: 0.7.6
@@ -5084,6 +5118,13 @@ snapshots:
       - supports-color
       - tsx
       - yaml
+
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.2
+      get-tsconfig: 4.14.0
+    optionalDependencies:
+      fsevents: 2.3.3
 
   tunnel-agent@0.6.0:
     dependencies:
@@ -5138,7 +5179,7 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite@6.4.1(@types/node@24.12.0)(yaml@2.8.2):
+  vite@6.4.1(@types/node@24.12.0)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.3)
@@ -5149,9 +5190,10 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.12.0
       fsevents: 2.3.3
+      tsx: 4.21.0
       yaml: 2.8.2
 
-  vite@6.4.1(@types/node@25.1.0)(yaml@2.8.2):
+  vite@6.4.1(@types/node@25.1.0)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.3)
@@ -5162,9 +5204,10 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.1.0
       fsevents: 2.3.3
+      tsx: 4.21.0
       yaml: 2.8.2
 
-  vite@7.3.1(@types/node@25.1.0)(yaml@2.8.2):
+  vite@7.3.1(@types/node@25.1.0)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       esbuild: 0.27.2
       fdir: 6.5.0(picomatch@4.0.3)
@@ -5175,12 +5218,13 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.1.0
       fsevents: 2.3.3
+      tsx: 4.21.0
       yaml: 2.8.2
 
-  vitest@4.0.18(@types/node@25.1.0)(yaml@2.8.2):
+  vitest@4.0.18(@types/node@25.1.0)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       '@vitest/expect': 4.0.18
-      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@25.1.0)(yaml@2.8.2))
+      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@25.1.0)(tsx@4.21.0)(yaml@2.8.2))
       '@vitest/pretty-format': 4.0.18
       '@vitest/runner': 4.0.18
       '@vitest/snapshot': 4.0.18
@@ -5197,7 +5241,7 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 7.3.1(@types/node@25.1.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@25.1.0)(tsx@4.21.0)(yaml@2.8.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.1.0


### PR DESCRIPTION
## Summary

Migrate the standalone `examples/node` directory into `apps/node-examples` as a proper pnpm workspace package.

## Why

- `examples/` was not part of the pnpm workspace, so examples relied on implicit/global resolution and had no type-checking coverage.
- Moving it under `apps/` makes it a first-class workspace citizen, consistent with the other demo apps (`browser-wallet`, `react-quick-card`).

## Changes

- Move `examples/node/*.ts` → `apps/node-examples/*.ts`
- Add `package.json` + `tsconfig.json` for workspace integration
- Update run-path references in file headers and README
- Remove obsolete `examples/` directory
- Fix pre-existing type error: `listPeers()` does not accept arguments

## Verification

- `pnpm install` ✅
- `pnpm -C apps/node-examples typecheck` ✅
- Full monorepo build + test suite (via pre-commit hook) ✅