### PR TITLE
fix(cli): auto-build multiaddr from pubkey + address in peer connect

### DIFF
--- a/.changeset/fix-peer-connect-multiaddr.md
+++ b/.changeset/fix-peer-connect-multiaddr.md
@@ -1,0 +1,10 @@
+---
+"@fiber-pay/cli": patch
+---
+
+fix(cli): auto-build multiaddr from pubkey + address in peer connect
+
+- `peer connect <pubkey> --address <bare-multiaddr>` now automatically computes the peerId from the pubkey and appends `/p2p/<peerId>` to the address before sending the RPC call
+- `peer connect <pubkey>` still sends `{ pubkey }` and relies on graph resolution
+- `peer connect <multiaddr-with-p2p>` still sends `{ address }` directly
+- improved error message when a bare multiaddr is passed as the sole positional argument

--- a/packages/cli/src/commands/peer.ts
+++ b/packages/cli/src/commands/peer.ts
@@ -97,7 +97,7 @@ export function createPeerCommand(config: CliConfig): Command {
       if (isPubkey(trimmedInput)) {
         const normalized = normalizePubkey(trimmedInput) as HexString;
         if (options.address) {
-          const address = String(options.address).trim();
+          const address = String(options.address).trim().replace(/\/+$/, '');
           if (!address.startsWith('/')) {
             throw new Error('Invalid --address: expected a multiaddr starting with "/"');
           }

--- a/packages/cli/src/commands/peer.ts
+++ b/packages/cli/src/commands/peer.ts
@@ -1,4 +1,4 @@
-import { type HexString, nodeIdToPeerId } from '@fiber-pay/sdk';
+import { buildMultiaddrFromNodeId, type HexString, nodeIdToPeerId } from '@fiber-pay/sdk';
 import { Command } from 'commander';
 import type { CliConfig } from '../lib/config.js';
 import { printJsonSuccess, printPeerListHuman } from '../lib/format.js';
@@ -84,6 +84,7 @@ export function createPeerCommand(config: CliConfig): Command {
   peer
     .command('connect')
     .argument('<multiaddrOrPubkey>')
+    .option('--address <addr>', 'Optional peer address (multiaddr) to connect to')
     .option('--timeout <sec>', 'Wait timeout for peer to appear in peer list', '8')
     .option('--json')
     .action(async (input, options) => {
@@ -95,12 +96,28 @@ export function createPeerCommand(config: CliConfig): Command {
 
       if (isPubkey(trimmedInput)) {
         const normalized = normalizePubkey(trimmedInput) as HexString;
-        connectParams = { pubkey: normalized };
-        targetForWait = normalized;
+        if (options.address) {
+          const address = String(options.address).trim();
+          if (!address.startsWith('/')) {
+            throw new Error('Invalid --address: expected a multiaddr starting with "/"');
+          }
+          const multiaddr = await buildMultiaddrFromNodeId(address, normalized);
+          connectParams = { address: multiaddr };
+          targetForWait = normalized;
+        } else {
+          connectParams = { pubkey: normalized };
+          targetForWait = normalized;
+        }
       } else if (trimmedInput.startsWith('/')) {
         const peerId = extractPeerIdFromMultiaddr(trimmedInput);
         if (!peerId) {
-          throw new Error('Invalid multiaddr: missing /p2p/<peerId> suffix');
+          throw new Error(
+            'Invalid multiaddr: missing /p2p/<peerId> suffix. ' +
+              'Provide a bare multiaddr with --address when using a pubkey as the first argument.',
+          );
+        }
+        if (options.address) {
+          throw new Error('Cannot use --address when the first argument is already a multiaddr');
         }
         connectParams = { address: trimmedInput };
         targetForWait = peerId;


### PR DESCRIPTION
## Problem

The upstream `connect_peer` RPC (v0.8.0+) changed from `peer_id` to `pubkey`, but the underlying libp2p multiaddr still requires a `/p2p/<peerId>` suffix for `save=true` to work correctly. The previous CLI behavior forced users to provide a full multiaddr with `/p2p/` even though the RPC no longer exposes `peer_id`, which is inconsistent and inconvenient.

## Changes

This PR improves the `peer connect` command so that users only need to know the **pubkey** and an optional **bare address**:

1. **`peer connect <pubkey>`**  
   → Sends `{ pubkey }` as before, relying on the node to resolve the address from graph data.

2. **`peer connect <pubkey> --address <bare-multiaddr>`**  
   → Automatically computes the `peerId` from the pubkey via `buildMultiaddrFromNodeId` and appends `/p2p/<peerId>` to the address before sending `{ address }`.

3. **`peer connect <multiaddr-with-p2p>`**  
   → Sends `{ address }` directly, unchanged.

4. **Bare multiaddr as sole positional argument**  
   → Now produces a clearer error message suggesting the use of `--address` with a pubkey.

## Verification

- `pnpm typecheck` ✅
- `pnpm lint` ✅
- `pnpm test` ✅
- `pnpm build` ✅