### PR TITLE
feat(sdk): add IFiberClient interface for browser/RPC API parity

### DIFF
--- a/.changeset/api-parity-issue-95.md
+++ b/.changeset/api-parity-issue-95.md
@@ -1,0 +1,11 @@
+---
+"@fiber-pay/sdk": minor
+---
+
+Add shared `IFiberClient` interface for browser/RPC API parity (issue #95)
+
+- New `IFiberClient` interface type enabling polymorphic usage of `FiberRpcClient` and `FiberBrowserNode`
+- `FiberBrowserNode.nodeInfo()` added (canonical); `getNodeInfo()` deprecated
+- `FiberBrowserNode.settleInvoice()` added (was missing)
+- `FiberRpcClient` mutation methods now return `void` instead of `null`
+- Both classes declare `implements IFiberClient`

--- a/packages/sdk/src/browser/fiber-browser-node.ts
+++ b/packages/sdk/src/browser/fiber-browser-node.ts
@@ -26,6 +26,7 @@
  */
 
 import { FiberRpcError } from '../rpc/client.js';
+import type { IFiberClient } from '../types/fiber-client.js';
 import type {
   AbandonChannelParams,
   AcceptChannelParams,
@@ -61,6 +62,7 @@ import type {
   SendPaymentParams,
   SendPaymentResult,
   SendPaymentWithRouterParams,
+  SettleInvoiceParams,
   ShutdownChannelParams,
   UpdateChannelParams,
 } from '../types/rpc.js';
@@ -114,7 +116,7 @@ export interface BrowserNodeEvents {
 // FiberBrowserNode
 // =============================================================================
 
-export class FiberBrowserNode {
+export class FiberBrowserNode implements IFiberClient {
   private config: FiberBrowserNodeConfig;
   private adapter: FiberWasmAdapter | null = null;
   private _state: BrowserNodeState = 'idle';
@@ -260,8 +262,15 @@ export class FiberBrowserNode {
 
   // --- Info ---
 
-  async getNodeInfo(): Promise<NodeInfoResult> {
+  async nodeInfo(): Promise<NodeInfoResult> {
     return this.ensureRunning().nodeInfo();
+  }
+
+  /**
+   * @deprecated Use `nodeInfo()` instead for consistency with FiberRpcClient.
+   */
+  async getNodeInfo(): Promise<NodeInfoResult> {
+    return this.nodeInfo();
   }
 
   // --- Peer ---
@@ -338,6 +347,10 @@ export class FiberBrowserNode {
 
   async cancelInvoice(params: CancelInvoiceParams): Promise<CancelInvoiceResult> {
     return this.ensureRunning().cancelInvoice(params);
+  }
+
+  async settleInvoice(params: SettleInvoiceParams): Promise<void> {
+    return this.ensureRunning().settleInvoice(params);
   }
 
   // --- Graph ---

--- a/packages/sdk/src/browser/index.ts
+++ b/packages/sdk/src/browser/index.ts
@@ -68,6 +68,7 @@ export {
   FiberRpcError,
 } from '../rpc/client.js';
 export { ckbHash, derivePublicKey } from '../security/crypto.js';
+export type { IFiberClient } from '../types/fiber-client.js';
 export type {
   AbandonChannelParams,
   AcceptChannelParams,
@@ -108,6 +109,7 @@ export type {
   SendPaymentParams,
   SendPaymentResult,
   SendPaymentWithRouterParams,
+  SettleInvoiceParams,
   ShutdownChannelParams,
   UpdateChannelParams,
 } from '../types/rpc.js';

--- a/packages/sdk/src/browser/wasm-adapter.ts
+++ b/packages/sdk/src/browser/wasm-adapter.ts
@@ -43,6 +43,7 @@ import type {
   SendPaymentParams,
   SendPaymentResult,
   SendPaymentWithRouterParams,
+  SettleInvoiceParams,
   ShutdownChannelParams,
   UpdateChannelParams,
 } from '../types/rpc.js';
@@ -272,6 +273,10 @@ export class FiberWasmAdapter {
 
   async cancelInvoice(params: CancelInvoiceParams): Promise<CancelInvoiceResult> {
     return this.invoke<CancelInvoiceResult>('cancel_invoice', [params]);
+  }
+
+  async settleInvoice(params: SettleInvoiceParams): Promise<void> {
+    await this.invoke('settle_invoice', [params]);
   }
 
   // ===========================================================================

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -49,6 +49,7 @@ export {
 export { PolicyEngine } from './security/policy-engine.js';
 export type * from './types/index.js';
 // Types - Re-export all types from types module
+// Note: IFiberClient is included via the wildcard type export above
 export { ChannelState } from './types/index.js';
 // Utility functions
 export {

--- a/packages/sdk/src/rpc/client.ts
+++ b/packages/sdk/src/rpc/client.ts
@@ -17,7 +17,6 @@ import type {
   CkbInvoiceStatus,
   // Peer methods
   ConnectPeerParams,
-  ConnectPeerResult,
   DisconnectPeerParams,
   GetInvoiceParams,
   GetInvoiceResult,
@@ -28,6 +27,8 @@ import type {
   // Graph methods
   GraphNodesParams,
   GraphNodesResult,
+  // Shared client interface
+  IFiberClient,
   JsonRpcError,
   JsonRpcRequest,
   JsonRpcResponse,
@@ -98,7 +99,7 @@ export class FiberRpcError extends Error {
 // RPC Client
 // =============================================================================
 
-export class FiberRpcClient {
+export class FiberRpcClient implements IFiberClient {
   private requestId = 0;
   private config: Required<Pick<RpcClientConfig, 'url' | 'timeout'>> & RpcClientConfig;
 
@@ -196,15 +197,15 @@ export class FiberRpcClient {
   /**
    * Connect to a peer
    */
-  async connectPeer(params: ConnectPeerParams): Promise<ConnectPeerResult> {
-    return this.call<ConnectPeerResult>('connect_peer', [params]);
+  async connectPeer(params: ConnectPeerParams): Promise<void> {
+    await this.call<null>('connect_peer', [params]);
   }
 
   /**
    * Disconnect from a peer
    */
-  async disconnectPeer(params: DisconnectPeerParams): Promise<null> {
-    return this.call<null>('disconnect_peer', [params]);
+  async disconnectPeer(params: DisconnectPeerParams): Promise<void> {
+    await this.call<null>('disconnect_peer', [params]);
   }
 
   /**
@@ -271,22 +272,22 @@ export class FiberRpcClient {
   /**
    * Shutdown (close) a channel
    */
-  async shutdownChannel(params: ShutdownChannelParams): Promise<null> {
-    return this.call<null>('shutdown_channel', [params]);
+  async shutdownChannel(params: ShutdownChannelParams): Promise<void> {
+    await this.call<null>('shutdown_channel', [params]);
   }
 
   /**
    * Abandon a pending channel
    */
-  async abandonChannel(params: AbandonChannelParams): Promise<null> {
-    return this.call<null>('abandon_channel', [params]);
+  async abandonChannel(params: AbandonChannelParams): Promise<void> {
+    await this.call<null>('abandon_channel', [params]);
   }
 
   /**
    * Update channel parameters
    */
-  async updateChannel(params: UpdateChannelParams): Promise<null> {
-    return this.call<null>('update_channel', [params]);
+  async updateChannel(params: UpdateChannelParams): Promise<void> {
+    await this.call<null>('update_channel', [params]);
   }
 
   // ===========================================================================
@@ -342,8 +343,8 @@ export class FiberRpcClient {
    * Used for conditional/escrow payments where the invoice was created
    * with a payment_hash (no preimage provided upfront)
    */
-  async settleInvoice(params: SettleInvoiceParams): Promise<null> {
-    return this.call<null>('settle_invoice', [params]);
+  async settleInvoice(params: SettleInvoiceParams): Promise<void> {
+    await this.call<null>('settle_invoice', [params]);
   }
 
   // ===========================================================================

--- a/packages/sdk/src/types/fiber-client.ts
+++ b/packages/sdk/src/types/fiber-client.ts
@@ -1,0 +1,173 @@
+/**
+ * IFiberClient — Shared interface for Fiber node clients
+ *
+ * Both `FiberRpcClient` (JSON-RPC over HTTP) and `FiberBrowserNode`
+ * (WASM in-browser) implement this interface, enabling dual-mode apps
+ * to switch backends without adapter glue code.
+ *
+ * @example
+ * ```ts
+ * import type { IFiberClient } from '@fiber-pay/sdk';
+ *
+ * async function getBalance(client: IFiberClient) {
+ *   const info = await client.nodeInfo();
+ *   const channels = await client.listChannels();
+ *   // Works identically regardless of RPC vs browser node
+ * }
+ * ```
+ */
+
+import type {
+  AbandonChannelParams,
+  AcceptChannelParams,
+  AcceptChannelResult,
+  BuildRouterParams,
+  BuildRouterResult,
+  CancelInvoiceParams,
+  CancelInvoiceResult,
+  Channel,
+  ChannelId,
+  CkbInvoiceStatus,
+  ConnectPeerParams,
+  DisconnectPeerParams,
+  GetInvoiceParams,
+  GetInvoiceResult,
+  GetPaymentParams,
+  GetPaymentResult,
+  GraphChannelsParams,
+  GraphChannelsResult,
+  GraphNodesParams,
+  GraphNodesResult,
+  ListChannelsParams,
+  ListChannelsResult,
+  ListPeersResult,
+  NewInvoiceParams,
+  NewInvoiceResult,
+  NodeInfoResult,
+  OpenChannelParams,
+  OpenChannelResult,
+  ParseInvoiceParams,
+  ParseInvoiceResult,
+  PaymentHash,
+  SendPaymentParams,
+  SendPaymentResult,
+  SendPaymentWithRouterParams,
+  ShutdownChannelParams,
+  UpdateChannelParams,
+} from './rpc.js';
+
+/**
+ * Common client interface shared by FiberRpcClient and FiberBrowserNode.
+ *
+ * Method names mirror the Fiber RPC spec (`node_info` → `nodeInfo`, etc.).
+ * Mutation methods that return nothing in practice use `Promise<void>`
+ * for ergonomic TypeScript usage.
+ */
+export interface IFiberClient {
+  // ---------------------------------------------------------------------------
+  // Info
+  // ---------------------------------------------------------------------------
+
+  /** Get local node information. */
+  nodeInfo(): Promise<NodeInfoResult>;
+
+  // ---------------------------------------------------------------------------
+  // Peer
+  // ---------------------------------------------------------------------------
+
+  /** Connect to a peer. */
+  connectPeer(params: ConnectPeerParams): Promise<void>;
+
+  /** Disconnect from a peer. */
+  disconnectPeer(params: DisconnectPeerParams): Promise<void>;
+
+  /** List all connected peers. */
+  listPeers(): Promise<ListPeersResult>;
+
+  // ---------------------------------------------------------------------------
+  // Channel
+  // ---------------------------------------------------------------------------
+
+  /** Open a new channel with a peer. */
+  openChannel(params: OpenChannelParams): Promise<OpenChannelResult>;
+
+  /** Accept a channel opening request. */
+  acceptChannel(params: AcceptChannelParams): Promise<AcceptChannelResult>;
+
+  /** List all channels. */
+  listChannels(params?: ListChannelsParams): Promise<ListChannelsResult>;
+
+  /** Shutdown (close) a channel. */
+  shutdownChannel(params: ShutdownChannelParams): Promise<void>;
+
+  /** Abandon a pending channel. */
+  abandonChannel(params: AbandonChannelParams): Promise<void>;
+
+  /** Update channel parameters. */
+  updateChannel(params: UpdateChannelParams): Promise<void>;
+
+  // ---------------------------------------------------------------------------
+  // Payment
+  // ---------------------------------------------------------------------------
+
+  /** Send a payment. */
+  sendPayment(params: SendPaymentParams): Promise<SendPaymentResult>;
+
+  /** Get payment status. */
+  getPayment(params: GetPaymentParams): Promise<GetPaymentResult>;
+
+  /** Build a custom route for payment. */
+  buildRouter(params: BuildRouterParams): Promise<BuildRouterResult>;
+
+  /** Send a payment using a pre-built route. */
+  sendPaymentWithRouter(params: SendPaymentWithRouterParams): Promise<SendPaymentResult>;
+
+  // ---------------------------------------------------------------------------
+  // Invoice
+  // ---------------------------------------------------------------------------
+
+  /** Create a new invoice. */
+  newInvoice(params: NewInvoiceParams): Promise<NewInvoiceResult>;
+
+  /** Parse an invoice string. */
+  parseInvoice(params: ParseInvoiceParams): Promise<ParseInvoiceResult>;
+
+  /** Get invoice by payment hash. */
+  getInvoice(params: GetInvoiceParams): Promise<GetInvoiceResult>;
+
+  /** Cancel an open invoice. */
+  cancelInvoice(params: CancelInvoiceParams): Promise<CancelInvoiceResult>;
+
+  // ---------------------------------------------------------------------------
+  // Graph
+  // ---------------------------------------------------------------------------
+
+  /** List nodes in the network graph. */
+  graphNodes(params?: GraphNodesParams): Promise<GraphNodesResult>;
+
+  /** List channels in the network graph. */
+  graphChannels(params?: GraphChannelsParams): Promise<GraphChannelsResult>;
+
+  // ---------------------------------------------------------------------------
+  // Polling Helpers
+  // ---------------------------------------------------------------------------
+
+  /** Wait for a payment to reach a terminal state (Success or Failed). */
+  waitForPayment(
+    paymentHash: PaymentHash,
+    options?: { timeout?: number; interval?: number },
+  ): Promise<GetPaymentResult>;
+
+  /** Wait for a channel to reach ChannelReady state. */
+  waitForChannelReady(
+    channelId: ChannelId,
+    options?: { timeout?: number; interval?: number },
+  ): Promise<Channel>;
+
+  /** Wait for an invoice to reach a specific status. */
+  waitForInvoiceStatus(
+    paymentHash: PaymentHash,
+    targetStatus: CkbInvoiceStatus | CkbInvoiceStatus[],
+    options?: { timeout?: number; interval?: number },
+  ): Promise<GetInvoiceResult>;
+}

--- a/packages/sdk/src/types/fiber-client.ts
+++ b/packages/sdk/src/types/fiber-client.ts
@@ -13,6 +13,7 @@
  *   const info = await client.nodeInfo();
  *   const channels = await client.listChannels();
  *   // Works identically regardless of RPC vs browser node
+ *   return channels;
  * }
  * ```
  */
@@ -52,6 +53,7 @@ import type {
   SendPaymentParams,
   SendPaymentResult,
   SendPaymentWithRouterParams,
+  SettleInvoiceParams,
   ShutdownChannelParams,
   UpdateChannelParams,
 } from './rpc.js';
@@ -137,6 +139,9 @@ export interface IFiberClient {
 
   /** Cancel an open invoice. */
   cancelInvoice(params: CancelInvoiceParams): Promise<CancelInvoiceResult>;
+
+  /** Settle a hold invoice with the preimage. */
+  settleInvoice(params: SettleInvoiceParams): Promise<void>;
 
   // ---------------------------------------------------------------------------
   // Graph

--- a/packages/sdk/src/types/index.ts
+++ b/packages/sdk/src/types/index.ts
@@ -2,5 +2,6 @@
  * Type exports
  */
 
+export * from './fiber-client.js';
 export * from './policy.js';
 export * from './rpc.js';

--- a/packages/sdk/tests/rpc-client.test.ts
+++ b/packages/sdk/tests/rpc-client.test.ts
@@ -107,7 +107,7 @@ describe('FiberRpcClient - New Methods', () => {
 
       const result = await client.settleInvoice(params);
 
-      expect(result).toBeNull();
+      expect(result).toBeUndefined();
       expect(fetchMock).toHaveBeenCalledOnce();
 
       const body = JSON.parse(fetchMock.mock.calls[0][1].body);


### PR DESCRIPTION
## Summary

Closes #95

Adds a shared `IFiberClient` interface so that `FiberRpcClient` and `FiberBrowserNode` can be used interchangeably, enabling dual-mode apps (local RPC node vs browser WASM node) without adapter glue code.

## Changes

### New `IFiberClient` interface
- Defines the common API contract for all Fiber node clients
- Importable from `@fiber-pay/sdk` and `@fiber-pay/sdk/browser`

### `FiberRpcClient` alignment
- Declares `implements IFiberClient`
- Mutation methods (`connectPeer`, `disconnectPeer`, `shutdownChannel`, `abandonChannel`, `updateChannel`, `settleInvoice`) now return `Promise<void>` instead of `Promise<null>`

### `FiberBrowserNode` alignment
- Declares `implements IFiberClient`
- Added `nodeInfo()` as the canonical method (matches RPC method name `node_info`)
- `getNodeInfo()` kept as deprecated alias for backward compat
- Added missing `settleInvoice()` method

### Supporting changes
- `FiberWasmAdapter`: added `settleInvoice()`
- `SettleInvoiceParams` exported from browser entry point
- Test updated for void return type

## Usage

```ts
import type { IFiberClient } from '@fiber-pay/sdk';

// Works with either backend
async function getBalance(client: IFiberClient) {
  const info = await client.nodeInfo();
  const channels = await client.listChannels();
  return channels;
}
```