### PR TITLE
feat(sdk): add TransportType and addr_type to ConnectPeerParams for Fiber v0.8.1

### DIFF
--- a/.changeset/connect-peer-addr-type-issue-110.md
+++ b/.changeset/connect-peer-addr-type-issue-110.md
@@ -1,0 +1,12 @@
+---
+"@fiber-pay/sdk": minor
+"@fiber-pay/cli": minor
+---
+
+Add `TransportType` and `addr_type` param to `ConnectPeerParams` for Fiber v0.8.1 (issue #110)
+
+- New `TransportType` union type: `'tcp' | 'ws' | 'wss'`
+- `ConnectPeerParams.addr_type` optional field for filtering peer addresses by transport protocol
+- CLI `peer connect` now accepts `--addr-type <tcp|ws|wss>` when connecting by pubkey
+- Especially useful in WASM/browser environments that only support WSS
+- Updated RPC type version comments to v0.8.1

--- a/packages/cli/src/commands/peer.ts
+++ b/packages/cli/src/commands/peer.ts
@@ -85,13 +85,21 @@ export function createPeerCommand(config: CliConfig): Command {
     .command('connect')
     .argument('<multiaddrOrPubkey>')
     .option('--address <addr>', 'Optional peer address (multiaddr) to connect to')
+    .option('--addr-type <type>', 'Filter peer addresses by transport type (tcp, ws, wss)')
     .option('--timeout <sec>', 'Wait timeout for peer to appear in peer list', '8')
     .option('--json')
     .action(async (input, options) => {
       const rpc = await createReadyRpcClient(config);
       const trimmedInput = input.trim();
 
-      let connectParams: { address: string } | { pubkey: HexString };
+      const addrType = options.addrType as 'tcp' | 'ws' | 'wss' | undefined;
+      if (addrType && !['tcp', 'ws', 'wss'].includes(addrType)) {
+        throw new Error('Invalid --addr-type: expected one of tcp, ws, wss');
+      }
+
+      let connectParams:
+        | { address: string }
+        | { pubkey: HexString; addr_type?: 'tcp' | 'ws' | 'wss' };
       let targetForWait: string;
 
       if (isPubkey(trimmedInput)) {
@@ -101,11 +109,16 @@ export function createPeerCommand(config: CliConfig): Command {
           if (!address.startsWith('/')) {
             throw new Error('Invalid --address: expected a multiaddr starting with "/"');
           }
+          if (addrType) {
+            throw new Error(
+              'Cannot use --addr-type together with --address (transport is already specified by the address)',
+            );
+          }
           const multiaddr = await buildMultiaddrFromNodeId(address, normalized);
           connectParams = { address: multiaddr };
           targetForWait = normalized;
         } else {
-          connectParams = { pubkey: normalized };
+          connectParams = { pubkey: normalized, ...(addrType && { addr_type: addrType }) };
           targetForWait = normalized;
         }
       } else if (trimmedInput.startsWith('/')) {
@@ -118,6 +131,9 @@ export function createPeerCommand(config: CliConfig): Command {
         }
         if (options.address) {
           throw new Error('Cannot use --address when the first argument is already a multiaddr');
+        }
+        if (addrType) {
+          throw new Error('Cannot use --addr-type when connecting with a full multiaddr');
         }
         connectParams = { address: trimmedInput };
         targetForWait = peerId;

--- a/packages/sdk/src/browser/index.ts
+++ b/packages/sdk/src/browser/index.ts
@@ -111,6 +111,7 @@ export type {
   SendPaymentWithRouterParams,
   SettleInvoiceParams,
   ShutdownChannelParams,
+  TransportType,
   UpdateChannelParams,
 } from '../types/rpc.js';
 export { ChannelState } from '../types/rpc.js';

--- a/packages/sdk/src/types/rpc.ts
+++ b/packages/sdk/src/types/rpc.ts
@@ -1,8 +1,8 @@
 /**
- * Fiber Network Node RPC Types (Fiber v0.8.0)
+ * Fiber Network Node RPC Types (Fiber v0.8.1)
  *
  * The types in this file are intended to align with the upstream RPC spec:
- * https://github.com/nervosnetwork/fiber/blob/v0.8.0/crates/fiber-lib/src/rpc/README.md
+ * https://github.com/nervosnetwork/fiber/blob/v0.8.1/crates/fiber-lib/src/rpc/README.md
  */
 
 // =============================================================================
@@ -26,6 +26,13 @@ export type PeerId = string;
 
 /** Multiaddr format for network addresses. */
 export type Multiaddr = string;
+
+/**
+ * Transport type for multiaddr filtering.
+ * Used by `connect_peer` to select addresses by transport protocol.
+ * @since Fiber v0.8.1
+ */
+export type TransportType = 'tcp' | 'ws' | 'wss';
 
 /** Channel ID (Hash256). */
 export type ChannelId = Hash256;
@@ -299,6 +306,13 @@ export interface ConnectPeerParams {
   address?: string;
   pubkey?: Pubkey;
   save?: boolean;
+  /**
+   * Filter peer addresses by transport type before random selection.
+   * Only applies when connecting via pubkey (no explicit address).
+   * Useful in WASM environments that only support WSS.
+   * @since Fiber v0.8.1
+   */
+  addr_type?: TransportType;
 }
 
 /** connect_peer returns null. */


### PR DESCRIPTION
## Summary

Closes #110

Adds the `addr_type` parameter to `ConnectPeerParams`, matching upstream Fiber v0.8.1 ([nervosnetwork/fiber#1270](https://github.com/nervosnetwork/fiber/pull/1270)).

## Background

When `connect_peer` is called with only a pubkey, the node randomly selects an address from the peer's known addresses. In WASM/browser environments, this may select a non-WSS address that is unsupported. The new `addr_type` parameter allows callers to filter addresses by transport type before random selection.

## Changes

### Types (`packages/sdk/src/types/rpc.ts`)
- New `TransportType` union: `'tcp' | 'ws' | 'wss'`
- `ConnectPeerParams.addr_type?: TransportType` — optional transport filter
- Updated version comment to v0.8.1

### Exports (`packages/sdk/src/browser/index.ts`)
- `TransportType` added to browser entry point re-exports

## Usage

```ts
// Browser WASM node — force WSS transport
await client.connectPeer({
  pubkey: '0xaabb...',
  addr_type: 'wss',
});

// Standard RPC — unchanged behavior (optional param)
await client.connectPeer({
  address: '/ip4/127.0.0.1/tcp/8228',
});
```

## Verification
- ✅ `pnpm run typecheck` — all 10 packages pass
- ✅ `pnpm test` — all tests pass