### PR TITLE
feat(react): add ConnectButton, NodeInfoPanel, and enhance useFiberNode

### DIFF
--- a/.changeset/connect-button-node-info-panel.md
+++ b/.changeset/connect-button-node-info-panel.md
@@ -1,0 +1,12 @@
+---
+"@fiber-pay/react": minor
+---
+
+feat(react): add ConnectButton, NodeInfoPanel components and enhance useFiberNode
+
+- Add `<ConnectButton>` component with standalone and external-hook modes, supporting passkey/password/rawKey/auto strategies
+- Add `<NodeInfoPanel>` component for displaying node stats, QR code, and copy-to-clipboard
+- Add `startWithRawKey()` to `useFiberNode` hook for `RawKeyCredentialProvider` support
+- Add `isStarting` and `isRunning` computed convenience booleans to `useFiberNode`
+- Export `RawKeyCredentialProvider` and `scriptToAddress` from `@fiber-pay/react`
+- Add `qrcode.react` as optional peer dependency for QR code rendering

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -42,7 +42,13 @@
     "@nervosnetwork/fiber-js": "~0.8.0"
   },
   "peerDependencies": {
-    "react": "^18.0.0 || ^19.0.0"
+    "react": "^18.0.0 || ^19.0.0",
+    "qrcode.react": "^4.0.0"
+  },
+  "peerDependenciesMeta": {
+    "qrcode.react": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@types/react": "^18.0.0 || ^19.0.0"

--- a/packages/react/src/connect-button.tsx
+++ b/packages/react/src/connect-button.tsx
@@ -20,7 +20,14 @@
  */
 
 import type { FiberBrowserNode, FiberWasmFactory, NodeInfoResult } from '@fiber-pay/sdk/browser';
-import { type CSSProperties, useCallback, useEffect, useRef, useState } from 'react';
+import {
+  type CSSProperties,
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 import type { UseFiberNodeOptions, UseFiberNodeResult } from './use-fiber-node.js';
 import { useFiberNode } from './use-fiber-node.js';
 
@@ -294,6 +301,7 @@ export function ConnectButton(props: ConnectButtonProps) {
     walletId,
     wasmFactory,
     nodeConfig,
+    enabled: !externalFiber,
   });
 
   const fiber = externalFiber ?? internalFiber;
@@ -318,6 +326,7 @@ export function ConnectButton(props: ConnectButtonProps) {
   // --- Local UI state -------------------------------------------------------
   const [isConnecting, setIsConnecting] = useState(false);
   const [showDropdown, setShowDropdown] = useState(false);
+  const [localError, setLocalError] = useState<string | null>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
 
   const effectiveIsStarting = isConnecting || isStarting;
@@ -357,10 +366,19 @@ export function ConnectButton(props: ConnectButtonProps) {
   // --- Actions --------------------------------------------------------------
 
   const resolvedStrategy =
-    strategy === 'auto' ? (rawKey ? 'rawKey' : password ? 'password' : 'passkey') : strategy;
+    strategy === 'auto'
+      ? hasPasskeyConfigured && isPasskeySupported
+        ? 'passkey'
+        : password
+          ? 'password'
+          : rawKey
+            ? 'rawKey'
+            : 'passkey'
+      : strategy;
 
   const handleConnect = useCallback(async () => {
     setIsConnecting(true);
+    setLocalError(null);
     try {
       switch (resolvedStrategy) {
         case 'password':
@@ -379,6 +397,10 @@ export function ConnectButton(props: ConnectButtonProps) {
           }
           break;
       }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      setLocalError(msg);
+      onError?.(msg);
     } finally {
       setIsConnecting(false);
     }
@@ -393,19 +415,27 @@ export function ConnectButton(props: ConnectButtonProps) {
     startWithPasskey,
     startWithRawKey,
     createPasskeyAndStart,
+    onError,
   ]);
 
   const handleDisconnect = useCallback(async () => {
-    await stop();
-    setShowDropdown(false);
-  }, [stop]);
+    try {
+      await stop();
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      setLocalError(msg);
+      onError?.(msg);
+    } finally {
+      setShowDropdown(false);
+    }
+  }, [stop, onError]);
 
   // --- Render ---------------------------------------------------------------
 
-  const hasError = !!error;
+  const hasError = !!(error || localError);
 
   // Determine button content and behaviour
-  let buttonLabel: React.ReactNode;
+  let buttonLabel: ReactNode;
   let buttonOnClick: (() => void) | undefined;
   let buttonDisabled = false;
   let buttonStyle: CSSProperties;
@@ -461,7 +491,7 @@ export function ConnectButton(props: ConnectButtonProps) {
       {/* Error / passkey unavailability message */}
       {(hasError ||
         (!isPasskeySupported && passkeyUnavailableReason && resolvedStrategy === 'passkey')) && (
-        <span style={styles.errorText}>{error || passkeyUnavailableReason}</span>
+        <span style={styles.errorText}>{error || localError || passkeyUnavailableReason}</span>
       )}
 
       {isRunning ? (

--- a/packages/react/src/connect-button.tsx
+++ b/packages/react/src/connect-button.tsx
@@ -1,0 +1,522 @@
+/**
+ * ConnectButton — A unified connect/disconnect button for Fiber browser nodes.
+ *
+ * Supports three usage modes:
+ * 1. **Standalone** — Internally manages `useFiberNode`. Simplest API.
+ * 2. **External hook** — Accepts a pre-existing `useFiberNode` result via the `fiber` prop,
+ *    so sibling components can share the same node instance.
+ * 3. **Auto-detection** — If `fiber` is provided, uses it; otherwise creates its own.
+ *
+ * @example Standalone
+ * ```tsx
+ * <ConnectButton network="testnet" strategy="passkey" onConnect={(node) => setNode(node)} />
+ * ```
+ *
+ * @example External hook
+ * ```tsx
+ * const fiber = useFiberNode({ network: "testnet" });
+ * <ConnectButton fiber={fiber} strategy="passkey" />
+ * ```
+ */
+
+import type { FiberBrowserNode, FiberWasmFactory, NodeInfoResult } from '@fiber-pay/sdk/browser';
+import { type CSSProperties, useCallback, useEffect, useRef, useState } from 'react';
+import type { UseFiberNodeOptions, UseFiberNodeResult } from './use-fiber-node.js';
+import { useFiberNode } from './use-fiber-node.js';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+/** Credential strategy the ConnectButton should use */
+export type ConnectStrategy = 'passkey' | 'password' | 'rawKey' | 'auto';
+
+export interface ConnectButtonProps {
+  /** Network to connect to. Required in standalone mode; ignored when `fiber` is provided. */
+  network?: 'testnet' | 'mainnet';
+
+  /**
+   * Pre-existing hook result from `useFiberNode()`.
+   * When provided, the button delegates to this instead of creating its own hook.
+   */
+  fiber?: UseFiberNodeResult;
+
+  /** Credential strategy. Defaults to `"auto"`. */
+  strategy?: ConnectStrategy;
+
+  /** Password for the "password" strategy. */
+  password?: string;
+
+  /** Raw Fiber key (32 bytes) for the "rawKey" strategy. */
+  rawKey?: Uint8Array;
+
+  /** Raw CKB secret key (32 bytes) for the "rawKey" strategy (optional). */
+  rawCkbKey?: Uint8Array;
+
+  /** Wallet identifier for IndexedDB isolation. */
+  walletId?: string;
+
+  /** Display name for passkey registration. */
+  passkeyUsername?: string;
+
+  /** Optional WASM factory override. */
+  wasmFactory?: FiberWasmFactory;
+
+  /** Additional node config. */
+  nodeConfig?: UseFiberNodeOptions['nodeConfig'];
+
+  /** Additional CSS class name(s) for the root container. */
+  className?: string;
+
+  /** Inline styles for the root container. */
+  style?: CSSProperties;
+
+  /**
+   * Called when the node reaches the "running" state.
+   * Receives the `FiberBrowserNode` instance and its `NodeInfoResult`.
+   */
+  onConnect?: (node: FiberBrowserNode, nodeInfo: NodeInfoResult) => void;
+
+  /** Called after the node is stopped. */
+  onDisconnect?: () => void;
+
+  /** Called when an error occurs. */
+  onError?: (error: string) => void;
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+function truncateNodeId(id: string): string {
+  if (id.length <= 16) return id;
+  return `${id.slice(0, 8)}…${id.slice(-4)}`;
+}
+
+// =============================================================================
+// CSS (inline defaults using CSS custom properties)
+// =============================================================================
+
+const styles = {
+  root: {
+    position: 'relative',
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: '0.5rem',
+    fontFamily: 'system-ui, -apple-system, sans-serif',
+  } satisfies CSSProperties,
+
+  button: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: '0.5rem',
+    padding: '0.5rem 1.25rem',
+    fontSize: '0.875rem',
+    fontWeight: 600,
+    borderRadius: '9999px',
+    border: 'none',
+    cursor: 'pointer',
+    transition: 'background-color 0.15s, opacity 0.15s',
+    lineHeight: 1.4,
+  } satisfies CSSProperties,
+
+  connectButton: {
+    backgroundColor: 'var(--fpay-accent, #6366f1)',
+    color: 'var(--fpay-accent-fg, #fff)',
+  } satisfies CSSProperties,
+
+  connectedButton: {
+    backgroundColor: 'var(--fpay-accent-subtle, rgba(99,102,241,0.12))',
+    color: 'var(--fpay-accent, #6366f1)',
+    border: '1px solid var(--fpay-accent-border, rgba(99,102,241,0.35))',
+  } satisfies CSSProperties,
+
+  disabledButton: {
+    opacity: 0.6,
+    cursor: 'not-allowed',
+  } satisfies CSSProperties,
+
+  statusDot: {
+    display: 'inline-block',
+    width: '0.5rem',
+    height: '0.5rem',
+    borderRadius: '50%',
+    backgroundColor: 'var(--fpay-accent, #6366f1)',
+  } satisfies CSSProperties,
+
+  errorText: {
+    fontSize: '0.75rem',
+    color: 'var(--fpay-error, #ef4444)',
+    maxWidth: '220px',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+  } satisfies CSSProperties,
+
+  dropdown: {
+    position: 'absolute',
+    right: 0,
+    top: '100%',
+    marginTop: '0.5rem',
+    width: '280px',
+    borderRadius: '0.75rem',
+    border: '1px solid var(--fpay-border, #e5e7eb)',
+    backgroundColor: 'var(--fpay-bg-elevated, #fff)',
+    padding: '1rem',
+    boxShadow: '0 10px 25px rgba(0,0,0,0.1)',
+    zIndex: 100,
+  } satisfies CSSProperties,
+
+  infoRow: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    padding: '0.375rem 0',
+    fontSize: '0.75rem',
+  } satisfies CSSProperties,
+
+  infoLabel: {
+    color: 'var(--fpay-text-secondary, #6b7280)',
+  } satisfies CSSProperties,
+
+  infoValue: {
+    fontFamily: 'ui-monospace, monospace',
+    color: 'var(--fpay-text-primary, #111827)',
+  } satisfies CSSProperties,
+
+  separator: {
+    borderTop: '1px solid var(--fpay-border, #e5e7eb)',
+    margin: '0.75rem 0',
+  } satisfies CSSProperties,
+
+  disconnectButton: {
+    display: 'flex',
+    width: '100%',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    padding: '0.625rem 0.75rem',
+    fontSize: '0.875rem',
+    fontWeight: 600,
+    border: '1px solid var(--fpay-border, #e5e7eb)',
+    borderRadius: '0.5rem',
+    backgroundColor: 'var(--fpay-bg-secondary, #f9fafb)',
+    color: 'var(--fpay-text-primary, #111827)',
+    cursor: 'pointer',
+    transition: 'background-color 0.15s',
+  } satisfies CSSProperties,
+
+  spinner: {
+    animation: 'fpay-spin 1s linear infinite',
+  } satisfies CSSProperties,
+};
+
+// Keyframes are injected once via a <style> tag
+const KEYFRAMES_ID = 'fpay-connect-button-keyframes';
+function ensureKeyframes() {
+  if (typeof document === 'undefined') return;
+  if (document.getElementById(KEYFRAMES_ID)) return;
+  const style = document.createElement('style');
+  style.id = KEYFRAMES_ID;
+  style.textContent = `@keyframes fpay-spin { to { transform: rotate(360deg); } }`;
+  document.head.appendChild(style);
+}
+
+// =============================================================================
+// Spinner SVG
+// =============================================================================
+
+function Spinner({ size = 16 }: { size?: number }) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      style={styles.spinner}
+      role="img"
+      aria-label="Loading"
+    >
+      <path d="M21 12a9 9 0 1 1-6.219-8.56" />
+    </svg>
+  );
+}
+
+// Chevron SVG for the dropdown toggle
+function Chevron({ open }: { open: boolean }) {
+  return (
+    <svg
+      width="12"
+      height="12"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      style={{ transition: 'transform 0.15s', transform: open ? 'rotate(180deg)' : 'none' }}
+      aria-hidden="true"
+    >
+      <polyline points="6 9 12 15 18 9" />
+    </svg>
+  );
+}
+
+// =============================================================================
+// Component
+// =============================================================================
+
+export function ConnectButton(props: ConnectButtonProps) {
+  const {
+    network = 'testnet',
+    fiber: externalFiber,
+    strategy = 'auto',
+    password,
+    rawKey,
+    rawCkbKey,
+    walletId,
+    passkeyUsername = 'User',
+    wasmFactory,
+    nodeConfig,
+    className,
+    style,
+    onConnect,
+    onDisconnect,
+    onError,
+  } = props;
+
+  // --- Hook: internal or external -------------------------------------------
+  const internalFiber = useFiberNode({
+    network,
+    walletId,
+    wasmFactory,
+    nodeConfig,
+  });
+
+  const fiber = externalFiber ?? internalFiber;
+
+  const {
+    state,
+    node,
+    nodeInfo,
+    error,
+    isStarting,
+    isRunning,
+    isPasskeySupported,
+    passkeyUnavailableReason,
+    hasPasskeyConfigured,
+    createPasskeyAndStart,
+    startWithPasskey,
+    startWithPassword,
+    startWithRawKey,
+    stop,
+  } = fiber;
+
+  // --- Local UI state -------------------------------------------------------
+  const [isConnecting, setIsConnecting] = useState(false);
+  const [showDropdown, setShowDropdown] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  const effectiveIsStarting = isConnecting || isStarting;
+
+  // Inject keyframes on mount
+  useEffect(() => ensureKeyframes(), []);
+
+  // Click-outside to close dropdown
+  useEffect(() => {
+    if (!showDropdown) return;
+    function handleClickOutside(e: MouseEvent) {
+      if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
+        setShowDropdown(false);
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [showDropdown]);
+
+  // Notify parent on connect/disconnect
+  const prevRunningRef = useRef(false);
+  useEffect(() => {
+    if (isRunning && !prevRunningRef.current && node && nodeInfo) {
+      onConnect?.(node, nodeInfo);
+    }
+    if (!isRunning && prevRunningRef.current) {
+      onDisconnect?.();
+    }
+    prevRunningRef.current = isRunning;
+  }, [isRunning, node, nodeInfo, onConnect, onDisconnect]);
+
+  // Notify parent on error
+  useEffect(() => {
+    if (error) onError?.(error);
+  }, [error, onError]);
+
+  // --- Actions --------------------------------------------------------------
+
+  const resolvedStrategy =
+    strategy === 'auto' ? (rawKey ? 'rawKey' : password ? 'password' : 'passkey') : strategy;
+
+  const handleConnect = useCallback(async () => {
+    setIsConnecting(true);
+    try {
+      switch (resolvedStrategy) {
+        case 'password':
+          if (!password) throw new Error('Password is required for "password" strategy');
+          await startWithPassword(password);
+          break;
+        case 'rawKey':
+          if (!rawKey) throw new Error('rawKey is required for "rawKey" strategy');
+          await startWithRawKey(rawKey, rawCkbKey);
+          break;
+        case 'passkey':
+          if (hasPasskeyConfigured) {
+            await startWithPasskey();
+          } else {
+            await createPasskeyAndStart(passkeyUsername);
+          }
+          break;
+      }
+    } finally {
+      setIsConnecting(false);
+    }
+  }, [
+    resolvedStrategy,
+    password,
+    rawKey,
+    rawCkbKey,
+    passkeyUsername,
+    hasPasskeyConfigured,
+    startWithPassword,
+    startWithPasskey,
+    startWithRawKey,
+    createPasskeyAndStart,
+  ]);
+
+  const handleDisconnect = useCallback(async () => {
+    await stop();
+    setShowDropdown(false);
+  }, [stop]);
+
+  // --- Render ---------------------------------------------------------------
+
+  const hasError = !!error;
+
+  // Determine button content and behaviour
+  let buttonLabel: React.ReactNode;
+  let buttonOnClick: (() => void) | undefined;
+  let buttonDisabled = false;
+  let buttonStyle: CSSProperties;
+
+  if (isRunning) {
+    buttonLabel = (
+      <>
+        <span style={styles.statusDot} />
+        <span style={{ fontFamily: 'ui-monospace, monospace' }}>
+          {nodeInfo?.pubkey ? truncateNodeId(nodeInfo.pubkey) : 'Connected'}
+        </span>
+        <Chevron open={showDropdown} />
+      </>
+    );
+    buttonOnClick = () => setShowDropdown((s) => !s);
+    buttonStyle = { ...styles.button, ...styles.connectedButton };
+  } else if (effectiveIsStarting) {
+    buttonLabel = (
+      <>
+        <Spinner />
+        Connecting…
+      </>
+    );
+    buttonDisabled = true;
+    buttonStyle = { ...styles.button, ...styles.connectButton, ...styles.disabledButton };
+  } else {
+    // Idle — label depends on strategy
+    switch (resolvedStrategy) {
+      case 'passkey':
+        buttonLabel = hasPasskeyConfigured ? 'Connect with Passkey' : 'Connect via Passkey';
+        if (!isPasskeySupported) {
+          buttonLabel = 'Passkey unavailable';
+          buttonDisabled = true;
+        }
+        break;
+      case 'password':
+        buttonLabel = 'Connect';
+        break;
+      case 'rawKey':
+        buttonLabel = 'Connect';
+        break;
+    }
+    buttonOnClick = handleConnect;
+    buttonStyle = {
+      ...styles.button,
+      ...styles.connectButton,
+      ...(buttonDisabled ? styles.disabledButton : {}),
+    };
+  }
+
+  return (
+    <div className={className} style={{ ...styles.root, ...style }} data-fpay-connect-button="">
+      {/* Error / passkey unavailability message */}
+      {(hasError ||
+        (!isPasskeySupported && passkeyUnavailableReason && resolvedStrategy === 'passkey')) && (
+        <span style={styles.errorText}>{error || passkeyUnavailableReason}</span>
+      )}
+
+      {isRunning ? (
+        <div style={{ position: 'relative' }} ref={dropdownRef}>
+          <button type="button" onClick={buttonOnClick} style={buttonStyle}>
+            {buttonLabel}
+          </button>
+
+          {showDropdown && (
+            <div style={styles.dropdown}>
+              {/* Node info */}
+              {nodeInfo && (
+                <>
+                  <div style={styles.infoRow}>
+                    <span style={styles.infoLabel}>Pubkey</span>
+                    <span style={styles.infoValue}>{truncateNodeId(nodeInfo.pubkey)}</span>
+                  </div>
+                  <div style={styles.infoRow}>
+                    <span style={styles.infoLabel}>State</span>
+                    <span style={styles.infoValue}>{state}</span>
+                  </div>
+                </>
+              )}
+
+              <div style={styles.separator} />
+
+              {/* Disconnect */}
+              <button
+                type="button"
+                onClick={() => void handleDisconnect()}
+                style={styles.disconnectButton}
+              >
+                <span>Disconnect</span>
+                <svg
+                  width="14"
+                  height="14"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  aria-hidden="true"
+                >
+                  <path d="M9 18l6-6-6-6" />
+                </svg>
+              </button>
+            </div>
+          )}
+        </div>
+      ) : (
+        <button type="button" onClick={buttonOnClick} disabled={buttonDisabled} style={buttonStyle}>
+          {buttonLabel}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -19,11 +19,16 @@ export {
   PasskeyCredentialProvider,
   PasswordCredentialProvider,
   RawKeyCredentialProvider,
+  scriptToAddress,
   shannonsToCkb,
   toHex,
 } from '@fiber-pay/sdk/browser';
+export type { ConnectButtonProps, ConnectStrategy } from './connect-button.js';
+export { ConnectButton } from './connect-button.js';
 export type { FiberPayQuickCardProps } from './fiber-pay-quick-card.js';
 export { FiberPayQuickCard } from './fiber-pay-quick-card.js';
+export type { NodeInfoPanelProps } from './node-info-panel.js';
+export { NodeInfoPanel } from './node-info-panel.js';
 export type { UseFiberNodeOptions, UseFiberNodeResult } from './use-fiber-node.js';
 export { useFiberNode } from './use-fiber-node.js';
 export type { UseFiberPaymentResult } from './use-fiber-payment.js';

--- a/packages/react/src/node-info-panel.tsx
+++ b/packages/react/src/node-info-panel.tsx
@@ -13,9 +13,13 @@
  * ```
  */
 
-import { scriptToAddress } from '@fiber-pay/sdk';
 import type { FiberBrowserNode } from '@fiber-pay/sdk/browser';
-import { ConfigBuilder, formatShannonsAsCkb, getLockBalanceShannons } from '@fiber-pay/sdk/browser';
+import {
+  ConfigBuilder,
+  formatShannonsAsCkb,
+  getLockBalanceShannons,
+  scriptToAddress,
+} from '@fiber-pay/sdk/browser';
 import {
   type ComponentType,
   type CSSProperties,
@@ -302,6 +306,7 @@ function InfoRow({ label, value, copyable }: { label: string; value: string; cop
             onClick={() => copyToClipboard(value)}
             style={styles.copyButton}
             title="Copy to clipboard"
+            aria-label={`Copy ${label}`}
           >
             <CopyIcon />
           </button>
@@ -341,9 +346,11 @@ export function NodeInfoPanel(props: NodeInfoPanelProps) {
 
   // Attempt to dynamically import qrcode.react if needed
   useEffect(() => {
+    let cancelled = false;
     if (!showQrCode || renderQrCode) return;
     import('qrcode.react')
       .then((mod: Record<string, unknown>) => {
+        if (cancelled) return;
         const Comp = (mod.QRCodeSVG ?? mod.default) as
           | ComponentType<{
               value: string;
@@ -357,10 +364,16 @@ export function NodeInfoPanel(props: NodeInfoPanelProps) {
       .catch(() => {
         // qrcode.react not installed — silently skip
       });
+    return () => {
+      cancelled = true;
+    };
   }, [showQrCode, renderQrCode]);
 
+  const loadingRef = useRef(false);
+
   const loadStats = useCallback(async () => {
-    if (!node || node.state !== 'running') return;
+    if (!node || node.state !== 'running' || loadingRef.current) return;
+    loadingRef.current = true;
     setStatsLoading(true);
     setStatsError(null);
     try {
@@ -371,6 +384,7 @@ export function NodeInfoPanel(props: NodeInfoPanelProps) {
         setStatsError(e instanceof Error ? e.message : String(e));
       }
     } finally {
+      loadingRef.current = false;
       if (!cancelledRef.current) setStatsLoading(false);
     }
   }, [node, network]);
@@ -439,11 +453,18 @@ export function NodeInfoPanel(props: NodeInfoPanelProps) {
             strokeWidth="2"
             strokeLinecap="round"
             strokeLinejoin="round"
-            style={{ animation: 'fpay-spin 1s linear infinite' }}
             role="img"
             aria-label="Loading"
           >
             <path d="M21 12a9 9 0 1 1-6.219-8.56" />
+            <animateTransform
+              attributeName="transform"
+              type="rotate"
+              from="0 12 12"
+              to="360 12 12"
+              dur="1s"
+              repeatCount="indefinite"
+            />
           </svg>
           Loading…
         </div>

--- a/packages/react/src/node-info-panel.tsx
+++ b/packages/react/src/node-info-panel.tsx
@@ -342,7 +342,6 @@ export function NodeInfoPanel(props: NodeInfoPanelProps) {
   // Attempt to dynamically import qrcode.react if needed
   useEffect(() => {
     if (!showQrCode || renderQrCode) return;
-    // @ts-expect-error — qrcode.react is an optional peer dependency
     import('qrcode.react')
       .then((mod: Record<string, unknown>) => {
         const Comp = (mod.QRCodeSVG ?? mod.default) as

--- a/packages/react/src/node-info-panel.tsx
+++ b/packages/react/src/node-info-panel.tsx
@@ -1,0 +1,516 @@
+/**
+ * NodeInfoPanel — Displays Fiber browser node metadata, stats, and optional QR code.
+ *
+ * This is a stateless display component that polls the running node for stats
+ * (peer count, channel count, CKB balance) and renders them with copy-to-clipboard
+ * support and an optional QR code for the node's CKB address.
+ *
+ * @example
+ * ```tsx
+ * import { NodeInfoPanel } from "@fiber-pay/react";
+ *
+ * <NodeInfoPanel node={node} network="testnet" showQrCode />
+ * ```
+ */
+
+import { scriptToAddress } from '@fiber-pay/sdk';
+import type { FiberBrowserNode } from '@fiber-pay/sdk/browser';
+import { ConfigBuilder, formatShannonsAsCkb, getLockBalanceShannons } from '@fiber-pay/sdk/browser';
+import {
+  type ComponentType,
+  type CSSProperties,
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export interface NodeInfoPanelProps {
+  /** The running FiberBrowserNode instance. */
+  node: FiberBrowserNode | null;
+
+  /** Network (needed for address derivation and RPC URL defaults). */
+  network: 'testnet' | 'mainnet';
+
+  /** How often to refresh stats (ms). Default: 15000. */
+  pollInterval?: number;
+
+  /** Whether to show a QR code of the CKB address. Requires `qrcode.react` to be installed. */
+  showQrCode?: boolean;
+
+  /**
+   * Optional QR code render function — allows consumers to bring their own QR library.
+   * Called with the CKB address string. If not provided and `showQrCode` is true,
+   * the component will attempt to dynamically import `qrcode.react`.
+   */
+  renderQrCode?: (value: string) => ReactNode;
+
+  /** Additional CSS class name(s). */
+  className?: string;
+
+  /** Inline styles. */
+  style?: CSSProperties;
+}
+
+interface NodeStats {
+  pubkey: string;
+  peers: number;
+  channels: number;
+  ckbAddress: string | null;
+  balanceCkb: string | null;
+  externalFunding: boolean;
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+function truncateMiddle(str: string, left = 8, right = 8): string {
+  if (str.length <= left + right + 3) return str;
+  return `${str.slice(0, left)}…${str.slice(-right)}`;
+}
+
+function copyToClipboard(text: string) {
+  void navigator.clipboard.writeText(text);
+}
+
+async function fetchNodeStats(
+  node: FiberBrowserNode,
+  network: 'testnet' | 'mainnet',
+): Promise<NodeStats> {
+  const [nodeInfo, peers, channels] = await Promise.all([
+    node.nodeInfo(),
+    node.listPeers(),
+    node.listChannels(),
+  ]);
+
+  const lockScript = nodeInfo.default_funding_lock_script;
+  const ckbRpcUrl = ConfigBuilder.getDefaults(network).ckbRpcUrl;
+
+  if (!lockScript || lockScript.args === '0x') {
+    return {
+      pubkey: nodeInfo.pubkey,
+      peers: peers.peers.length,
+      channels: channels.channels.length,
+      ckbAddress: null,
+      balanceCkb: null,
+      externalFunding: true,
+    };
+  }
+
+  const ckbAddress = scriptToAddress(lockScript, network);
+  const balanceShannons = await getLockBalanceShannons(ckbRpcUrl, lockScript);
+  const balanceCkb = formatShannonsAsCkb(balanceShannons, 4);
+
+  return {
+    pubkey: nodeInfo.pubkey,
+    peers: peers.peers.length,
+    channels: channels.channels.length,
+    ckbAddress,
+    balanceCkb,
+    externalFunding: false,
+  };
+}
+
+// =============================================================================
+// CSS
+// =============================================================================
+
+const styles = {
+  root: {
+    fontFamily: 'system-ui, -apple-system, sans-serif',
+    fontSize: '0.875rem',
+    color: 'var(--fpay-text-primary, #111827)',
+  } satisfies CSSProperties,
+
+  idle: {
+    padding: '1rem',
+    textAlign: 'center',
+    color: 'var(--fpay-text-secondary, #6b7280)',
+    fontSize: '0.75rem',
+  } satisfies CSSProperties,
+
+  loading: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '0.5rem',
+    padding: '0.5rem 0',
+    fontSize: '0.75rem',
+    color: 'var(--fpay-text-secondary, #6b7280)',
+  } satisfies CSSProperties,
+
+  errorBox: {
+    marginBottom: '0.5rem',
+    padding: '0.375rem 0.5rem',
+    fontSize: '0.75rem',
+    borderRadius: '0.5rem',
+    border: '1px solid var(--fpay-error-border, rgba(239,68,68,0.3))',
+    backgroundColor: 'var(--fpay-error-bg, rgba(239,68,68,0.1))',
+    color: 'var(--fpay-error, #ef4444)',
+  } satisfies CSSProperties,
+
+  infoRow: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    gap: '0.75rem',
+    padding: '0.375rem 0',
+  } satisfies CSSProperties,
+
+  infoLabel: {
+    fontSize: '0.75rem',
+    color: 'var(--fpay-text-secondary, #6b7280)',
+  } satisfies CSSProperties,
+
+  infoValueWrapper: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '0.375rem',
+  } satisfies CSSProperties,
+
+  infoValue: {
+    fontFamily: 'ui-monospace, monospace',
+    fontSize: '0.75rem',
+    color: 'var(--fpay-text-primary, #111827)',
+  } satisfies CSSProperties,
+
+  copyButton: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: '0.25rem',
+    borderRadius: '0.25rem',
+    border: 'none',
+    background: 'none',
+    cursor: 'pointer',
+    color: 'var(--fpay-text-secondary, #6b7280)',
+    transition: 'color 0.15s',
+  } satisfies CSSProperties,
+
+  statsGrid: {
+    display: 'grid',
+    gridTemplateColumns: '1fr 1fr',
+    gap: '0.5rem',
+    marginTop: '0.5rem',
+  } satisfies CSSProperties,
+
+  statCard: {
+    padding: '0.375rem 0.5rem',
+    textAlign: 'center',
+    borderRadius: '0.5rem',
+    border: '1px solid var(--fpay-border, #e5e7eb)',
+    backgroundColor: 'var(--fpay-bg-secondary, #f9fafb)',
+  } satisfies CSSProperties,
+
+  statLabel: {
+    fontSize: '0.625rem',
+    color: 'var(--fpay-text-secondary, #6b7280)',
+  } satisfies CSSProperties,
+
+  statValue: {
+    fontSize: '0.875rem',
+    fontWeight: 600,
+    color: 'var(--fpay-text-primary, #111827)',
+  } satisfies CSSProperties,
+
+  qrContainer: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    gap: '0.25rem',
+    marginTop: '0.75rem',
+    padding: '0.5rem',
+    borderRadius: '0.5rem',
+    border: '1px solid var(--fpay-border, #e5e7eb)',
+    backgroundColor: 'var(--fpay-bg-secondary, #f9fafb)',
+  } satisfies CSSProperties,
+
+  qrCaption: {
+    fontSize: '0.625rem',
+    color: 'var(--fpay-text-secondary, #6b7280)',
+  } satisfies CSSProperties,
+
+  balanceRow: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    width: '100%',
+    marginTop: '0.5rem',
+    paddingTop: '0.5rem',
+    borderTop: '1px solid var(--fpay-border, #e5e7eb)',
+  } satisfies CSSProperties,
+
+  statusBadge: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: '0.375rem',
+    padding: '0.25rem 0.625rem',
+    fontSize: '0.75rem',
+    fontWeight: 500,
+    borderRadius: '9999px',
+    marginBottom: '0.5rem',
+  } satisfies CSSProperties,
+};
+
+const STATUS_COLORS: Record<string, { bg: string; fg: string; dot: string }> = {
+  idle: { bg: 'rgba(107,114,128,0.1)', fg: '#6b7280', dot: '#9ca3af' },
+  unlocking: { bg: 'rgba(245,158,11,0.1)', fg: '#d97706', dot: '#f59e0b' },
+  starting: { bg: 'rgba(245,158,11,0.1)', fg: '#d97706', dot: '#f59e0b' },
+  running: { bg: 'rgba(34,197,94,0.1)', fg: '#16a34a', dot: '#22c55e' },
+  stopping: { bg: 'rgba(245,158,11,0.1)', fg: '#d97706', dot: '#f59e0b' },
+  stopped: { bg: 'rgba(107,114,128,0.1)', fg: '#6b7280', dot: '#9ca3af' },
+  error: { bg: 'rgba(239,68,68,0.1)', fg: '#dc2626', dot: '#ef4444' },
+};
+
+// =============================================================================
+// Sub-components
+// =============================================================================
+
+function CopyIcon() {
+  return (
+    <svg
+      width="12"
+      height="12"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+      <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+    </svg>
+  );
+}
+
+function InfoRow({ label, value, copyable }: { label: string; value: string; copyable?: boolean }) {
+  return (
+    <div style={styles.infoRow}>
+      <span style={styles.infoLabel}>{label}</span>
+      <div style={styles.infoValueWrapper}>
+        <span style={styles.infoValue}>{truncateMiddle(value, 6, 6)}</span>
+        {copyable && (
+          <button
+            type="button"
+            onClick={() => copyToClipboard(value)}
+            style={styles.copyButton}
+            title="Copy to clipboard"
+          >
+            <CopyIcon />
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// =============================================================================
+// Component
+// =============================================================================
+
+export function NodeInfoPanel(props: NodeInfoPanelProps) {
+  const {
+    node,
+    network,
+    pollInterval = 15000,
+    showQrCode = false,
+    renderQrCode,
+    className,
+    style,
+  } = props;
+
+  const [stats, setStats] = useState<NodeStats | null>(null);
+  const [statsError, setStatsError] = useState<string | null>(null);
+  const [statsLoading, setStatsLoading] = useState(false);
+  const cancelledRef = useRef(false);
+
+  // QR code dynamic import state
+  const [QRComponent, setQRComponent] = useState<ComponentType<{
+    value: string;
+    size?: number;
+    bgColor?: string;
+    fgColor?: string;
+  }> | null>(null);
+
+  // Attempt to dynamically import qrcode.react if needed
+  useEffect(() => {
+    if (!showQrCode || renderQrCode) return;
+    // @ts-expect-error — qrcode.react is an optional peer dependency
+    import('qrcode.react')
+      .then((mod: Record<string, unknown>) => {
+        const Comp = (mod.QRCodeSVG ?? mod.default) as
+          | ComponentType<{
+              value: string;
+              size?: number;
+              bgColor?: string;
+              fgColor?: string;
+            }>
+          | undefined;
+        if (Comp) setQRComponent(() => Comp);
+      })
+      .catch(() => {
+        // qrcode.react not installed — silently skip
+      });
+  }, [showQrCode, renderQrCode]);
+
+  const loadStats = useCallback(async () => {
+    if (!node || node.state !== 'running') return;
+    setStatsLoading(true);
+    setStatsError(null);
+    try {
+      const data = await fetchNodeStats(node, network);
+      if (!cancelledRef.current) setStats(data);
+    } catch (e) {
+      if (!cancelledRef.current) {
+        setStatsError(e instanceof Error ? e.message : String(e));
+      }
+    } finally {
+      if (!cancelledRef.current) setStatsLoading(false);
+    }
+  }, [node, network]);
+
+  useEffect(() => {
+    cancelledRef.current = false;
+
+    if (!node || node.state !== 'running') {
+      setStats(null);
+      setStatsError(null);
+      return;
+    }
+
+    void loadStats();
+    const interval = setInterval(() => void loadStats(), pollInterval);
+    return () => {
+      cancelledRef.current = true;
+      clearInterval(interval);
+    };
+  }, [node, node?.state, pollInterval, loadStats]);
+
+  // --- Render ---------------------------------------------------------------
+
+  if (!node) {
+    return (
+      <div className={className} style={{ ...styles.root, ...style }} data-fpay-node-info="">
+        <div style={styles.idle}>No node connected</div>
+      </div>
+    );
+  }
+
+  const nodeState = node.state;
+  const statusColor = STATUS_COLORS[nodeState] ?? STATUS_COLORS.idle;
+
+  return (
+    <div className={className} style={{ ...styles.root, ...style }} data-fpay-node-info="">
+      {/* Status badge */}
+      <div
+        style={{
+          ...styles.statusBadge,
+          backgroundColor: statusColor.bg,
+          color: statusColor.fg,
+        }}
+      >
+        <span
+          style={{
+            display: 'inline-block',
+            width: '0.5rem',
+            height: '0.5rem',
+            borderRadius: '50%',
+            backgroundColor: statusColor.dot,
+          }}
+        />
+        {nodeState}
+      </div>
+
+      {/* Loading indicator */}
+      {statsLoading && !stats && (
+        <div style={styles.loading}>
+          <svg
+            width="12"
+            height="12"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            style={{ animation: 'fpay-spin 1s linear infinite' }}
+            role="img"
+            aria-label="Loading"
+          >
+            <path d="M21 12a9 9 0 1 1-6.219-8.56" />
+          </svg>
+          Loading…
+        </div>
+      )}
+
+      {/* Error */}
+      {statsError && <div style={styles.errorBox}>{statsError}</div>}
+
+      {/* Stats */}
+      {stats && (
+        <>
+          <InfoRow label="Pubkey" value={stats.pubkey} copyable />
+
+          {stats.externalFunding ? (
+            <div style={{ padding: '0.25rem 0', fontSize: '0.75rem', color: '#6b7280' }}>
+              External funding mode
+            </div>
+          ) : stats.ckbAddress ? (
+            <InfoRow label="CKB Address" value={stats.ckbAddress} copyable />
+          ) : null}
+
+          <div style={styles.statsGrid}>
+            <div style={styles.statCard}>
+              <div style={styles.statLabel}>Peers</div>
+              <div style={styles.statValue}>{stats.peers}</div>
+            </div>
+            <div style={styles.statCard}>
+              <div style={styles.statLabel}>Channels</div>
+              <div style={styles.statValue}>{stats.channels}</div>
+            </div>
+          </div>
+
+          {/* QR Code */}
+          {showQrCode && stats.ckbAddress && (
+            <div style={styles.qrContainer}>
+              {renderQrCode ? (
+                renderQrCode(stats.ckbAddress)
+              ) : QRComponent ? (
+                <QRComponent
+                  value={stats.ckbAddress}
+                  size={120}
+                  bgColor="transparent"
+                  fgColor="currentColor"
+                />
+              ) : (
+                <div style={{ fontSize: '0.625rem', color: '#9ca3af' }}>
+                  Install qrcode.react for QR code
+                </div>
+              )}
+              <span style={styles.qrCaption}>Scan to deposit CKB</span>
+              <div style={styles.balanceRow}>
+                <span style={{ fontSize: '0.75rem', color: '#6b7280' }}>Balance</span>
+                <span
+                  style={{
+                    fontFamily: 'ui-monospace, monospace',
+                    fontSize: '0.75rem',
+                    fontWeight: 500,
+                  }}
+                >
+                  {stats.balanceCkb ?? '—'} CKB
+                </span>
+              </div>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/packages/react/src/use-fiber-node.ts
+++ b/packages/react/src/use-fiber-node.ts
@@ -8,8 +8,9 @@ import {
   type PasskeySupportReason,
   type PasskeySupportStatus,
   PasswordCredentialProvider,
+  RawKeyCredentialProvider,
 } from '@fiber-pay/sdk/browser';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 export interface UseFiberNodeOptions {
   network: 'testnet' | 'mainnet';
@@ -23,6 +24,10 @@ export interface UseFiberNodeResult {
   node: FiberBrowserNode | null;
   nodeInfo: NodeInfoResult | null;
   error: string | null;
+  /** Whether the node is currently starting (unlocking or starting state) */
+  isStarting: boolean;
+  /** Whether the node is running and ready for RPC calls */
+  isRunning: boolean;
   isPasskeySupported: boolean;
   passkeySupportReason: PasskeySupportReason | null;
   passkeyUnavailableReason: string | null;
@@ -30,6 +35,7 @@ export interface UseFiberNodeResult {
   startWithPassword: (password: string) => Promise<void>;
   createPasskeyAndStart: (username?: string) => Promise<void>;
   startWithPasskey: () => Promise<void>;
+  startWithRawKey: (fiberKey: Uint8Array, ckbSecretKey?: Uint8Array) => Promise<void>;
   stop: () => Promise<void>;
 }
 
@@ -141,7 +147,9 @@ export function useFiberNode(options: UseFiberNodeOptions): UseFiberNodeResult {
   }, [walletId]);
 
   const initNode = useCallback(
-    (credential: PasswordCredentialProvider | PasskeyCredentialProvider) => {
+    (
+      credential: PasswordCredentialProvider | PasskeyCredentialProvider | RawKeyCredentialProvider,
+    ) => {
       if (nodeRef.current) {
         const existingState = nodeRef.current.state;
         if (existingState !== 'idle' && existingState !== 'stopped' && existingState !== 'error') {
@@ -291,6 +299,29 @@ export function useFiberNode(options: UseFiberNodeOptions): UseFiberNodeResult {
     }
   }, [cleanupFailedStart, initNode, walletId]);
 
+  const startWithRawKey = useCallback(
+    async (fiberKey: Uint8Array, ckbSecretKey?: Uint8Array) => {
+      setError(null);
+      let node: FiberBrowserNode | null = null;
+
+      try {
+        const credential = new RawKeyCredentialProvider(fiberKey, ckbSecretKey, walletId);
+        node = initNode(credential);
+        const info = await node.start();
+        if (isMountedRef.current) {
+          setNodeInfo(info);
+        }
+      } catch (startError) {
+        if (isMountedRef.current) {
+          setError(asErrorMessage(startError));
+        }
+
+        await cleanupFailedStart(node);
+      }
+    },
+    [cleanupFailedStart, initNode, walletId],
+  );
+
   const stop = useCallback(async () => {
     const node = nodeRef.current;
     if (!node) {
@@ -315,11 +346,16 @@ export function useFiberNode(options: UseFiberNodeOptions): UseFiberNodeResult {
     }
   }, [detachNodeListeners]);
 
+  const isStarting = useMemo(() => state === 'unlocking' || state === 'starting', [state]);
+  const isRunning = useMemo(() => state === 'running', [state]);
+
   return {
     state,
     node: nodeRef.current,
     nodeInfo,
     error,
+    isStarting,
+    isRunning,
     isPasskeySupported,
     passkeySupportReason,
     passkeyUnavailableReason,
@@ -327,6 +363,7 @@ export function useFiberNode(options: UseFiberNodeOptions): UseFiberNodeResult {
     startWithPassword,
     createPasskeyAndStart,
     startWithPasskey,
+    startWithRawKey,
     stop,
   };
 }

--- a/packages/react/src/use-fiber-node.ts
+++ b/packages/react/src/use-fiber-node.ts
@@ -17,6 +17,8 @@ export interface UseFiberNodeOptions {
   walletId?: string;
   nodeConfig?: FiberBrowserNodeConfig['nodeConfig'];
   wasmFactory?: FiberWasmFactory;
+  /** If false, suppresses initialization effects (like passkey detection). Default true. */
+  enabled?: boolean;
 }
 
 export interface UseFiberNodeResult {
@@ -115,6 +117,7 @@ export function useFiberNode(options: UseFiberNodeOptions): UseFiberNodeResult {
   );
 
   useEffect(() => {
+    if (options.enabled === false) return;
     let cancelled = false;
 
     PasskeyCredentialProvider.getSupportStatus()
@@ -144,7 +147,7 @@ export function useFiberNode(options: UseFiberNodeOptions): UseFiberNodeResult {
     return () => {
       cancelled = true;
     };
-  }, [walletId]);
+  }, [walletId, options.enabled]);
 
   const initNode = useCallback(
     (

--- a/packages/react/tsup.config.ts
+++ b/packages/react/tsup.config.ts
@@ -8,5 +8,5 @@ export default defineConfig({
   sourcemap: true,
   target: 'es2022',
   outDir: 'dist',
-  external: ['react', 'react/jsx-runtime', '@nervosnetwork/fiber-js'],
+  external: ['react', 'react/jsx-runtime', '@nervosnetwork/fiber-js', 'qrcode.react'],
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -241,6 +241,9 @@ importers:
       '@nervosnetwork/fiber-js':
         specifier: ~0.8.0
         version: 0.8.0
+      qrcode.react:
+        specifier: ^4.0.0
+        version: 4.2.0(react@19.2.4)
       react:
         specifier: ^18.0.0 || ^19.0.0
         version: 19.2.4
@@ -2268,6 +2271,11 @@ packages:
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  qrcode.react@4.2.0:
+    resolution: {integrity: sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   qrcode@1.5.4:
     resolution: {integrity: sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==}
@@ -4771,6 +4779,10 @@ snapshots:
       once: 1.4.0
 
   punycode@2.3.1: {}
+
+  qrcode.react@4.2.0(react@19.2.4):
+    dependencies:
+      react: 19.2.4
 
   qrcode@1.5.4:
     dependencies:


### PR DESCRIPTION
Closes #113

## Summary

Adds two new first-class React components and enhances the `useFiberNode` hook to reduce integration boilerplate from ~150+ lines to a single component import.

### New Components

#### `<ConnectButton>`
Unified connect/disconnect button supporting all three credential strategies:

```tsx
// Standalone mode — simplest API
<ConnectButton network="testnet" strategy="passkey" onConnect={(node) => setNode(node)} />

// External hook mode — share node with sibling components
const fiber = useFiberNode({ network: "testnet" });
<ConnectButton fiber={fiber} strategy="passkey" />
<Chat node={fiber.node} />
```

- Strategies: `passkey`, `password`, `rawKey`, `auto`
- State-driven rendering: idle → connecting → connected (dropdown) → error
- Click-outside dropdown dismiss
- CSS-variable theming (`--fpay-*`) with sensible defaults, overridable via `className`

#### `<NodeInfoPanel>`
Stateless display panel for node metadata:

```tsx
<NodeInfoPanel node={node} network="testnet" showQrCode />
```

- Polling-based stats refresh (pubkey, peers, channels, CKB balance)
- Optional QR code via `qrcode.react` (optional peer dep) or `renderQrCode` prop
- Copy-to-clipboard for pubkey and CKB address
- Color-coded status badge

### Hook Enhancements

- **`startWithRawKey(fiberKey, ckbKey?)`** — enables `RawKeyCredentialProvider` usage through the hook (previously only Password and Passkey were supported)
- **`isStarting`** / **`isRunning`** — computed convenience booleans, eliminating the `state === 'starting' || state === 'unlocking'` boilerplate every consumer was writing
- **Widened `initNode` parameter type** to accept all credential providers

### Other Changes

- New exports: `ConnectButton`, `NodeInfoPanel`, `RawKeyCredentialProvider`, `scriptToAddress`
- `qrcode.react` added as optional peer dependency
- All SVGs have proper accessibility attributes

### Validation

- ✅ TypeScript: clean
- ✅ Build: 40KB ESM bundle
- ✅ Tests: 84 pass across 8 test files
- ✅ Biome lint: clean