### PR TITLE
feat(cli): impl servel security rule for better safety

### DIFF
--- a/.changeset/require-agent-isolation.md
+++ b/.changeset/require-agent-isolation.md
@@ -1,0 +1,13 @@
+---
+"@fiber-pay/cli": minor
+---
+
+# Agent Serve Isolation
+
+feat(cli): require namespace isolation for `agent serve`
+
+- Remove `--no-isolation` from `agent serve`
+- Make Linux namespace isolation mandatory at startup
+- Fail fast with `AGENT_SERVE_ISOLATION_REQUIRED` when `unshare` probe fails
+- Remove directory-only fallback execution path
+- Update setup and security docs to reflect strict isolation requirements

--- a/.changeset/require-agent-isolation.md
+++ b/.changeset/require-agent-isolation.md
@@ -10,4 +10,5 @@ feat(cli): require namespace isolation for `agent serve`
 - Make Linux namespace isolation mandatory at startup
 - Fail fast with `AGENT_SERVE_ISOLATION_REQUIRED` when `unshare` probe fails
 - Remove directory-only fallback execution path
+- Breaking API contract: `agent serve` now issues signed session tokens; resuming a session requires both `sessionId` and `sessionToken`
 - Update setup and security docs to reflect strict isolation requirements

--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ Build a browser payment UI component quickly with SDK browser APIs:
 
 - [docs/wasm-passkey-payment-component-quickstart.md](docs/wasm-passkey-payment-component-quickstart.md)
 
+## Agent serve app integration
+
+For external frontend/app projects that call `agent serve` directly:
+
+- [docs/agent-serve-frontend-integration.md](docs/agent-serve-frontend-integration.md)
+
 ## Development
 
 Please read `docs/develop.md` for details.

--- a/docs/agent-serve-frontend-integration.md
+++ b/docs/agent-serve-frontend-integration.md
@@ -1,0 +1,173 @@
+# Agent Serve Frontend Integration Guide
+
+This guide is for external frontend or application projects that call `fiber-pay agent serve` directly.
+
+It focuses on:
+
+- session contract changes (`sessionId` + `sessionToken`)
+- migration steps from older clients
+- security requirements for bearer-style session tokens
+- practical request and error handling patterns
+
+For core CLI usage and L402 background, also read [l402-agent-guide.md](./l402-agent-guide.md).
+
+## Who should read this
+
+- Browser frontend apps
+- Mobile apps
+- Server-side app backends that proxy user prompts to `agent serve`
+
+## Breaking contract change
+
+Session ownership is now enforced with a server-signed token.
+
+Old behavior:
+
+- clients could reuse context by sending only `sessionId`
+
+New behavior:
+
+- new session request: send only `prompt`
+- resume session request: send `prompt`, `sessionId`, and `sessionToken`
+- sending only one of `sessionId` or `sessionToken` is rejected
+
+## Request and response contract
+
+### 1) Start a new session
+
+Request:
+
+```http
+POST /
+Content-Type: application/json
+
+{
+  "prompt": "Explain channel rebalance in simple terms"
+}
+```
+
+Success response shape:
+
+```json
+{
+  "response": "...",
+  "agent": "codex",
+  "durationMs": 1234,
+  "session": {
+    "id": "sess-...",
+    "token": "fpst....",
+    "created": true
+  }
+}
+```
+
+Client action:
+
+- persist `session.id` and `session.token` together
+
+### 2) Resume an existing session
+
+Request:
+
+```http
+POST /
+Content-Type: application/json
+
+{
+  "prompt": "Continue from previous answer and add examples",
+  "sessionId": "sess-...",
+  "sessionToken": "fpst...."
+}
+```
+
+Typical response:
+
+```json
+{
+  "response": "...",
+  "agent": "codex",
+  "durationMs": 1180,
+  "session": {
+    "id": "sess-...",
+    "token": "fpst....",
+    "created": false
+  }
+}
+```
+
+### 3) SSE mode
+
+When using SSE, `done` and `error` events include `session` as well.
+
+This lets streaming clients keep session state in sync.
+
+## Error codes you must handle
+
+Session contract failures:
+
+- `400 SESSION_MISSING_TOKEN`
+- `400 SESSION_INVALID_INPUT`
+- `400 SESSION_INVALID_ID`
+- `403 SESSION_INVALID_TOKEN`
+
+Operational failures (existing behavior):
+
+- `502 EXEC_FAILED` style agent execution failure payloads
+- standard `402` challenge when L402 payment is required
+
+## End-to-end integration flow (L402 + session)
+
+1. Send prompt request to `POST /`.
+2. If response is `402`, parse macaroon and invoice.
+3. Pay invoice through your Fiber node.
+4. Retry request with L402 headers.
+5. Read `session.id` and `session.token` from success response.
+6. On next turn, send both `sessionId` and `sessionToken`.
+
+## Frontend migration checklist
+
+1. Remove client-side session ID generation for new sessions.
+2. Add `sessionToken` field to your local chat/session model.
+3. Update resume calls to send both fields.
+4. Add explicit handling for `SESSION_*` error codes.
+5. Ensure SSE parser captures `session` from `done` and `error` events.
+6. Add regression tests for:
+   - new-session flow (prompt only)
+   - resume flow (id + token)
+   - missing token (400)
+   - tampered token (403)
+
+## Security notes for session tokens
+
+`sessionToken` is a bearer credential.
+
+If leaked, an attacker can replay session ownership during token validity.
+
+They still need to satisfy L402 payment checks, but session ownership can be hijacked for that window.
+
+Minimum controls:
+
+1. HTTPS only (no plaintext transport).
+2. Never log `sessionToken` (app logs, analytics, error telemetry).
+3. Prefer in-memory storage for active chat sessions.
+4. If persistence is required, use shortest practical lifetime and protect at rest.
+5. Delete local session state when the user ends a conversation.
+
+Recommended hardening:
+
+1. Keep token lifetime short (hours, not days).
+2. Rotate/refresh tokens on long sessions.
+3. Add anomaly monitoring for repeated `SESSION_INVALID_TOKEN` responses.
+4. Avoid exposing full request/response payloads in debugging tools.
+
+## Compatibility note
+
+Clients that only send `sessionId` on resume are no longer compatible.
+
+Update to the new contract before rolling out server versions with signed session enforcement.
+
+## Related docs
+
+- [l402-agent-guide.md](./l402-agent-guide.md)
+- [boxlite-agent-setup.md](./boxlite-agent-setup.md)
+- [agent-serve-sse-changelog.md](./agent-serve-sse-changelog.md)

--- a/docs/l402-agent-guide.md
+++ b/docs/l402-agent-guide.md
@@ -93,8 +93,15 @@ fiber-pay agent serve \
 
 This starts an HTTP server on the default port `:8402` (configurable via `--port`) with:
 
-- `POST /` — accepts `{"prompt": "..."}`, invokes `acpx <agent> exec` and returns the response
+- `POST /` — accepts `{"prompt": "..."}` for a new server-issued session, or
+  `{"prompt": "...", "sessionId": "...", "sessionToken": "..."}` to resume
 - L402 payment gate — every request requires payment before the agent runs
+
+Session contract:
+
+- Server always returns `session: { id, token, created }` in JSON responses.
+- Reusing a session requires both `sessionId` and `sessionToken`.
+- Requests that send only one of the two fields are rejected.
 
 Supported agents: any [acpx-compatible agent](https://github.com/openclaw/acpx) — `codex`, `claude`, `opencode`, `gemini`, `pi`, etc.
 

--- a/docs/l402-agent-guide.md
+++ b/docs/l402-agent-guide.md
@@ -5,6 +5,10 @@ This guide covers two features:
 1. **L402 SDK module** — build L402-gated APIs using `@fiber-pay/sdk/node`
 2. **CLI agent commands** — one-command paid AI agent services
 
+If you are integrating `agent serve` from an external frontend or app project,
+see [agent-serve-frontend-integration.md](./agent-serve-frontend-integration.md)
+for migration and security guidance.
+
 ## Prerequisites
 
 - A running Fiber node (`fiber-pay node start`)

--- a/packages/cli/src/commands/agent.ts
+++ b/packages/cli/src/commands/agent.ts
@@ -21,10 +21,6 @@ export function createAgentCommand(config: CliConfig): Command {
     .option('--cwd <path>', 'Working directory for agent execution')
     .option('--approve-all', 'Auto-approve all agent tool calls')
     .option('--timeout <seconds>', 'Max agent execution time per request', '3600')
-    .option(
-      '--no-isolation',
-      'Disable Linux namespace isolation (use only for debugging; isolation is on by default)',
-    )
     .option('--format <fmt>', 'Agent output format passed to acpx (text, json, quiet)', 'quiet')
     .option(
       '--workspace-ttl <hours>',

--- a/packages/cli/src/lib/agent-serve.test.ts
+++ b/packages/cli/src/lib/agent-serve.test.ts
@@ -72,6 +72,12 @@ const baseOptions: AgentServeOptions = {
   boxliteBoxId: 'test-box',
 };
 
+interface SessionEnvelope {
+  id: string;
+  token: string;
+  created: boolean;
+}
+
 function getTestServer() {
   return globalThis.__testServer;
 }
@@ -95,6 +101,25 @@ async function startTestServer(options: Partial<AgentServeOptions> = {}) {
   const url = `http://${addr.address}:${addr.port}`;
 
   return { server, url, serverPromise };
+}
+
+function readSession(body: unknown): SessionEnvelope {
+  if (
+    !body ||
+    typeof body !== 'object' ||
+    !('session' in body) ||
+    typeof (body as { session?: unknown }).session !== 'object' ||
+    (body as { session?: unknown }).session === null
+  ) {
+    throw new Error('expected response.session');
+  }
+
+  const session = (body as { session: SessionEnvelope }).session;
+  if (typeof session.id !== 'string' || typeof session.token !== 'string') {
+    throw new Error('expected session.id and session.token');
+  }
+
+  return session;
 }
 
 describe('runAgentServeCommand', () => {
@@ -165,6 +190,7 @@ describe('runAgentServeCommand', () => {
     });
 
     it('returns 200 with agent response on successful exec', async () => {
+      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '', exit_code: 0 });
       mockExec.mockResolvedValueOnce({ stdout: 'hello world', stderr: '', exit_code: 0 });
 
       const { server, url } = await startTestServer();
@@ -176,9 +202,11 @@ describe('runAgentServeCommand', () => {
       });
 
       expect(response.status).toBe(200);
-      const body = (await response.json()) as { response: string; agent: string };
+      const body = (await response.json()) as { response: string; agent: string; session: unknown };
       expect(body.response).toBe('hello world');
       expect(body.agent).toBe('codex');
+      const session = readSession(body);
+      expect(session.created).toBe(true);
 
       server?.close();
     });
@@ -247,7 +275,12 @@ describe('runAgentServeCommand', () => {
     });
 
     it('returns 502 with stderr on non-zero exit code', async () => {
+      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '', exit_code: 0 });
       mockExec.mockResolvedValueOnce({ stdout: '', stderr: 'agent crashed', exit_code: 1 });
+      mockExec.mockResolvedValueOnce({ stdout: 'closed', stderr: '', exit_code: 0 });
+      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '', exit_code: 0 });
+      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '', exit_code: 0 });
+      mockExec.mockResolvedValueOnce({ stdout: '', stderr: 'agent crashed again', exit_code: 1 });
 
       const { server, url } = await startTestServer();
 
@@ -260,21 +293,37 @@ describe('runAgentServeCommand', () => {
       expect(response.status).toBe(502);
       const body = (await response.json()) as { error: string; stderr: string };
       expect(body.error).toBe('Agent execution failed.');
-      expect(body.stderr).toBe('agent crashed');
+      expect(body.stderr).toContain('agent crashed');
 
       server?.close();
     });
 
-    it('passes sessionId to acpx via -s flag and ensures session first', async () => {
-      mockExec.mockResolvedValueOnce({ stdout: 'ses_123\tcreated', stderr: '', exit_code: 0 });
-      mockExec.mockResolvedValueOnce({ stdout: 'hello session', stderr: '', exit_code: 0 });
+    it('reuses a server-issued session when sessionId and sessionToken are provided', async () => {
+      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '', exit_code: 0 });
+      mockExec.mockResolvedValueOnce({ stdout: 'bootstrap', stderr: '', exit_code: 0 });
 
       const { server, url } = await startTestServer();
+
+      const firstResponse = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ prompt: 'bootstrap' }),
+      });
+      expect(firstResponse.status).toBe(200);
+      const firstBody = (await firstResponse.json()) as { session: unknown };
+      const session = readSession(firstBody);
+
+      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '', exit_code: 0 });
+      mockExec.mockResolvedValueOnce({ stdout: 'hello session', stderr: '', exit_code: 0 });
 
       const response = await fetch(url, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ prompt: 'say hello', sessionId: 'my-session-123' }),
+        body: JSON.stringify({
+          prompt: 'say hello',
+          sessionId: session.id,
+          sessionToken: session.token,
+        }),
       });
 
       expect(response.status).toBe(200);
@@ -285,43 +334,60 @@ describe('runAgentServeCommand', () => {
         (call) =>
           call[0] === 'sh' &&
           (call[1] as string[])[1]?.includes('sessions ensure') &&
-          (call[1] as string[])[1]?.includes('my-session-123'),
+          (call[1] as string[])[1]?.includes(session.id),
       );
       expect(ensureCall).toBeDefined();
       const ensureScript = ((ensureCall?.[1] as string[]) || [])[1] || '';
       expect(ensureScript).toContain('acpx');
       expect(ensureScript).toContain('sessions ensure');
-      expect(ensureScript).toContain('my-session-123');
+      expect(ensureScript).toContain(session.id);
 
       const agentExecCall = mockExec.mock.calls.find(
         (call) =>
           call[0] === 'unshare' &&
           typeof (call[1] as string[]).at(-1) === 'string' &&
-          ((call[1] as string[]).at(-1) as string).includes('my-session-123'),
+          ((call[1] as string[]).at(-1) as string).includes(session.id),
       );
       expect(agentExecCall).toBeDefined();
       const shScript = ((agentExecCall?.[1] as string[]) || []).at(-1) || '';
       expect(shScript).toContain('-s');
-      expect(shScript).toContain('my-session-123');
+      expect(shScript).toContain(session.id);
       expect(shScript).not.toContain("'exec'");
 
       server?.close();
     });
 
     it('retries session prompt after closing and re-ensuring on failure', async () => {
-      mockExec.mockResolvedValueOnce({ stdout: 'ses_123\tcreated', stderr: '', exit_code: 0 });
+      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '', exit_code: 0 });
+      mockExec.mockResolvedValueOnce({ stdout: 'bootstrap', stderr: '', exit_code: 0 });
+
+      const { server, url } = await startTestServer();
+
+      const firstResponse = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ prompt: 'bootstrap' }),
+      });
+
+      expect(firstResponse.status).toBe(200);
+      const firstBody = (await firstResponse.json()) as { session: unknown };
+      const session = readSession(firstBody);
+
+      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '', exit_code: 0 });
       mockExec.mockResolvedValueOnce({ stdout: '', stderr: 'agent needs reconnect', exit_code: 1 });
       mockExec.mockResolvedValueOnce({ stdout: 'closed', stderr: '', exit_code: 0 });
       mockExec.mockResolvedValueOnce({ stdout: '', stderr: '', exit_code: 0 });
-      mockExec.mockResolvedValueOnce({ stdout: 'ses_123\tcreated', stderr: '', exit_code: 0 });
+      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '', exit_code: 0 });
       mockExec.mockResolvedValueOnce({ stdout: 'hello retry', stderr: '', exit_code: 0 });
-
-      const { server, url } = await startTestServer();
 
       const response = await fetch(url, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ prompt: 'say hello', sessionId: 'my-session-123' }),
+        body: JSON.stringify({
+          prompt: 'say hello',
+          sessionId: session.id,
+          sessionToken: session.token,
+        }),
       });
 
       expect(response.status).toBe(200);
@@ -332,7 +398,7 @@ describe('runAgentServeCommand', () => {
         (call) =>
           call[0] === 'sh' &&
           (call[1] as string[])[1]?.includes('sessions close') &&
-          (call[1] as string[])[1]?.includes('my-session-123'),
+          (call[1] as string[])[1]?.includes(session.id),
       );
       expect(closeCall).toBeDefined();
 
@@ -340,7 +406,7 @@ describe('runAgentServeCommand', () => {
         (call) =>
           call[0] === 'sh' &&
           (call[1] as string[])[1]?.includes('sessions ensure') &&
-          (call[1] as string[])[1]?.includes('my-session-123'),
+          (call[1] as string[])[1]?.includes(session.id),
       );
       expect(ensureCalls.length).toBeGreaterThanOrEqual(2);
 
@@ -348,7 +414,7 @@ describe('runAgentServeCommand', () => {
         (call) =>
           call[0] === 'unshare' &&
           typeof (call[1] as string[]).at(-1) === 'string' &&
-          ((call[1] as string[]).at(-1) as string).includes('my-session-123'),
+          ((call[1] as string[]).at(-1) as string).includes(session.id),
       );
       expect(execCalls.length).toBeGreaterThanOrEqual(2);
 
@@ -356,16 +422,33 @@ describe('runAgentServeCommand', () => {
     });
 
     it('closes session when execPrompt throws a BoxliteError', async () => {
-      mockExec.mockResolvedValueOnce({ stdout: 'ses_123\tcreated', stderr: '', exit_code: 0 });
-      mockExec.mockRejectedValueOnce(new BoxliteError('EXEC_FAILED', 'BoxLite exec timed out'));
-      mockExec.mockResolvedValueOnce({ stdout: 'closed', stderr: '', exit_code: 0 });
+      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '', exit_code: 0 });
+      mockExec.mockResolvedValueOnce({ stdout: 'bootstrap', stderr: '', exit_code: 0 });
 
       const { server, url } = await startTestServer();
+
+      const firstResponse = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ prompt: 'bootstrap' }),
+      });
+
+      expect(firstResponse.status).toBe(200);
+      const firstBody = (await firstResponse.json()) as { session: unknown };
+      const session = readSession(firstBody);
+
+      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '', exit_code: 0 });
+      mockExec.mockRejectedValueOnce(new BoxliteError('EXEC_FAILED', 'BoxLite exec timed out'));
+      mockExec.mockResolvedValueOnce({ stdout: 'closed', stderr: '', exit_code: 0 });
 
       const response = await fetch(url, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ prompt: 'say hello', sessionId: 'my-session-123' }),
+        body: JSON.stringify({
+          prompt: 'say hello',
+          sessionId: session.id,
+          sessionToken: session.token,
+        }),
       });
 
       expect(response.status).toBe(502);
@@ -374,7 +457,7 @@ describe('runAgentServeCommand', () => {
         (call) =>
           call[0] === 'sh' &&
           (call[1] as string[])[1]?.includes('sessions close') &&
-          (call[1] as string[])[1]?.includes('my-session-123'),
+          (call[1] as string[])[1]?.includes(session.id),
       );
       expect(closeCall).toBeDefined();
 
@@ -382,15 +465,32 @@ describe('runAgentServeCommand', () => {
     });
 
     it('closes session when ensure throws a BoxliteError', async () => {
-      mockExec.mockRejectedValueOnce(new BoxliteError('EXEC_FAILED', 'BoxLite exec timed out'));
-      mockExec.mockResolvedValueOnce({ stdout: 'closed', stderr: '', exit_code: 0 });
+      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '', exit_code: 0 });
+      mockExec.mockResolvedValueOnce({ stdout: 'bootstrap', stderr: '', exit_code: 0 });
 
       const { server, url } = await startTestServer();
+
+      const firstResponse = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ prompt: 'bootstrap' }),
+      });
+
+      expect(firstResponse.status).toBe(200);
+      const firstBody = (await firstResponse.json()) as { session: unknown };
+      const session = readSession(firstBody);
+
+      mockExec.mockRejectedValueOnce(new BoxliteError('EXEC_FAILED', 'BoxLite exec timed out'));
+      mockExec.mockResolvedValueOnce({ stdout: 'closed', stderr: '', exit_code: 0 });
 
       const response = await fetch(url, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ prompt: 'say hello', sessionId: 'my-session-123' }),
+        body: JSON.stringify({
+          prompt: 'say hello',
+          sessionId: session.id,
+          sessionToken: session.token,
+        }),
       });
 
       expect(response.status).toBe(502);
@@ -399,7 +499,7 @@ describe('runAgentServeCommand', () => {
         (call) =>
           call[0] === 'sh' &&
           (call[1] as string[])[1]?.includes('sessions close') &&
-          (call[1] as string[])[1]?.includes('my-session-123'),
+          (call[1] as string[])[1]?.includes(session.id),
       );
       expect(closeCalls.length).toBeGreaterThanOrEqual(1);
 
@@ -407,6 +507,7 @@ describe('runAgentServeCommand', () => {
     });
 
     it('passes format option to acpx and returns parsed data for json format', async () => {
+      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '', exit_code: 0 });
       mockExec.mockResolvedValueOnce({
         stdout: '{"jsonrpc":"2.0","id":1}\n{"jsonrpc":"2.0","result":"done"}',
         stderr: '',
@@ -448,6 +549,7 @@ describe('runAgentServeCommand', () => {
     });
 
     it('allows request body to override CLI format option', async () => {
+      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '', exit_code: 0 });
       mockExec.mockResolvedValueOnce({ stdout: 'plain text', stderr: '', exit_code: 0 });
 
       const { server, url } = await startTestServer({ format: 'json' });
@@ -486,6 +588,7 @@ describe('runAgentServeCommand', () => {
       process.env.OPENAI_API_KEY = 'openai-key';
       process.env.PATH = '/usr/bin';
 
+      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '', exit_code: 0 });
       mockExec.mockResolvedValueOnce({ stdout: 'ok', stderr: '', exit_code: 0 });
 
       const { server, url } = await startTestServer();
@@ -525,6 +628,56 @@ describe('runAgentServeCommand', () => {
 
       server?.close();
     });
+
+    it('rejects sessionId without sessionToken', async () => {
+      const { server, url } = await startTestServer();
+
+      const response = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ prompt: 'hello', sessionId: 'sess-test' }),
+      });
+
+      expect(response.status).toBe(400);
+      const body = (await response.json()) as { code?: string };
+      expect(body.code).toBe('SESSION_MISSING_TOKEN');
+
+      server?.close();
+    });
+
+    it('rejects a tampered sessionToken', async () => {
+      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '', exit_code: 0 });
+      mockExec.mockResolvedValueOnce({ stdout: 'bootstrap', stderr: '', exit_code: 0 });
+
+      const { server, url } = await startTestServer();
+
+      const firstResponse = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ prompt: 'bootstrap' }),
+      });
+
+      expect(firstResponse.status).toBe(200);
+      const firstBody = (await firstResponse.json()) as { session: unknown };
+      const session = readSession(firstBody);
+      const tampered = `${session.token}tampered`;
+
+      const secondResponse = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          prompt: 'hello',
+          sessionId: session.id,
+          sessionToken: tampered,
+        }),
+      });
+
+      expect(secondResponse.status).toBe(403);
+      const secondBody = (await secondResponse.json()) as { code?: string };
+      expect(secondBody.code).toBe('SESSION_INVALID_TOKEN');
+
+      server?.close();
+    });
   });
 
   // ---------------------------------------------------------------------------
@@ -552,6 +705,7 @@ describe('runAgentServeCommand', () => {
       mockExec.mockResolvedValueOnce({ stdout: '', stderr: '', exit_code: 0 });
       mockExec.mockResolvedValueOnce({ stdout: 'isolation-probe-ok', stderr: '', exit_code: 0 });
       mockExec.mockResolvedValueOnce({ stdout: '1000000 50%', stderr: '', exit_code: 0 });
+      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '', exit_code: 0 });
       mockExec.mockResolvedValueOnce({ stdout: 'wrapped result', stderr: '', exit_code: 0 });
       // Default fallback for any subsequent fire-and-forget cleanup calls
       mockExec.mockResolvedValue({ stdout: '', stderr: '', exit_code: 0 });
@@ -569,8 +723,10 @@ describe('runAgentServeCommand', () => {
       expect(body.response).toBe('wrapped result');
 
       const agentExecCall = mockExec.mock.calls[4];
-      expect(agentExecCall[0]).toBe('unshare');
-      const unshareArgs = agentExecCall[1] as string[];
+      expect(agentExecCall[0]).toBe('sh');
+      const unshareCall = mockExec.mock.calls[5];
+      expect(unshareCall[0]).toBe('unshare');
+      const unshareArgs = unshareCall[1] as string[];
       expect(unshareArgs).toContain('--user');
       expect(unshareArgs).toContain('--pid');
       expect(unshareArgs).toContain('--mount');
@@ -602,16 +758,32 @@ describe('runAgentServeCommand', () => {
       mockExec.mockResolvedValueOnce({ stdout: 'isolation-probe-ok', stderr: '', exit_code: 0 });
       mockExec.mockResolvedValueOnce({ stdout: '1000000 50%', stderr: '', exit_code: 0 });
       mockExec.mockResolvedValueOnce({ stdout: '', stderr: '', exit_code: 0 });
-      mockExec.mockRejectedValueOnce(new BoxliteError('EXEC_FAILED', 'timed out'));
-      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '', exit_code: 0 });
+      mockExec.mockResolvedValueOnce({ stdout: 'bootstrap', stderr: '', exit_code: 0 });
       mockExec.mockResolvedValue({ stdout: '', stderr: '', exit_code: 0 });
 
       const { server, url, serverPromise } = await startIsolatedServer();
 
+      const firstResponse = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ prompt: 'bootstrap' }),
+      });
+      expect(firstResponse.status).toBe(200);
+      const firstBody = (await firstResponse.json()) as { session: unknown };
+      const session = readSession(firstBody);
+
+      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '', exit_code: 0 });
+      mockExec.mockRejectedValueOnce(new BoxliteError('EXEC_FAILED', 'timed out'));
+      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '', exit_code: 0 });
+
       const response = await fetch(url, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ prompt: 'work', sessionId: 'cleanup-test' }),
+        body: JSON.stringify({
+          prompt: 'work',
+          sessionId: session.id,
+          sessionToken: session.token,
+        }),
       });
 
       expect(response.status).toBe(502);
@@ -623,8 +795,8 @@ describe('runAgentServeCommand', () => {
       );
       expect(rmCall).toBeDefined();
       const rmScript = (rmCall?.[1] as string[])[1];
-      expect(rmScript).toContain('/workspace/sessions/cleanup-test');
-      expect(rmScript).toContain('/tmp/fiber-sessions/cleanup-test');
+      expect(rmScript).toContain(`/workspace/sessions/${session.id}`);
+      expect(rmScript).toContain(`/tmp/fiber-sessions/${session.id}`);
 
       server.close();
       serverPromise.catch(() => {});

--- a/packages/cli/src/lib/agent-serve.test.ts
+++ b/packages/cli/src/lib/agent-serve.test.ts
@@ -70,14 +70,17 @@ const baseOptions: AgentServeOptions = {
   rootKey: 'a'.repeat(64),
   boxliteUrl: 'http://localhost:8100',
   boxliteBoxId: 'test-box',
-  // Disable namespace isolation in the base test config so that preflight
-  // adds no extra exec calls and all existing call-index assertions remain
-  // stable.  Isolation-specific behaviour is tested in describe('isolation').
-  noIsolation: true,
 };
 
 function getTestServer() {
   return globalThis.__testServer;
+}
+
+function queueSuccessfulIsolationPreflight() {
+  mockExec.mockResolvedValueOnce({ stdout: '1.0.0', stderr: '', exit_code: 0 });
+  mockExec.mockResolvedValueOnce({ stdout: '', stderr: '', exit_code: 0 });
+  mockExec.mockResolvedValueOnce({ stdout: 'isolation-probe-ok', stderr: '', exit_code: 0 });
+  mockExec.mockResolvedValueOnce({ stdout: '1000000 50%', stderr: '', exit_code: 0 });
 }
 
 async function startTestServer(options: Partial<AgentServeOptions> = {}) {
@@ -101,6 +104,7 @@ describe('runAgentServeCommand', () => {
     mockCheckBoxExists.mockReset();
     mockExec.mockReset();
     mockExecStream.mockReset();
+    mockExec.mockResolvedValue({ stdout: '', stderr: '', exit_code: 0 });
     delete globalThis.__testServer;
     process.exit = vi.fn().mockImplementation((code: number) => {
       throw new Error(`process.exit(${code})`);
@@ -156,8 +160,11 @@ describe('runAgentServeCommand', () => {
   });
 
   describe('POST /', () => {
+    beforeEach(() => {
+      queueSuccessfulIsolationPreflight();
+    });
+
     it('returns 200 with agent response on successful exec', async () => {
-      mockExec.mockResolvedValueOnce({ stdout: '1.0.0', stderr: '', exit_code: 0 });
       mockExec.mockResolvedValueOnce({ stdout: 'hello world', stderr: '', exit_code: 0 });
 
       const { server, url } = await startTestServer();
@@ -177,7 +184,6 @@ describe('runAgentServeCommand', () => {
     });
 
     it('streams SSE chunk/done events when stream mode is requested', async () => {
-      mockExec.mockResolvedValueOnce({ stdout: '1.0.0', stderr: '', exit_code: 0 });
       mockExecStream.mockReturnValueOnce(
         (async function* () {
           yield { stdout: 'hello ', stderr: '' };
@@ -212,7 +218,6 @@ describe('runAgentServeCommand', () => {
     });
 
     it('streams SSE error event when execution fails in stream mode', async () => {
-      mockExec.mockResolvedValueOnce({ stdout: '1.0.0', stderr: '', exit_code: 0 });
       mockExecStream.mockReturnValueOnce({
         [Symbol.asyncIterator]: () => ({
           next: async () => {
@@ -242,7 +247,6 @@ describe('runAgentServeCommand', () => {
     });
 
     it('returns 502 with stderr on non-zero exit code', async () => {
-      mockExec.mockResolvedValueOnce({ stdout: '1.0.0', stderr: '', exit_code: 0 });
       mockExec.mockResolvedValueOnce({ stdout: '', stderr: 'agent crashed', exit_code: 1 });
 
       const { server, url } = await startTestServer();
@@ -262,7 +266,6 @@ describe('runAgentServeCommand', () => {
     });
 
     it('passes sessionId to acpx via -s flag and ensures session first', async () => {
-      mockExec.mockResolvedValueOnce({ stdout: '1.0.0', stderr: '', exit_code: 0 });
       mockExec.mockResolvedValueOnce({ stdout: 'ses_123\tcreated', stderr: '', exit_code: 0 });
       mockExec.mockResolvedValueOnce({ stdout: 'hello session', stderr: '', exit_code: 0 });
 
@@ -278,27 +281,38 @@ describe('runAgentServeCommand', () => {
       const body = (await response.json()) as { response: string; agent: string };
       expect(body.response).toBe('hello session');
 
-      const ensureCall = mockExec.mock.calls[1];
-      expect(ensureCall[0]).toBe('sh');
-      const ensureScript = (ensureCall[1] as string[])[1];
+      const ensureCall = mockExec.mock.calls.find(
+        (call) =>
+          call[0] === 'sh' &&
+          (call[1] as string[])[1]?.includes('sessions ensure') &&
+          (call[1] as string[])[1]?.includes('my-session-123'),
+      );
+      expect(ensureCall).toBeDefined();
+      const ensureScript = ((ensureCall?.[1] as string[]) || [])[1] || '';
       expect(ensureScript).toContain('acpx');
       expect(ensureScript).toContain('sessions ensure');
       expect(ensureScript).toContain('my-session-123');
 
-      const agentExecCall = mockExec.mock.calls[2];
-      const execArgs = agentExecCall[1] as string[];
-      expect(execArgs).toContain('-s');
-      expect(execArgs).toContain('my-session-123');
-      expect(execArgs).not.toContain('exec');
+      const agentExecCall = mockExec.mock.calls.find(
+        (call) =>
+          call[0] === 'unshare' &&
+          typeof (call[1] as string[]).at(-1) === 'string' &&
+          ((call[1] as string[]).at(-1) as string).includes('my-session-123'),
+      );
+      expect(agentExecCall).toBeDefined();
+      const shScript = ((agentExecCall?.[1] as string[]) || []).at(-1) || '';
+      expect(shScript).toContain('-s');
+      expect(shScript).toContain('my-session-123');
+      expect(shScript).not.toContain("'exec'");
 
       server?.close();
     });
 
     it('retries session prompt after closing and re-ensuring on failure', async () => {
-      mockExec.mockResolvedValueOnce({ stdout: '1.0.0', stderr: '', exit_code: 0 });
       mockExec.mockResolvedValueOnce({ stdout: 'ses_123\tcreated', stderr: '', exit_code: 0 });
       mockExec.mockResolvedValueOnce({ stdout: '', stderr: 'agent needs reconnect', exit_code: 1 });
       mockExec.mockResolvedValueOnce({ stdout: 'closed', stderr: '', exit_code: 0 });
+      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '', exit_code: 0 });
       mockExec.mockResolvedValueOnce({ stdout: 'ses_123\tcreated', stderr: '', exit_code: 0 });
       mockExec.mockResolvedValueOnce({ stdout: 'hello retry', stderr: '', exit_code: 0 });
 
@@ -314,24 +328,34 @@ describe('runAgentServeCommand', () => {
       const body = (await response.json()) as { response: string; agent: string };
       expect(body.response).toBe('hello retry');
 
-      const closeCall = mockExec.mock.calls[3];
-      expect(closeCall[0]).toBe('sh');
-      expect((closeCall[1] as string[])[1]).toContain('sessions close');
-      expect((closeCall[1] as string[])[1]).toContain('my-session-123');
+      const closeCall = mockExec.mock.calls.find(
+        (call) =>
+          call[0] === 'sh' &&
+          (call[1] as string[])[1]?.includes('sessions close') &&
+          (call[1] as string[])[1]?.includes('my-session-123'),
+      );
+      expect(closeCall).toBeDefined();
 
-      const retryEnsureCall = mockExec.mock.calls[4];
-      expect(retryEnsureCall[0]).toBe('sh');
-      expect((retryEnsureCall[1] as string[])[1]).toContain('sessions ensure');
-      expect((retryEnsureCall[1] as string[])[1]).toContain('my-session-123');
+      const ensureCalls = mockExec.mock.calls.filter(
+        (call) =>
+          call[0] === 'sh' &&
+          (call[1] as string[])[1]?.includes('sessions ensure') &&
+          (call[1] as string[])[1]?.includes('my-session-123'),
+      );
+      expect(ensureCalls.length).toBeGreaterThanOrEqual(2);
 
-      const retryExecCall = mockExec.mock.calls[5];
-      expect(retryExecCall[1] as string[]).toContain('-s');
+      const execCalls = mockExec.mock.calls.filter(
+        (call) =>
+          call[0] === 'unshare' &&
+          typeof (call[1] as string[]).at(-1) === 'string' &&
+          ((call[1] as string[]).at(-1) as string).includes('my-session-123'),
+      );
+      expect(execCalls.length).toBeGreaterThanOrEqual(2);
 
       server?.close();
     });
 
     it('closes session when execPrompt throws a BoxliteError', async () => {
-      mockExec.mockResolvedValueOnce({ stdout: '1.0.0', stderr: '', exit_code: 0 });
       mockExec.mockResolvedValueOnce({ stdout: 'ses_123\tcreated', stderr: '', exit_code: 0 });
       mockExec.mockRejectedValueOnce(new BoxliteError('EXEC_FAILED', 'BoxLite exec timed out'));
       mockExec.mockResolvedValueOnce({ stdout: 'closed', stderr: '', exit_code: 0 });
@@ -358,7 +382,6 @@ describe('runAgentServeCommand', () => {
     });
 
     it('closes session when ensure throws a BoxliteError', async () => {
-      mockExec.mockResolvedValueOnce({ stdout: '1.0.0', stderr: '', exit_code: 0 });
       mockExec.mockRejectedValueOnce(new BoxliteError('EXEC_FAILED', 'BoxLite exec timed out'));
       mockExec.mockResolvedValueOnce({ stdout: 'closed', stderr: '', exit_code: 0 });
 
@@ -384,7 +407,6 @@ describe('runAgentServeCommand', () => {
     });
 
     it('passes format option to acpx and returns parsed data for json format', async () => {
-      mockExec.mockResolvedValueOnce({ stdout: '1.0.0', stderr: '', exit_code: 0 });
       mockExec.mockResolvedValueOnce({
         stdout: '{"jsonrpc":"2.0","id":1}\n{"jsonrpc":"2.0","result":"done"}',
         stderr: '',
@@ -413,16 +435,19 @@ describe('runAgentServeCommand', () => {
         { jsonrpc: '2.0', result: 'done' },
       ]);
 
-      const agentExecCall = mockExec.mock.calls[1];
-      const execArgs = agentExecCall[1] as string[];
-      expect(execArgs).toContain('--format');
-      expect(execArgs).toContain('json');
+      const agentExecCall = mockExec.mock.calls.find(
+        (call) =>
+          call[0] === 'unshare' && ((call[1] as string[]).at(-1) as string).includes('test json'),
+      );
+      expect(agentExecCall).toBeDefined();
+      const shScript = ((agentExecCall?.[1] as string[]) || []).at(-1) || '';
+      expect(shScript).toContain('--format');
+      expect(shScript).toContain('json');
 
       server?.close();
     });
 
     it('allows request body to override CLI format option', async () => {
-      mockExec.mockResolvedValueOnce({ stdout: '1.0.0', stderr: '', exit_code: 0 });
       mockExec.mockResolvedValueOnce({ stdout: 'plain text', stderr: '', exit_code: 0 });
 
       const { server, url } = await startTestServer({ format: 'json' });
@@ -438,10 +463,16 @@ describe('runAgentServeCommand', () => {
       expect(body.response).toBe('plain text');
       expect(body.format).toBeUndefined();
 
-      const agentExecCall = mockExec.mock.calls[1];
-      const execArgs = agentExecCall[1] as string[];
-      expect(execArgs).toContain('--format');
-      expect(execArgs).toContain('quiet');
+      const agentExecCall = mockExec.mock.calls.find(
+        (call) =>
+          call[0] === 'unshare' &&
+          typeof (call[1] as string[]).at(-1) === 'string' &&
+          ((call[1] as string[]).at(-1) as string).includes('test override'),
+      );
+      expect(agentExecCall).toBeDefined();
+      const shScript = ((agentExecCall?.[1] as string[]) || []).at(-1) || '';
+      expect(shScript).toContain('--format');
+      expect(shScript).toContain('quiet');
 
       server?.close();
     });
@@ -455,7 +486,6 @@ describe('runAgentServeCommand', () => {
       process.env.OPENAI_API_KEY = 'openai-key';
       process.env.PATH = '/usr/bin';
 
-      mockExec.mockResolvedValueOnce({ stdout: '1.0.0', stderr: '', exit_code: 0 });
       mockExec.mockResolvedValueOnce({ stdout: 'ok', stderr: '', exit_code: 0 });
 
       const { server, url } = await startTestServer();
@@ -466,7 +496,17 @@ describe('runAgentServeCommand', () => {
         body: JSON.stringify({ prompt: 'test' }),
       });
 
-      const agentExecCall = mockExec.mock.calls[1];
+      const agentExecCall = mockExec.mock.calls.find((call) => {
+        if (call[0] !== 'unshare') {
+          return false;
+        }
+        const script = ((call[1] as string[]) || []).at(-1);
+        return typeof script === 'string' && script.includes('exec') && script.includes('test');
+      });
+      expect(agentExecCall).toBeDefined();
+      if (!agentExecCall) {
+        throw new Error('expected unshare call for agent execution');
+      }
       const execOptions = agentExecCall[2] as {
         env?: Record<string, string>;
         cwd?: string;
@@ -491,15 +531,13 @@ describe('runAgentServeCommand', () => {
   // Isolation-specific behaviour
   // ---------------------------------------------------------------------------
   describe('isolation', () => {
-    // Helper: start a server with isolation ENABLED (noIsolation: false).
-    // The caller must set up mockExec for the three preflight calls:
-    //   [0] acpx --version, [1] sh mkdir, [2] unshare probe
+    // The caller must set up mockExec for preflight calls in order:
+    //   [0] acpx --version, [1] sh mkdir, [2] unshare probe, [3] disk check
     // Returns { server, url, serverPromise } so the test can stop the server.
     async function startIsolatedServer(extraOptions: Partial<AgentServeOptions> = {}) {
       mockCheckBoxExists.mockResolvedValue(true);
       const serverPromise = runAgentServeCommand(baseConfig, {
         ...baseOptions,
-        noIsolation: false, // override base default
         ...extraOptions,
       });
       await new Promise((r) => setTimeout(r, 50));
@@ -548,59 +586,14 @@ describe('runAgentServeCommand', () => {
       serverPromise.catch(() => {});
     });
 
-    it('falls back to direct acpx exec when namespace probe fails', async () => {
+    it('exits with 1 when namespace probe fails', async () => {
+      mockCheckBoxExists.mockResolvedValue(true);
       mockExec.mockResolvedValueOnce({ stdout: '1.0.0', stderr: '', exit_code: 0 });
       mockExec.mockResolvedValueOnce({ stdout: '', stderr: '', exit_code: 0 });
       mockExec.mockRejectedValueOnce(new Error('operation not permitted'));
-      mockExec.mockResolvedValueOnce({ stdout: '1000000 50%', stderr: '', exit_code: 0 });
-      mockExec.mockResolvedValueOnce({ stdout: 'fallback result', stderr: '', exit_code: 0 });
-      // Default fallback for any subsequent fire-and-forget cleanup calls
-      mockExec.mockResolvedValue({ stdout: '', stderr: '', exit_code: 0 });
-
-      const { server, url, serverPromise } = await startIsolatedServer();
-
-      const response = await fetch(url, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ prompt: 'say hello' }),
-      });
-
-      expect(response.status).toBe(200);
-      const body = (await response.json()) as { response: string };
-      expect(body.response).toBe('fallback result');
-
-      const agentExecCall = mockExec.mock.calls[4];
-      expect(agentExecCall[0]).toBe('acpx');
-
-      server.close();
-      serverPromise.catch(() => {});
-    });
-
-    it('skips mkdir and probe entirely when noIsolation is set', async () => {
-      // Only the version check should fire during preflight
-      mockExec.mockResolvedValueOnce({ stdout: '1.0.0', stderr: '', exit_code: 0 });
-      mockExec.mockResolvedValueOnce({ stdout: 'direct result', stderr: '', exit_code: 0 });
-
-      // startTestServer uses baseOptions which has noIsolation: true
-      const { server, url } = await startTestServer();
-
-      const response = await fetch(url, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ prompt: 'say hello' }),
-      });
-
-      expect(response.status).toBe(200);
-
-      // Exactly 2 exec calls total: version check + agent exec
-      expect(mockExec).toHaveBeenCalledTimes(2);
-
-      // No unshare calls at all
-      const commands = mockExec.mock.calls.map((c) => c[0] as string);
-      expect(commands).not.toContain('unshare');
-      expect(commands[1]).toBe('acpx');
-
-      server?.close();
+      await expect(runAgentServeCommand(baseConfig, baseOptions)).rejects.toThrow(
+        'process.exit(1)',
+      );
     });
 
     it('session dir is cleaned up when a named session is closed', async () => {

--- a/packages/cli/src/lib/agent-serve.ts
+++ b/packages/cli/src/lib/agent-serve.ts
@@ -806,9 +806,9 @@ export async function runAgentServeCommand(
       ],
       { timeout: 10 },
     );
-  } catch {
-    const message =
-      'Linux namespace isolation probe failed. This deployment requires unshare-based isolation.';
+  } catch (error) {
+    const errorMsg = error instanceof Error ? error.message : String(error);
+    const message = `Linux namespace isolation probe failed: ${errorMsg}. This deployment requires unshare-based isolation.`;
     if (asJson) {
       printJsonError({
         code: 'AGENT_SERVE_ISOLATION_REQUIRED',

--- a/packages/cli/src/lib/agent-serve.ts
+++ b/packages/cli/src/lib/agent-serve.ts
@@ -17,9 +17,8 @@
  *   - PID namespace: agent cannot see other sessions' processes via `ps` or `/proc`
  *   - User namespace: virtual root inside the namespace (no real privilege escalation)
  *
- * Isolation is probed at startup. If the kernel does not support unprivileged user
- * namespaces the server falls back to directory-only isolation and logs a warning.
- * Use `--no-isolation` to skip the probe entirely (development/debug only).
+ * Isolation is mandatory and probed at startup. If the kernel does not support
+ * unprivileged namespaces, startup aborts immediately.
  *
  * Run `scripts/boxlite-setup.sh` inside the BoxLite Alpine container once to install
  * `util-linux` (full-featured `unshare`) and create the required base directories.
@@ -49,8 +48,6 @@ export interface AgentServeOptions {
   boxliteUrl?: string;
   boxliteBoxId?: string;
   json?: boolean;
-  /** Skip Linux namespace isolation even if the kernel supports it (useful for debugging). */
-  noIsolation?: boolean;
   /** How long (in hours) to keep a named session workspace before auto-cleanup. */
   workspaceTtlHours?: string;
   /** Minimum free space (in MB) required on /workspace before accepting a new session. */
@@ -265,15 +262,10 @@ async function runAcpx(
     format?: string;
     signal?: AbortSignal;
     onChunk?: (chunk: { type: 'stdout' | 'stderr'; text: string }) => void;
-    /** Whether the BoxLite box supports Linux namespace isolation. */
-    isolationAvailable?: boolean;
-    /** Override to skip isolation for this call (e.g. --no-isolation flag). */
-    noIsolation?: boolean;
   },
 ): Promise<{ stdout: string; stderr: string; exitCode: number }> {
   const client = new BoxliteClient(options.boxliteUrl, options.boxliteBoxId);
   const supportsGlobalFlags = !['opencode'].includes(agent);
-  const useIsolation = Boolean(options.isolationAvailable) && !options.noIsolation;
 
   // Compute stable session paths.
   // Named sessions: deterministic path so successive requests share the same workspace.
@@ -296,15 +288,13 @@ async function runAcpx(
       acpxArgs.push(agent, 'exec', prompt);
     }
 
-    // When isolation is available, wrap acpx inside `unshare` so that the
+    // Wrap acpx inside `unshare` so that the
     // agent process gets its own PID and mount namespaces.  Inside those
     // namespaces the sh init script bind-mounts the per-session directory
     // over /workspace and a per-session tmpdir over /tmp before exec-ing
     // acpx, giving each session a completely private filesystem view.
-    const execCommand = useIsolation ? 'unshare' : 'acpx';
-    const execArgs = useIsolation
-      ? buildIsolationWrapArgs('acpx', acpxArgs, sessionDir, sessionTmpDir)
-      : acpxArgs;
+    const execCommand = 'unshare';
+    const execArgs = buildIsolationWrapArgs('acpx', acpxArgs, sessionDir, sessionTmpDir);
 
     const execOptions = {
       env: buildSafeEnv(),
@@ -364,15 +354,11 @@ async function runAcpx(
     } catch {}
     // Clean up the isolated session workspace so that a re-opened session
     // starts with a fresh directory rather than stale state.
-    // Only run when isolation was actually used — without isolation there is
-    // no per-session directory to remove.
-    if (useIsolation) {
-      client
-        .exec('sh', ['-c', `rm -rf ${shellQuote(sessionDir)} ${shellQuote(sessionTmpDir)}`], {
-          timeout: 10,
-        })
-        .catch(() => {});
-    }
+    client
+      .exec('sh', ['-c', `rm -rf ${shellQuote(sessionDir)} ${shellQuote(sessionTmpDir)}`], {
+        timeout: 10,
+      })
+      .catch(() => {});
   }
 
   if (options.sessionId) {
@@ -436,13 +422,11 @@ async function runAcpx(
 
   // Anonymous one-shot request: clean up the workspace after exec completes.
   const result = await execPrompt();
-  if (useIsolation) {
-    client
-      .exec('sh', ['-c', `rm -rf ${shellQuote(sessionDir)} ${shellQuote(sessionTmpDir)}`], {
-        timeout: 10,
-      })
-      .catch(() => {});
-  }
+  client
+    .exec('sh', ['-c', `rm -rf ${shellQuote(sessionDir)} ${shellQuote(sessionTmpDir)}`], {
+      timeout: 10,
+    })
+    .catch(() => {});
   return {
     stdout: result.stdout,
     stderr: result.stderr,
@@ -558,76 +542,85 @@ export async function runAgentServeCommand(
     process.exit(1);
   }
 
-  // When isolation is requested, prepare the directory structure and probe
-  // whether the kernel supports unprivileged user namespaces.
-  let isolationAvailable = false;
+  // Isolation is mandatory: prepare directory structure and verify that
+  // unprivileged user namespaces work before serving traffic.
   const workspaceMinFreeMb = parseInt(options.workspaceMinFreeMb || '100', 10);
   const workspaceTtlHours = parseInt(options.workspaceTtlHours || '24', 10);
-  if (!options.noIsolation) {
-    // Ensure the base session directories exist (non-fatal; the isolation
-    // script also creates them lazily, but pre-creating avoids a race on
-    // the very first request).
-    try {
-      await client.exec('sh', ['-c', 'mkdir -p /workspace/sessions /tmp/fiber-sessions'], {
-        timeout: 5,
+  // Ensure the base session directories exist (non-fatal; the isolation
+  // script also creates them lazily, but pre-creating avoids a race on
+  // the very first request).
+  try {
+    await client.exec('sh', ['-c', 'mkdir -p /workspace/sessions /tmp/fiber-sessions'], {
+      timeout: 5,
+    });
+  } catch {
+    // Non-fatal: the namespace init script will retry inside unshare.
+  }
+
+  // Probe whether the kernel allows unprivileged user namespaces.
+  try {
+    await client.exec(
+      'unshare',
+      [
+        '--user',
+        '--pid',
+        '--mount',
+        '--fork',
+        '--map-root-user',
+        '--mount-proc',
+        'sh',
+        '-c',
+        'echo isolation-probe-ok',
+      ],
+      { timeout: 10 },
+    );
+  } catch {
+    const message =
+      'Linux namespace isolation probe failed. This deployment requires unshare-based isolation.';
+    if (asJson) {
+      printJsonError({
+        code: 'AGENT_SERVE_ISOLATION_REQUIRED',
+        message,
+        recoverable: true,
+        suggestion:
+          'Run scripts/boxlite-setup.sh in the Box and ensure kernel.unprivileged_userns_clone=1 on the host.',
       });
-    } catch {
-      // Non-fatal: the namespace init script will retry inside unshare.
-    }
-
-    // Probe whether the kernel allows unprivileged user namespaces.
-    try {
-      await client.exec(
-        'unshare',
-        [
-          '--user',
-          '--pid',
-          '--mount',
-          '--fork',
-          '--map-root-user',
-          '--mount-proc',
-          'sh',
-          '-c',
-          'echo isolation-probe-ok',
-        ],
-        { timeout: 10 },
+    } else {
+      console.error(`Error: ${message}`);
+      console.error(
+        '  Run scripts/boxlite-setup.sh in the Box and ensure kernel.unprivileged_userns_clone=1 on the host.',
       );
-      isolationAvailable = true;
-    } catch {
-      // Kernel does not allow unprivileged namespaces; fall back to
-      // directory-only isolation.  Run `scripts/boxlite-setup.sh` inside
-      // the box and check kernel.unprivileged_userns_clone on the host.
-      isolationAvailable = false;
     }
+    process.exit(1);
+  }
 
-    // Disk-space guard: probe /workspace availability at startup.
-    const disk = await checkDiskSpace(client);
-    if (disk) {
-      const availableMb = Math.floor(disk.availableBytes / (1024 * 1024));
-      if (disk.usedPercent >= 95) {
-        const message = `Workspace disk is critically full (${disk.usedPercent}% used, ${availableMb} MB free).`;
-        if (asJson) {
-          printJsonError({
-            code: 'AGENT_SERVE_DISK_FULL',
-            message,
-            recoverable: true,
-            suggestion: 'Free up disk space on the BoxLite host or increase container storage.',
-          });
-        } else {
-          console.error(`Error: ${message}`);
-        }
-        process.exit(1);
+  // Disk-space guard: probe /workspace availability at startup.
+  const disk = await checkDiskSpace(client);
+  if (disk) {
+    const availableMb = Math.floor(disk.availableBytes / (1024 * 1024));
+    if (disk.usedPercent >= 95) {
+      const message = `Workspace disk is critically full (${disk.usedPercent}% used, ${availableMb} MB free).`;
+      if (asJson) {
+        printJsonError({
+          code: 'AGENT_SERVE_DISK_FULL',
+          message,
+          recoverable: true,
+          suggestion: 'Free up disk space on the BoxLite host or increase container storage.',
+        });
+      } else {
+        console.error(`Error: ${message}`);
       }
-      if (disk.usedPercent >= 90) {
-        console.warn(
-          `Warning: Workspace disk is nearly full (${disk.usedPercent}% used, ${availableMb} MB free).`,
-        );
-      }
-      if (availableMb < workspaceMinFreeMb) {
-        console.warn(
-          `Warning: Workspace free space (${availableMb} MB) is below --workspace-min-free-mb (${workspaceMinFreeMb} MB). New sessions may be rejected.`,
-        );
-      }
+      process.exit(1);
+    }
+    if (disk.usedPercent >= 90) {
+      console.warn(
+        `Warning: Workspace disk is nearly full (${disk.usedPercent}% used, ${availableMb} MB free).`,
+      );
+    }
+    if (availableMb < workspaceMinFreeMb) {
+      console.warn(
+        `Warning: Workspace free space (${availableMb} MB) is below --workspace-min-free-mb (${workspaceMinFreeMb} MB). New sessions may be rejected.`,
+      );
     }
   }
 
@@ -790,8 +783,6 @@ export async function runAgentServeCommand(
           sessionId: normalizedSessionId,
           format: requestFormat,
           signal: abortController.signal,
-          isolationAvailable,
-          noIsolation: options.noIsolation,
           onChunk: (chunk) => {
             sendSse('chunk', chunk);
           },
@@ -842,8 +833,6 @@ export async function runAgentServeCommand(
         boxliteBoxId,
         sessionId: normalizedSessionId,
         format: requestFormat,
-        isolationAvailable,
-        noIsolation: options.noIsolation,
       });
 
       const durationMs = Date.now() - startTime;
@@ -999,11 +988,7 @@ export async function runAgentServeCommand(
       boxliteBoxId,
     });
   } else {
-    const isolationLabel = options.noIsolation
-      ? 'disabled (--no-isolation)'
-      : isolationAvailable
-        ? 'namespace (PID + mount + user)'
-        : 'directory-only (unshare unavailable)';
+    const isolationLabel = 'namespace (PID + mount + user)';
     console.log('Agent service started');
     console.log(`  Listen:     ${listenUrl}`);
     console.log(`  Agent:      ${options.agent}`);

--- a/packages/cli/src/lib/agent-serve.ts
+++ b/packages/cli/src/lib/agent-serve.ts
@@ -50,6 +50,8 @@ export interface AgentServeOptions {
   json?: boolean;
   /** How long (in hours) to keep a named session workspace before auto-cleanup. */
   workspaceTtlHours?: string;
+  /** Commander maps --workspace-ttl to workspaceTtl at runtime. */
+  workspaceTtl?: string;
   /** Minimum free space (in MB) required on /workspace before accepting a new session. */
   workspaceMinFreeMb?: string;
 }
@@ -290,6 +292,11 @@ function parseRootKey(rootKey: string): Buffer | undefined {
     return undefined;
   }
   return Buffer.from(normalized, 'hex');
+}
+
+function deriveSessionSigningKey(rootKey: Buffer): Buffer {
+  // Use a dedicated context so session-token signing is separated from L402 macaroon key usage.
+  return createHmac('sha256', rootKey).update('fiber-pay:agent-serve:session-token:v1').digest();
 }
 
 function resolveSessionCredentials(
@@ -675,6 +682,32 @@ export async function runAgentServeCommand(
   // the prompt-injection key-exfiltration vector entirely.
   const rootKey = options.rootKey || process.env.L402_ROOT_KEY;
 
+  const parsePositiveIntegerOption = (
+    value: string | undefined,
+    defaultValue: string,
+    optionName: string,
+    errorCode: string,
+  ): number => {
+    const rawValue = (value ?? defaultValue).trim();
+    if (!/^[1-9]\d*$/.test(rawValue)) {
+      const message = `Invalid value for ${optionName}: expected a positive integer, received "${value ?? defaultValue}".`;
+      if (asJson) {
+        printJsonError({
+          code: errorCode,
+          message,
+          recoverable: true,
+          suggestion: `Provide ${optionName} as a positive integer value.`,
+        });
+      } else {
+        console.error(`Error: ${message}`);
+        console.error(`  Provide ${optionName} as a positive integer value.`);
+      }
+      process.exit(1);
+    }
+
+    return Number(rawValue);
+  };
+
   if (Number.isNaN(port) || port < 0 || port > 65535) {
     if (asJson) {
       printJsonError({
@@ -735,6 +768,21 @@ export async function runAgentServeCommand(
     }
     process.exit(1);
   }
+  const sessionSigningSecret = deriveSessionSigningKey(sessionSecret);
+
+  const workspaceMinFreeMb = parsePositiveIntegerOption(
+    options.workspaceMinFreeMb,
+    '100',
+    '--workspace-min-free-mb',
+    'AGENT_SERVE_INVALID_WORKSPACE_MIN_FREE_MB',
+  );
+  const workspaceTtlOption = options.workspaceTtl ?? options.workspaceTtlHours;
+  const workspaceTtlHours = parsePositiveIntegerOption(
+    workspaceTtlOption,
+    '24',
+    '--workspace-ttl',
+    'AGENT_SERVE_INVALID_WORKSPACE_TTL',
+  );
 
   // Pre-flight: check BoxLite connectivity and acpx availability
   const client = new BoxliteClient(boxliteUrl, boxliteBoxId);
@@ -775,8 +823,6 @@ export async function runAgentServeCommand(
 
   // Isolation is mandatory: prepare directory structure and verify that
   // unprivileged user namespaces work before serving traffic.
-  const workspaceMinFreeMb = parseInt(options.workspaceMinFreeMb || '100', 10);
-  const workspaceTtlHours = parseInt(options.workspaceTtlHours || '24', 10);
   const sessionTokenTtlSeconds = Math.max(MIN_SESSION_TOKEN_TTL_SECONDS, workspaceTtlHours * 3600);
   // Ensure the base session directories exist (non-fatal; the isolation
   // script also creates them lazily, but pre-creating avoids a race on
@@ -949,7 +995,7 @@ export async function runAgentServeCommand(
 
     const sessionResolution = resolveSessionCredentials(
       req.body as Record<string, unknown> | undefined,
-      sessionSecret,
+      sessionSigningSecret,
       sessionTokenTtlSeconds,
     );
 

--- a/packages/cli/src/lib/agent-serve.ts
+++ b/packages/cli/src/lib/agent-serve.ts
@@ -24,7 +24,7 @@
  * `util-linux` (full-featured `unshare`) and create the required base directories.
  */
 
-import { randomUUID } from 'node:crypto';
+import { createHmac, randomUUID, timingSafeEqual } from 'node:crypto';
 import { createServer, type Server } from 'node:http';
 import type { Currency } from '@fiber-pay/sdk';
 import { createL402Middleware, FiberRpcClient } from '@fiber-pay/sdk/node';
@@ -58,6 +58,22 @@ interface AgentServeRequest extends express.Request {
   l402?: { valid?: boolean; paymentHash?: string; preimage?: string };
   _fiberPayRequestId?: number;
 }
+
+interface SessionCredentials {
+  sessionId: string;
+  sessionToken: string;
+  created: boolean;
+}
+
+interface SessionTokenPayload {
+  v: 1;
+  sid: string;
+  iat: number;
+  exp: number;
+}
+
+const SESSION_TOKEN_PREFIX = 'fpst';
+const MIN_SESSION_TOKEN_TTL_SECONDS = 300;
 
 function getClientIp(req: AgentServeRequest): string {
   const forwarded = req.headers['x-forwarded-for'];
@@ -149,6 +165,205 @@ function sanitizeSessionId(raw: string): string {
  */
 function shellQuote(s: string): string {
   return `'${s.replace(/'/g, "'\\''")}' `;
+}
+
+function encodeBase64Url(data: Buffer | string): string {
+  return Buffer.from(data)
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/g, '');
+}
+
+function decodeBase64Url(value: string): Buffer | undefined {
+  if (!/^[A-Za-z0-9\-_]+$/.test(value)) {
+    return undefined;
+  }
+
+  const padding = (4 - (value.length % 4)) % 4;
+  const base64 = `${value}${'='.repeat(padding)}`.replace(/-/g, '+').replace(/_/g, '/');
+
+  try {
+    return Buffer.from(base64, 'base64');
+  } catch {
+    return undefined;
+  }
+}
+
+function sessionTokenSignature(payloadPart: string, secret: Buffer): string {
+  return encodeBase64Url(createHmac('sha256', secret).update(payloadPart).digest());
+}
+
+function mintSessionToken(sessionId: string, secret: Buffer, ttlSeconds: number): string {
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  const payload: SessionTokenPayload = {
+    v: 1,
+    sid: sessionId,
+    iat: nowSeconds,
+    exp: nowSeconds + ttlSeconds,
+  };
+  const payloadPart = encodeBase64Url(JSON.stringify(payload));
+  const signaturePart = sessionTokenSignature(payloadPart, secret);
+  return `${SESSION_TOKEN_PREFIX}.${payloadPart}.${signaturePart}`;
+}
+
+function timingSafeStringEqual(left: string, right: string): boolean {
+  const leftBuffer = Buffer.from(left);
+  const rightBuffer = Buffer.from(right);
+
+  if (leftBuffer.length !== rightBuffer.length) {
+    return false;
+  }
+
+  return timingSafeEqual(leftBuffer, rightBuffer);
+}
+
+function isValidSessionId(sessionId: string): boolean {
+  if (sessionId.length === 0 || sessionId.length > 64) {
+    return false;
+  }
+
+  return sanitizeSessionId(sessionId) === sessionId;
+}
+
+function verifySessionToken(
+  sessionId: string,
+  token: string,
+  secret: Buffer,
+): { valid: true } | { valid: false; reason: string } {
+  const parts = token.split('.');
+  if (parts.length !== 3 || parts[0] !== SESSION_TOKEN_PREFIX) {
+    return { valid: false, reason: 'Invalid session token format.' };
+  }
+
+  const payloadPart = parts[1] || '';
+  const signaturePart = parts[2] || '';
+  if (payloadPart.length === 0 || signaturePart.length === 0) {
+    return { valid: false, reason: 'Invalid session token format.' };
+  }
+
+  const expectedSignature = sessionTokenSignature(payloadPart, secret);
+  if (!timingSafeStringEqual(signaturePart, expectedSignature)) {
+    return { valid: false, reason: 'Session token signature mismatch.' };
+  }
+
+  const payloadBuffer = decodeBase64Url(payloadPart);
+  if (!payloadBuffer) {
+    return { valid: false, reason: 'Invalid session token payload encoding.' };
+  }
+
+  let payload: SessionTokenPayload;
+  try {
+    payload = JSON.parse(payloadBuffer.toString('utf-8')) as SessionTokenPayload;
+  } catch {
+    return { valid: false, reason: 'Invalid session token payload.' };
+  }
+
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  if (payload.v !== 1) {
+    return { valid: false, reason: 'Unsupported session token version.' };
+  }
+
+  if (typeof payload.sid !== 'string' || !isValidSessionId(payload.sid)) {
+    return { valid: false, reason: 'Invalid session token session id.' };
+  }
+
+  if (!Number.isInteger(payload.exp) || payload.exp <= nowSeconds) {
+    return { valid: false, reason: 'Session token expired.' };
+  }
+
+  if (!Number.isInteger(payload.iat) || payload.iat <= 0 || payload.iat > payload.exp) {
+    return { valid: false, reason: 'Invalid session token timestamps.' };
+  }
+
+  if (payload.sid !== sessionId) {
+    return { valid: false, reason: 'Session token does not match session id.' };
+  }
+
+  return { valid: true };
+}
+
+function parseRootKey(rootKey: string): Buffer | undefined {
+  const trimmed = rootKey.trim();
+  const normalized = trimmed.startsWith('0x') ? trimmed.slice(2) : trimmed;
+  if (!/^[a-fA-F0-9]{64}$/.test(normalized)) {
+    return undefined;
+  }
+  return Buffer.from(normalized, 'hex');
+}
+
+function resolveSessionCredentials(
+  body: Record<string, unknown> | undefined,
+  secret: Buffer,
+  ttlSeconds: number,
+):
+  | { ok: true; credentials: SessionCredentials }
+  | { ok: false; status: number; code: string; message: string } {
+  const rawSessionId = body?.sessionId;
+  const rawSessionToken = body?.sessionToken;
+  const hasSessionId = rawSessionId !== undefined;
+  const hasSessionToken = rawSessionToken !== undefined;
+
+  if (!hasSessionId && !hasSessionToken) {
+    const sessionId = `sess-${randomUUID()}`;
+    return {
+      ok: true,
+      credentials: {
+        sessionId,
+        sessionToken: mintSessionToken(sessionId, secret, ttlSeconds),
+        created: true,
+      },
+    };
+  }
+
+  if (!hasSessionId || !hasSessionToken) {
+    return {
+      ok: false,
+      status: 400,
+      code: 'SESSION_MISSING_TOKEN',
+      message: 'Both "sessionId" and "sessionToken" are required when resuming a session.',
+    };
+  }
+
+  if (typeof rawSessionId !== 'string' || typeof rawSessionToken !== 'string') {
+    return {
+      ok: false,
+      status: 400,
+      code: 'SESSION_INVALID_INPUT',
+      message: '"sessionId" and "sessionToken" must be strings.',
+    };
+  }
+
+  const sessionId = rawSessionId.trim();
+  const sessionToken = rawSessionToken.trim();
+
+  if (!isValidSessionId(sessionId)) {
+    return {
+      ok: false,
+      status: 400,
+      code: 'SESSION_INVALID_ID',
+      message: 'Invalid "sessionId" format.',
+    };
+  }
+
+  const verifyResult = verifySessionToken(sessionId, sessionToken, secret);
+  if (!verifyResult.valid) {
+    return {
+      ok: false,
+      status: 403,
+      code: 'SESSION_INVALID_TOKEN',
+      message: verifyResult.reason,
+    };
+  }
+
+  return {
+    ok: true,
+    credentials: {
+      sessionId,
+      sessionToken,
+      created: false,
+    },
+  };
 }
 
 /**
@@ -505,6 +720,22 @@ export async function runAgentServeCommand(
     process.exit(1);
   }
 
+  const sessionSecret = parseRootKey(rootKey);
+  if (!sessionSecret) {
+    if (asJson) {
+      printJsonError({
+        code: 'AGENT_SERVE_INVALID_ROOT_KEY',
+        message: 'Invalid root key format.',
+        recoverable: true,
+        suggestion: 'Provide a 32-byte hex key with --root-key (example: openssl rand -hex 32).',
+      });
+    } else {
+      console.error('Error: Invalid root key format.');
+      console.error('  Provide a 32-byte hex key with --root-key (example: openssl rand -hex 32).');
+    }
+    process.exit(1);
+  }
+
   // Pre-flight: check BoxLite connectivity and acpx availability
   const client = new BoxliteClient(boxliteUrl, boxliteBoxId);
   try {
@@ -546,6 +777,7 @@ export async function runAgentServeCommand(
   // unprivileged user namespaces work before serving traffic.
   const workspaceMinFreeMb = parseInt(options.workspaceMinFreeMb || '100', 10);
   const workspaceTtlHours = parseInt(options.workspaceTtlHours || '24', 10);
+  const sessionTokenTtlSeconds = Math.max(MIN_SESSION_TOKEN_TTL_SECONDS, workspaceTtlHours * 3600);
   // Ensure the base session directories exist (non-fatal; the isolation
   // script also creates them lazily, but pre-creating avoids a race on
   // the very first request).
@@ -704,7 +936,6 @@ export async function runAgentServeCommand(
   app.post('/', async (req: AgentServeRequest, res) => {
     const requestId = getRequestId(req);
     const prompt = req.body?.prompt;
-    const sessionId = req.body?.sessionId;
     const requestFormat = typeof req.body?.format === 'string' ? req.body.format : options.format;
     if (!prompt || typeof prompt !== 'string') {
       if (!asJson) {
@@ -716,14 +947,39 @@ export async function runAgentServeCommand(
       return;
     }
 
+    const sessionResolution = resolveSessionCredentials(
+      req.body as Record<string, unknown> | undefined,
+      sessionSecret,
+      sessionTokenTtlSeconds,
+    );
+
+    if (!sessionResolution.ok) {
+      if (!asJson) {
+        console.log(
+          `[REQ ${requestId}] rejected session credentials code=${sessionResolution.code} status=${sessionResolution.status}`,
+        );
+      }
+      res.status(sessionResolution.status).json({
+        error: sessionResolution.message,
+        code: sessionResolution.code,
+      });
+      return;
+    }
+
+    const session = sessionResolution.credentials;
+    const responseSession = {
+      id: session.sessionId,
+      token: session.sessionToken,
+      created: session.created,
+    };
+
     const startTime = Date.now();
-    const normalizedSessionId = typeof sessionId === 'string' ? sessionId : undefined;
     const useSse = shouldUseSse(req);
 
     try {
       if (!asJson) {
         console.log(
-          `[REQ ${requestId}] payment accepted, invoking agent=${options.agent} promptChars=${prompt.length}${sessionId ? ` session=${sessionId}` : ''}${requestFormat && requestFormat !== 'quiet' ? ` format=${requestFormat}` : ''}${useSse ? ' stream=sse' : ''}`,
+          `[REQ ${requestId}] payment accepted, invoking agent=${options.agent} promptChars=${prompt.length} session=${session.sessionId}${requestFormat && requestFormat !== 'quiet' ? ` format=${requestFormat}` : ''}${useSse ? ' stream=sse' : ''}`,
         );
       }
 
@@ -780,7 +1036,7 @@ export async function runAgentServeCommand(
           timeoutSeconds,
           boxliteUrl,
           boxliteBoxId,
-          sessionId: normalizedSessionId,
+          sessionId: session.sessionId,
           format: requestFormat,
           signal: abortController.signal,
           onChunk: (chunk) => {
@@ -807,6 +1063,7 @@ export async function runAgentServeCommand(
             message: result.stderr.slice(0, 1000) || 'Agent execution failed.',
             agent: options.agent,
             durationMs,
+            session: responseSession,
           });
           closeStream();
           return;
@@ -819,6 +1076,7 @@ export async function runAgentServeCommand(
         sendSse('done', {
           durationMs,
           agent: options.agent,
+          session: responseSession,
           ...(requestFormat && requestFormat !== 'quiet' ? { format: requestFormat } : {}),
         });
         closeStream();
@@ -831,7 +1089,7 @@ export async function runAgentServeCommand(
         timeoutSeconds,
         boxliteUrl,
         boxliteBoxId,
-        sessionId: normalizedSessionId,
+        sessionId: session.sessionId,
         format: requestFormat,
       });
 
@@ -849,6 +1107,7 @@ export async function runAgentServeCommand(
           agent: options.agent,
           stderr: result.stderr.slice(0, 1000),
           durationMs,
+          session: responseSession,
         });
         return;
       }
@@ -863,6 +1122,7 @@ export async function runAgentServeCommand(
         response: result.stdout.trim(),
         agent: options.agent,
         durationMs,
+        session: responseSession,
         ...(requestFormat && requestFormat !== 'quiet' ? { format: requestFormat } : {}),
         ...(data !== undefined ? { data } : {}),
       });
@@ -872,14 +1132,14 @@ export async function runAgentServeCommand(
         console.log(`[REQ ${requestId}] agent execution error: ${message}`);
       }
 
-      if (typeof normalizedSessionId === 'string' && !normalizedSessionId.startsWith('__')) {
+      if (!session.sessionId.startsWith('__')) {
         try {
           const cleanupClient = new BoxliteClient(boxliteUrl, boxliteBoxId);
           await cleanupClient.exec(
             'sh',
             [
               '-c',
-              `cd /workspace && acpx ${shellQuote(options.agent)} sessions close ${shellQuote(normalizedSessionId)}`,
+              `cd /workspace && acpx ${shellQuote(options.agent)} sessions close ${shellQuote(session.sessionId)}`,
             ],
             {
               env: buildSafeEnv(),
@@ -907,6 +1167,7 @@ export async function runAgentServeCommand(
                 message: error.message.slice(0, 1000),
                 agent: options.agent,
                 durationMs: Date.now() - startTime,
+                session: responseSession,
               })}\n\n`,
             );
           } else {
@@ -917,6 +1178,7 @@ export async function runAgentServeCommand(
                 message: error instanceof Error ? error.message : String(error),
                 agent: options.agent,
                 durationMs: Date.now() - startTime,
+                session: responseSession,
               })}\n\n`,
             );
           }
@@ -932,6 +1194,7 @@ export async function runAgentServeCommand(
           agent: options.agent,
           stderr: error.message.slice(0, 1000),
           durationMs: Date.now() - startTime,
+          session: responseSession,
         });
         return;
       }
@@ -939,6 +1202,7 @@ export async function runAgentServeCommand(
       res.status(500).json({
         error: 'Internal server error.',
         message: error instanceof Error ? error.message : String(error),
+        session: responseSession,
       });
     }
   });

--- a/scripts/boxlite-setup.sh
+++ b/scripts/boxlite-setup.sh
@@ -97,7 +97,7 @@ elif [ "$ns_user" = "1" ]; then
   echo "    Check kernel seccomp/AppArmor restrictions."
 else
   echo "=== Setup complete — namespace isolation NOT AVAILABLE ==="
-  echo "    Falling back to directory-only isolation."
+  echo "    fiber-pay agent serve will fail startup until this is fixed."
   echo ""
   echo "    To enable unprivileged user namespaces on the host:"
   echo "      sysctl -w kernel.unprivileged_userns_clone=1"

--- a/skills/fiber-pay/references/l402-agent.md
+++ b/skills/fiber-pay/references/l402-agent.md
@@ -40,10 +40,11 @@ HTTP service that invokes a local AI agent via [acpx](https://github.com/opencla
 fiber-pay agent serve --agent opencode --price 0.1 --root-key <hex> --approve-all
 ```
 
-- Endpoint: `POST /` with `{"prompt": "...", "sessionId": "<optional>"}`
+- Endpoint: `POST /` with `{"prompt": "..."}` for a new session, or
+   `{"prompt": "...", "sessionId": "...", "sessionToken": "..."}` to resume.
 - Requires: `npm install -g acpx` and the target agent installed
 - Agents: any acpx-compatible — `codex`, `claude`, `opencode`, `gemini`, `pi`, etc.
-- Session mode: pass `sessionId` to maintain multi-turn context across requests
+- Session mode: server issues `sessionId` + `sessionToken`; clients must send both to resume.
 
 Key flags: `--port`, `--cwd`, `--timeout`, `--approve-all`, `--format`.
 
@@ -175,5 +176,6 @@ fiber-pay --profile user agent call http://127.0.0.1:8402 --prompt "say hello"
 | Agent pollutes shared `/tmp` | ❌ private `/tmp` per session |
 | Deliberate path traversal by known abs path | ⚠️ same UID; use UUID session IDs |
 
-Session IDs are sanitized and session dirs are named with the sanitized ID.
-For additional hardening, use random UUID values as session IDs from the client side.
+Session IDs are generated server-side and signed into a `sessionToken`.
+Resuming a session requires both fields (`sessionId` + `sessionToken`), and
+token validation rejects guessed or cross-user session reuse.

--- a/skills/fiber-pay/references/l402-agent.md
+++ b/skills/fiber-pay/references/l402-agent.md
@@ -45,7 +45,7 @@ fiber-pay agent serve --agent opencode --price 0.1 --root-key <hex> --approve-al
 - Agents: any acpx-compatible — `codex`, `claude`, `opencode`, `gemini`, `pi`, etc.
 - Session mode: pass `sessionId` to maintain multi-turn context across requests
 
-Key flags: `--port`, `--cwd`, `--timeout`, `--approve-all`, `--format`, `--no-isolation`.
+Key flags: `--port`, `--cwd`, `--timeout`, `--approve-all`, `--format`.
 
 ### Per-session Linux namespace isolation
 
@@ -53,7 +53,7 @@ Each paid session runs in an isolated Linux namespace so that opencode/codex/cla
 **cannot access other users' files or processes**:
 
 | Isolation layer | Mechanism | Effect |
-|----------------|-----------|--------|
+| --------------- | --------- | ------ |
 | File system | `mount --bind` per session | Agent sees `/workspace` = its own private dir only |
 | Process visibility | PID namespace | `ps`, `/proc` shows only the session's own processes |
 | Temp directory | `mount --bind /tmp` | `/tmp` is private to the session |
@@ -61,18 +61,16 @@ Each paid session runs in an isolated Linux namespace so that opencode/codex/cla
 
 Session workspace layout inside the BoxLite box:
 
-```
+```text
 /workspace/sessions/<sanitized-sessionId>/   ← bind-mounted as /workspace
 /tmp/fiber-sessions/<sanitized-sessionId>/   ← bind-mounted as /tmp
 ```
 
-Isolation is **automatic** — the server probes `unshare` capability at startup and
-prints the active mode:
+Isolation is **mandatory** — the server probes `unshare` capability at startup and
+only starts when namespace isolation is available:
 
-```
+```text
 Isolation:  namespace (PID + mount + user)   ← full isolation
-Isolation:  directory-only (unshare unavailable)  ← fallback
-Isolation:  disabled (--no-isolation)         ← debug flag used
 ```
 
 #### Smooth upgrade checklist (for live deployments)
@@ -81,6 +79,7 @@ When upgrading a running `agent serve` from a pre-namespace version to the
 namespace-isolated version, follow this order to avoid downtime or session loss:
 
 1. **Host sysctl pre-check**
+
    ```bash
    sysctl kernel.unprivileged_userns_clone   # must be 1
    # Persist across reboots:
@@ -89,6 +88,7 @@ namespace-isolated version, follow this order to avoid downtime or session loss:
 
 2. **BoxLite container prep (non-destructive)**
    Run the setup script **inside the running box** (do not recreate the container):
+
    ```bash
    # Via BoxLite exec API
    boxlite --url http://localhost:8100 exec <box-id> -- sh -c "
@@ -98,12 +98,15 @@ namespace-isolated version, follow this order to avoid downtime or session loss:
      chmod 1777 /tmp/fiber-sessions
    "
    ```
+
    Confirm the container outputs:
-   ```
+
+   ```text
    === Setup complete — full namespace isolation AVAILABLE ===
    ```
 
 3. **Build and restart the Node service**
+
    ```bash
    pnpm install && pnpm build
    # Gracefully stop the old process
@@ -111,17 +114,22 @@ namespace-isolated version, follow this order to avoid downtime or session loss:
    # Start the new binary with the same flags
    nohup node ./packages/cli/dist/cli.js agent serve ... > /tmp/agent-serve.log 2>&1 &
    ```
+
    Watch the startup log for:
-   ```
+
+   ```text
    Isolation:  namespace (PID + mount + user)
    ```
 
-4. **Rollback (if agent execution breaks)**
-   Append `--no-isolation` to the startup command and restart immediately:
+4. **If startup fails at isolation probe**
+   Treat this as a hard failure and fix the environment rather than relaxing security:
+
    ```bash
-   fiber-pay agent serve ... --no-isolation
+   # inside box
+   sh scripts/boxlite-setup.sh
+   # on host
+   sysctl kernel.unprivileged_userns_clone
    ```
-   This falls back to the shared-run mode without destroying existing sessions.
 
 #### Known BoxLite exec API caveat
 
@@ -135,15 +143,6 @@ sh -c "cd /workspace && acpx <agent> sessions ensure --name <sessionId>"
 
 If you write custom automation around the BoxLite API, apply the same
 `cd /workspace && ...` pattern instead of passing `cwd`.
-
-#### Disabling isolation (debug only)
-
-```bash
-fiber-pay agent serve --agent opencode --price 0.1 --root-key <hex> --no-isolation
-```
-
-`--no-isolation` skips both the `unshare` probe and the namespace wrapping. All
-sessions share the same `/workspace` — suitable only for local development.
 
 ## CLI: agent call
 
@@ -169,12 +168,12 @@ fiber-pay --profile user agent call http://127.0.0.1:8402 --prompt "say hello"
 
 ## Security model summary
 
-| Threat | `noIsolation` (off) | With namespace isolation |
-|--------|---------------------|--------------------------|
-| Agent reads another session's `/workspace` | ✅ possible | ❌ path not visible in mount namespace |
-| Agent sees other sessions' processes | ✅ via `ps` | ❌ PID namespace hides them |
-| Agent pollutes shared `/tmp` | ✅ possible | ❌ private `/tmp` per session |
-| Deliberate path traversal by known abs path | ✅ possible | ⚠️ same UID; use UUID session IDs |
+| Threat | With mandatory namespace isolation |
+| ------ | ---------------------------------- |
+| Agent reads another session's `/workspace` | ❌ path not visible in mount namespace |
+| Agent sees other sessions' processes | ❌ PID namespace hides them |
+| Agent pollutes shared `/tmp` | ❌ private `/tmp` per session |
+| Deliberate path traversal by known abs path | ⚠️ same UID; use UUID session IDs |
 
 Session IDs are sanitized and session dirs are named with the sanitized ID.
 For additional hardening, use random UUID values as session IDs from the client side.


### PR DESCRIPTION
## Summary

This PR hardens `fiber-pay agent serve` by requiring Linux namespace isolation and removing the non-isolated fallback path.

## Changes

- Remove `--no-isolation` from `fiber-pay agent serve`
- Require startup isolation probe (`unshare`) and fail fast when unavailable
- Always execute agent runs under namespace isolation
- Improve probe failure diagnostics by including underlying error details

## Breaking API Contract (agent serve)

`POST /` session semantics changed:

- New session: send only `{"prompt": "..."}`
- Resume session: must send both `sessionId` and `sessionToken`
- Server now returns `session: { id, token, created }` in JSON responses
- SSE `done` / `error` events now include `session`

Related error codes:

- `SESSION_MISSING_TOKEN`
- `SESSION_INVALID_INPUT`
- `SESSION_INVALID_ID`
- `SESSION_INVALID_TOKEN`

## Security and implementation notes

- Session-token signing uses a dedicated derived key context (not direct L402 key reuse)
- `workspace` numeric options are validated as positive integers to avoid invalid TTL/token states

## Docs

- Added frontend/app integration guide: `docs/agent-serve-frontend-integration.md`
- Linked from: `docs/l402-agent-guide.md`, `README.md`
