### PR TITLE
fix(cli): persist target fiber version in profile to prevent auto-downgrade during node start

### DIFF
--- a/.changeset/cli-node-start-binary-downgrade.md
+++ b/.changeset/cli-node-start-binary-downgrade.md
@@ -1,0 +1,5 @@
+---
+"@fiber-pay/cli": patch
+---
+
+fix: persist target fiber version in profile to prevent auto-downgrade during node start

--- a/packages/cli/src/lib/config.ts
+++ b/packages/cli/src/lib/config.ts
@@ -19,6 +19,7 @@ export interface ProfileConfig {
   binaryPath?: string;
   keyPassword?: string;
   runtimeProxyListen?: string;
+  fiberVersion?: string;
 }
 
 export interface EffectiveConfigSources {

--- a/packages/cli/src/lib/node-start.ts
+++ b/packages/cli/src/lib/node-start.ts
@@ -10,7 +10,7 @@ import {
 import { startRuntimeService } from '@fiber-pay/runtime';
 import { getBinaryManagerInstallDirOrThrow, resolveBinaryPath } from './binary-path.js';
 import { autoConnectBootnodes, extractBootnodeAddrs } from './bootnode.js';
-import { type CliConfig, ensureNodeConfigFile } from './config.js';
+import { type CliConfig, ensureNodeConfigFile, loadProfileConfig } from './config.js';
 import { printJsonError, printJsonEvent } from './format.js';
 import { appendToTodayLog, flushPendingLogs, resolveLogDirForDate } from './log-files.js';
 import { runMigrationGuard } from './node-migration.js';
@@ -168,7 +168,8 @@ export async function runNodeStartCommand(
   const binaryPath = resolvedBinary.binaryPath;
   if (resolvedBinary.source === 'profile-managed') {
     const installDir = getBinaryManagerInstallDirOrThrow(resolvedBinary);
-    await ensureFiberBinary({ installDir });
+    const profile = loadProfileConfig(config.dataDir);
+    await ensureFiberBinary({ installDir, version: profile?.fiberVersion });
   }
   const binaryVersion = getBinaryVersion(binaryPath);
   const configFilePath = ensureNodeConfigFile(config.dataDir, config.network);

--- a/packages/cli/src/lib/node-upgrade.ts
+++ b/packages/cli/src/lib/node-upgrade.ts
@@ -5,6 +5,7 @@
 import { BinaryManager, type DownloadProgress, MigrationManager } from '@fiber-pay/node';
 import { getBinaryManagerInstallDirOrThrow, resolveBinaryPath } from './binary-path.js';
 import type { CliConfig } from './config.js';
+import { loadProfileConfig, saveProfileConfig } from './config.js';
 import { printJsonError, printJsonSuccess } from './format.js';
 import { normalizeMigrationCheck, replaceRawMigrateHint } from './migration-utils.js';
 import { isProcessRunning, readPidFile } from './pid.js';
@@ -166,6 +167,13 @@ export async function runNodeUpgradeCommand(
 
   // Step 7: Final status
   const newInfo = await binaryManager.getBinaryInfo();
+
+  if (resolvedBinary.source === 'profile-managed') {
+    const profile = loadProfileConfig(config.dataDir) || {};
+    profile.fiberVersion = newInfo.version;
+    saveProfileConfig(config.dataDir, profile);
+  }
+
   if (json) {
     printJsonSuccess({
       action: 'upgraded',


### PR DESCRIPTION
### What does this PR do?

Resolves a bug where running `fiber-pay node start` with a specific profile would unintentionally force a downgrade to the default version (v0.8.0), overwriting the user's previously installed target version.

### Why is it needed?

Previously, when a user ran `fiber-pay node upgrade --version 0.8.1`, the CLI successfully downloaded and installed 0.8.1. However, since the target version wasn't recorded in the profile, subsequent calls to `node start` fell back to `DEFAULT_FIBER_VERSION` (v0.8.0) when validating the binary, forcing a silent redownload of the default version.

### How does it fix it?

1. Adds `fiberVersion` to the `ProfileConfig` definition.
2. During `node upgrade`, if upgrading a profile-managed binary, the target version is written to `profile.json`.
3. During `node start`, `profile.fiberVersion` is read and passed to `ensureFiberBinary`, bypassing the fallback to the default version when a target is already specified.