### PR TITLE
feat(cli): implement host-side HTTP proxy for agent serve

### DIFF
--- a/.changeset/secure-agent-proxy.md
+++ b/.changeset/secure-agent-proxy.md
@@ -1,0 +1,5 @@
+---
+'@fiber-pay/cli': minor
+---
+
+Implement host-side HTTP proxy to secure agent API keys and enforce outbound network deny-list in BoxLite environments

--- a/packages/cli/src/commands/agent.ts
+++ b/packages/cli/src/commands/agent.ts
@@ -42,6 +42,16 @@ export function createAgentCommand(config: CliConfig): Command {
       'BoxLite box ID',
       process.env.BOXLITE_BOX_ID || 'fiber-pay-agent',
     )
+    .option(
+      '--proxy-port <port>',
+      'Host-side proxy port for API key shim and network filtering',
+      '8111',
+    )
+    .option(
+      '--proxy-host-addr <addr>',
+      'Address the container uses to reach the host (auto-detected if omitted)',
+    )
+    .option('--no-proxy', 'Disable host-side proxy (passes real API keys to container — INSECURE)')
     .option('--json')
     .addHelpText(
       'after',

--- a/packages/cli/src/lib/agent-proxy.test.ts
+++ b/packages/cli/src/lib/agent-proxy.test.ts
@@ -1,10 +1,36 @@
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   AgentProxy,
   isDeniedAddress,
-  resolveAndCheckDenied,
+  resolveAllAndCheck,
   SHIM_PLACEHOLDER,
 } from './agent-proxy.js';
+
+// Mock dns/promises to avoid real DNS lookups in tests (CI-safe).
+vi.mock('node:dns/promises', () => ({
+  lookup: vi.fn(async (hostname: string, opts?: { all?: boolean }) => {
+    const records: Record<string, Array<{ address: string; family: number }>> = {
+      localhost: [{ address: '127.0.0.1', family: 4 }],
+      'example.com': [{ address: '93.184.216.34', family: 4 }],
+      'dual.example.com': [
+        { address: '93.184.216.34', family: 4 },
+        { address: '10.0.0.1', family: 4 },
+      ],
+    };
+
+    const entries = records[hostname];
+    if (!entries) {
+      const err = new Error(`getaddrinfo ENOTFOUND ${hostname}`);
+      (err as NodeJS.ErrnoException).code = 'ENOTFOUND';
+      throw err;
+    }
+
+    if (opts?.all) {
+      return entries;
+    }
+    return entries[0];
+  }),
+}));
 
 // ---------------------------------------------------------------------------
 // isDeniedAddress — synchronous CIDR check
@@ -87,6 +113,28 @@ describe('isDeniedAddress', () => {
     });
   });
 
+  describe('IPv4-mapped IPv6 addresses', () => {
+    it('denies ::ffff:127.0.0.1 (mapped loopback)', () => {
+      expect(isDeniedAddress('::ffff:127.0.0.1')).toBe(true);
+    });
+
+    it('denies ::ffff:10.0.0.1 (mapped RFC-1918)', () => {
+      expect(isDeniedAddress('::ffff:10.0.0.1')).toBe(true);
+    });
+
+    it('denies ::ffff:192.168.1.1 (mapped RFC-1918)', () => {
+      expect(isDeniedAddress('::ffff:192.168.1.1')).toBe(true);
+    });
+
+    it('denies ::ffff:172.16.0.1 (mapped RFC-1918)', () => {
+      expect(isDeniedAddress('::ffff:172.16.0.1')).toBe(true);
+    });
+
+    it('allows ::ffff:8.8.8.8 (mapped public)', () => {
+      expect(isDeniedAddress('::ffff:8.8.8.8')).toBe(false);
+    });
+  });
+
   describe('edge cases', () => {
     it('returns false for invalid IP', () => {
       expect(isDeniedAddress('not-an-ip')).toBe(false);
@@ -99,25 +147,37 @@ describe('isDeniedAddress', () => {
 });
 
 // ---------------------------------------------------------------------------
-// resolveAndCheckDenied — async DNS resolve + check
+// resolveAllAndCheck — async DNS resolve + check (mocked)
 // ---------------------------------------------------------------------------
 
-describe('resolveAndCheckDenied', () => {
-  it('denies raw loopback IP without DNS lookup', async () => {
-    expect(await resolveAndCheckDenied('127.0.0.1')).toBe(true);
+describe('resolveAllAndCheck', () => {
+  it('returns null for raw loopback IP', async () => {
+    expect(await resolveAllAndCheck('127.0.0.1')).toBe(null);
   });
 
-  it('denies raw private IP without DNS lookup', async () => {
-    expect(await resolveAndCheckDenied('10.0.0.5')).toBe(true);
+  it('returns null for raw private IP', async () => {
+    expect(await resolveAllAndCheck('10.0.0.5')).toBe(null);
   });
 
-  it('denies localhost (resolves to 127.0.0.1)', async () => {
-    expect(await resolveAndCheckDenied('localhost')).toBe(true);
+  it('returns null for localhost (resolves to 127.0.0.1)', async () => {
+    expect(await resolveAllAndCheck('localhost')).toBe(null);
   });
 
-  it('allows a public hostname', async () => {
-    // dns.google resolves to 8.8.8.8 / 8.8.4.4
-    expect(await resolveAndCheckDenied('dns.google')).toBe(false);
+  it('returns the resolved IP for a public hostname', async () => {
+    expect(await resolveAllAndCheck('example.com')).toBe('93.184.216.34');
+  });
+
+  it('returns null if any resolved address is denied', async () => {
+    // dual.example.com resolves to both public and private IPs.
+    expect(await resolveAllAndCheck('dual.example.com')).toBe(null);
+  });
+
+  it('returns null for unresolvable hostnames (fail-closed)', async () => {
+    expect(await resolveAllAndCheck('nonexistent.invalid')).toBe(null);
+  });
+
+  it('returns raw allowed IP as-is', async () => {
+    expect(await resolveAllAndCheck('8.8.8.8')).toBe('8.8.8.8');
   });
 });
 

--- a/packages/cli/src/lib/agent-proxy.test.ts
+++ b/packages/cli/src/lib/agent-proxy.test.ts
@@ -1,0 +1,307 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  AgentProxy,
+  isDeniedAddress,
+  resolveAndCheckDenied,
+  SHIM_PLACEHOLDER,
+} from './agent-proxy.js';
+
+// ---------------------------------------------------------------------------
+// isDeniedAddress — synchronous CIDR check
+// ---------------------------------------------------------------------------
+
+describe('isDeniedAddress', () => {
+  describe('IPv4 denied addresses', () => {
+    it('denies loopback 127.0.0.1', () => {
+      expect(isDeniedAddress('127.0.0.1')).toBe(true);
+    });
+
+    it('denies loopback 127.255.255.255', () => {
+      expect(isDeniedAddress('127.255.255.255')).toBe(true);
+    });
+
+    it('denies RFC-1918 10.x.x.x', () => {
+      expect(isDeniedAddress('10.0.0.1')).toBe(true);
+      expect(isDeniedAddress('10.255.255.255')).toBe(true);
+    });
+
+    it('denies RFC-1918 172.16.x.x through 172.31.x.x', () => {
+      expect(isDeniedAddress('172.16.0.1')).toBe(true);
+      expect(isDeniedAddress('172.31.255.255')).toBe(true);
+    });
+
+    it('allows 172.32.0.1 (outside RFC-1918 /12)', () => {
+      expect(isDeniedAddress('172.32.0.1')).toBe(false);
+    });
+
+    it('denies RFC-1918 192.168.x.x', () => {
+      expect(isDeniedAddress('192.168.0.1')).toBe(true);
+      expect(isDeniedAddress('192.168.255.255')).toBe(true);
+    });
+
+    it('denies link-local 169.254.x.x', () => {
+      expect(isDeniedAddress('169.254.1.1')).toBe(true);
+    });
+
+    it('denies 0.0.0.0/8', () => {
+      expect(isDeniedAddress('0.0.0.0')).toBe(true);
+      expect(isDeniedAddress('0.255.255.255')).toBe(true);
+    });
+  });
+
+  describe('IPv4 allowed addresses', () => {
+    it('allows public IP 8.8.8.8', () => {
+      expect(isDeniedAddress('8.8.8.8')).toBe(false);
+    });
+
+    it('allows public IP 1.1.1.1', () => {
+      expect(isDeniedAddress('1.1.1.1')).toBe(false);
+    });
+
+    it('allows public IP 203.0.113.1', () => {
+      expect(isDeniedAddress('203.0.113.1')).toBe(false);
+    });
+  });
+
+  describe('IPv6 denied addresses', () => {
+    it('denies loopback ::1', () => {
+      expect(isDeniedAddress('::1')).toBe(true);
+    });
+
+    it('denies unique local fc00::', () => {
+      expect(isDeniedAddress('fc00::1')).toBe(true);
+    });
+
+    it('denies unique local fd00::', () => {
+      expect(isDeniedAddress('fd12::1')).toBe(true);
+    });
+
+    it('denies link-local fe80::', () => {
+      expect(isDeniedAddress('fe80::1')).toBe(true);
+    });
+  });
+
+  describe('IPv6 allowed addresses', () => {
+    it('allows public IPv6 2001:db8::1', () => {
+      expect(isDeniedAddress('2001:db8::1')).toBe(false);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('returns false for invalid IP', () => {
+      expect(isDeniedAddress('not-an-ip')).toBe(false);
+    });
+
+    it('returns false for empty string', () => {
+      expect(isDeniedAddress('')).toBe(false);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveAndCheckDenied — async DNS resolve + check
+// ---------------------------------------------------------------------------
+
+describe('resolveAndCheckDenied', () => {
+  it('denies raw loopback IP without DNS lookup', async () => {
+    expect(await resolveAndCheckDenied('127.0.0.1')).toBe(true);
+  });
+
+  it('denies raw private IP without DNS lookup', async () => {
+    expect(await resolveAndCheckDenied('10.0.0.5')).toBe(true);
+  });
+
+  it('denies localhost (resolves to 127.0.0.1)', async () => {
+    expect(await resolveAndCheckDenied('localhost')).toBe(true);
+  });
+
+  it('allows a public hostname', async () => {
+    // dns.google resolves to 8.8.8.8 / 8.8.4.4
+    expect(await resolveAndCheckDenied('dns.google')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AgentProxy — integration tests
+// ---------------------------------------------------------------------------
+
+describe('AgentProxy', () => {
+  let proxy: AgentProxy;
+
+  afterEach(async () => {
+    if (proxy) await proxy.stop();
+  });
+
+  it('starts and stops without error', async () => {
+    proxy = new AgentProxy({
+      port: 0,
+      host: '127.0.0.1',
+      hostAddr: '127.0.0.1',
+      apiKeys: {},
+    });
+    await proxy.start();
+    await proxy.stop();
+  });
+
+  it('responds to /health', async () => {
+    proxy = new AgentProxy({
+      port: 0,
+      host: '127.0.0.1',
+      hostAddr: '127.0.0.1',
+      apiKeys: {},
+    });
+    await proxy.start();
+
+    const response = await fetch(`${proxy.proxyUrl}/health`);
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { status: string };
+    expect(body.status).toBe('ok');
+  });
+
+  it('returns 404 for unknown routes', async () => {
+    proxy = new AgentProxy({
+      port: 0,
+      host: '127.0.0.1',
+      hostAddr: '127.0.0.1',
+      apiKeys: {},
+    });
+    await proxy.start();
+
+    const response = await fetch(`${proxy.proxyUrl}/unknown`);
+    expect(response.status).toBe(404);
+  });
+
+  describe('buildContainerEnv', () => {
+    it('includes fake API keys and proxy URLs', () => {
+      proxy = new AgentProxy({
+        port: 8111,
+        hostAddr: '192.168.1.100',
+        apiKeys: {
+          anthropic: 'real-anthropic-key',
+          openai: 'real-openai-key',
+        },
+      });
+
+      const env = proxy.buildContainerEnv();
+
+      expect(env.ANTHROPIC_API_KEY).toBe(SHIM_PLACEHOLDER);
+      expect(env.OPENAI_API_KEY).toBe(SHIM_PLACEHOLDER);
+      expect(env.ANTHROPIC_BASE_URL).toBe('http://192.168.1.100:8111/anthropic');
+      expect(env.OPENAI_BASE_URL).toBe('http://192.168.1.100:8111/openai');
+      expect(env.HTTP_PROXY).toBe('http://192.168.1.100:8111');
+      expect(env.HTTPS_PROXY).toBe('http://192.168.1.100:8111');
+      expect(env.HOME).toBe('/home/boxlite');
+    });
+
+    it('omits keys that are not provided', () => {
+      proxy = new AgentProxy({
+        port: 8111,
+        hostAddr: '192.168.1.100',
+        apiKeys: { anthropic: 'real-key' },
+      });
+
+      const env = proxy.buildContainerEnv();
+
+      expect(env.ANTHROPIC_API_KEY).toBe(SHIM_PLACEHOLDER);
+      expect(env.ANTHROPIC_BASE_URL).toBeDefined();
+      expect(env.OPENAI_API_KEY).toBeUndefined();
+      expect(env.OPENAI_BASE_URL).toBeUndefined();
+    });
+  });
+
+  describe('buildOpenCodeConfig', () => {
+    it('generates valid JSON with provider base URLs', () => {
+      proxy = new AgentProxy({
+        port: 8111,
+        hostAddr: '10.0.0.1',
+        apiKeys: {
+          anthropic: 'real-key',
+          openai: 'real-key',
+        },
+      });
+
+      const config = JSON.parse(proxy.buildOpenCodeConfig()) as {
+        provider: Record<string, { options: { baseURL: string } }>;
+      };
+
+      expect(config.provider.anthropic.options.baseURL).toBe('http://10.0.0.1:8111/anthropic');
+      expect(config.provider.openai.options.baseURL).toBe('http://10.0.0.1:8111/openai');
+    });
+  });
+
+  describe('CONNECT tunnel deny-list', () => {
+    async function sendConnect(proxyUrl: string, target: string): Promise<string> {
+      const { connect: netConnect } = await import('node:net');
+      const url = new URL(proxyUrl);
+
+      return new Promise<string>((resolve, reject) => {
+        const socket = netConnect(Number(url.port), url.hostname, () => {
+          socket.write(`CONNECT ${target} HTTP/1.1\r\nHost: ${target}\r\n\r\n`);
+        });
+        let data = '';
+        socket.on('data', (chunk) => {
+          data += chunk.toString();
+          if (data.includes('\r\n\r\n') || data.includes('\n\n')) {
+            socket.destroy();
+            resolve(data);
+          }
+        });
+        socket.on('error', reject);
+        socket.on('close', () => resolve(data));
+      });
+    }
+
+    it('denies CONNECT to 127.0.0.1', async () => {
+      proxy = new AgentProxy({
+        port: 0,
+        host: '127.0.0.1',
+        hostAddr: '127.0.0.1',
+        apiKeys: {},
+      });
+      await proxy.start();
+
+      const result = await sendConnect(proxy.proxyUrl, '127.0.0.1:8080');
+      expect(result).toContain('403');
+      expect(result).toContain('denied');
+    });
+
+    it('denies CONNECT to 10.0.0.1', async () => {
+      proxy = new AgentProxy({
+        port: 0,
+        host: '127.0.0.1',
+        hostAddr: '127.0.0.1',
+        apiKeys: {},
+      });
+      await proxy.start();
+
+      const result = await sendConnect(proxy.proxyUrl, '10.0.0.1:8080');
+      expect(result).toContain('403');
+    });
+
+    it('denies CONNECT to localhost', async () => {
+      proxy = new AgentProxy({
+        port: 0,
+        host: '127.0.0.1',
+        hostAddr: '127.0.0.1',
+        apiKeys: {},
+      });
+      await proxy.start();
+
+      const result = await sendConnect(proxy.proxyUrl, 'localhost:8080');
+      expect(result).toContain('403');
+    });
+
+    it('denies CONNECT to 192.168.x.x', async () => {
+      proxy = new AgentProxy({
+        port: 0,
+        host: '127.0.0.1',
+        hostAddr: '127.0.0.1',
+        apiKeys: {},
+      });
+      await proxy.start();
+
+      const result = await sendConnect(proxy.proxyUrl, '192.168.1.1:80');
+      expect(result).toContain('403');
+    });
+  });
+});

--- a/packages/cli/src/lib/agent-proxy.ts
+++ b/packages/cli/src/lib/agent-proxy.ts
@@ -1,0 +1,501 @@
+/**
+ * Agent Proxy — Host-side HTTP proxy for BoxLite containers
+ *
+ * Provides two security layers for `agent serve`:
+ *
+ * 1. **API-key shim (reverse proxy)**: The container never sees the real
+ *    API keys.  Instead it is given fake placeholder keys and
+ *    `*_BASE_URL` env vars that point to local reverse-proxy routes
+ *    (e.g. `/anthropic/*`, `/openai/*`).  When a request arrives the
+ *    proxy strips the fake auth header and injects the real one before
+ *    forwarding to the upstream provider over HTTPS.
+ *
+ * 2. **Network deny-list (forward proxy / CONNECT tunnel)**: The container
+ *    sets `HTTP_PROXY` / `HTTPS_PROXY` to this proxy.  Every `CONNECT`
+ *    request is resolved to an IP and checked against a hard-coded
+ *    deny-list of private / loopback / link-local CIDRs.  Denied
+ *    destinations receive a `403` response; all other traffic is
+ *    tunnelled transparently.
+ */
+
+import { lookup } from 'node:dns/promises';
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
+import { connect, type Socket } from 'node:net';
+import { networkInterfaces } from 'node:os';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface AgentProxyOptions {
+  /** Port the proxy listens on. */
+  port: number;
+  /** Host/IP the proxy binds to (default `0.0.0.0`). */
+  host?: string;
+  /**
+   * Address that the **container** uses to reach this proxy.
+   * If omitted, auto-detected via `detectHostAddress()`.
+   */
+  hostAddr?: string;
+  /** Real API keys to inject upstream (key = provider name). */
+  apiKeys: {
+    anthropic?: string;
+    openai?: string;
+  };
+}
+
+export interface ProxyEnv {
+  /** Environment variables to pass into the container. */
+  env: Record<string, string>;
+  /** The proxy URL as seen from the container. */
+  proxyUrl: string;
+}
+
+// ---------------------------------------------------------------------------
+// CIDR deny-list
+// ---------------------------------------------------------------------------
+
+interface CidrEntry {
+  /** Numeric representation of the network address. */
+  addr: bigint;
+  /** Bitmask with `prefix` leading 1-bits. */
+  mask: bigint;
+}
+
+const IPV4_MAX = 0xffffffffn;
+
+function parseIpv4ToBigInt(ip: string): bigint | undefined {
+  const parts = ip.split('.');
+  if (parts.length !== 4) return undefined;
+  let result = 0n;
+  for (const part of parts) {
+    const n = Number(part);
+    if (Number.isNaN(n) || n < 0 || n > 255) return undefined;
+    result = (result << 8n) | BigInt(n);
+  }
+  return result;
+}
+
+function parseCidr(cidr: string): CidrEntry | undefined {
+  const [ipPart, prefixPart] = cidr.split('/');
+  if (!ipPart || !prefixPart) return undefined;
+  const prefix = Number(prefixPart);
+  if (Number.isNaN(prefix) || prefix < 0 || prefix > 32) return undefined;
+  const addr = parseIpv4ToBigInt(ipPart);
+  if (addr === undefined) return undefined;
+  const mask = prefix === 0 ? 0n : (IPV4_MAX << BigInt(32 - prefix)) & IPV4_MAX;
+  return { addr: addr & mask, mask };
+}
+
+const DENIED_CIDRS_RAW = [
+  '127.0.0.0/8', // loopback
+  '10.0.0.0/8', // RFC-1918 private
+  '172.16.0.0/12', // RFC-1918 private
+  '192.168.0.0/16', // RFC-1918 private
+  '169.254.0.0/16', // link-local
+  '0.0.0.0/8', // "this" network
+];
+
+const DENIED_CIDRS: CidrEntry[] = DENIED_CIDRS_RAW.map(parseCidr).filter(
+  (entry): entry is CidrEntry => entry !== undefined,
+);
+
+/** IPv6 addresses that are always denied. */
+const DENIED_IPV6_PREFIXES = [
+  '::1', // loopback
+  'fc', // unique local (fc00::/7)
+  'fd', // unique local (fc00::/7)
+  'fe80:', // link-local (fe80::/10)
+];
+
+/**
+ * Check whether an IP address string falls within the deny-list.
+ * Supports both IPv4 and IPv6.
+ */
+export function isDeniedAddress(ip: string): boolean {
+  // IPv6 check (simple prefix match — sufficient for loopback/ULA/link-local)
+  if (ip.includes(':')) {
+    const lower = ip.toLowerCase();
+    if (lower === '::1') return true;
+    for (const prefix of DENIED_IPV6_PREFIXES) {
+      if (lower.startsWith(prefix)) return true;
+    }
+    return false;
+  }
+
+  // IPv4 CIDR check
+  const addr = parseIpv4ToBigInt(ip);
+  if (addr === undefined) return false;
+  for (const cidr of DENIED_CIDRS) {
+    if ((addr & cidr.mask) === cidr.addr) return true;
+  }
+  return false;
+}
+
+/**
+ * DNS-resolve a hostname and check whether **any** of its addresses
+ * fall within the deny-list.
+ *
+ * @returns `true` if the hostname resolves to a denied address.
+ */
+export async function resolveAndCheckDenied(hostname: string): Promise<boolean> {
+  // If the hostname is already a raw IP, skip DNS.
+  if (isDeniedAddress(hostname)) return true;
+
+  try {
+    const { address } = await lookup(hostname);
+    return isDeniedAddress(address);
+  } catch {
+    // DNS failure — deny by default (fail-closed).
+    return true;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Host address detection
+// ---------------------------------------------------------------------------
+
+/**
+ * Auto-detect the first non-loopback IPv4 address on this host.
+ * Used as the default value for the proxy URL that the container sees.
+ */
+export function detectHostAddress(): string {
+  const ifaces = networkInterfaces();
+  for (const name of Object.keys(ifaces)) {
+    const addrs = ifaces[name];
+    if (!addrs) continue;
+    for (const addr of addrs) {
+      if (addr.family === 'IPv4' && !addr.internal) {
+        return addr.address;
+      }
+    }
+  }
+  // Fallback — unlikely but safe.
+  return '127.0.0.1';
+}
+
+// ---------------------------------------------------------------------------
+// Reverse proxy helpers
+// ---------------------------------------------------------------------------
+
+/** Pipe an incoming Node request body to an outgoing fetch-style request. */
+async function collectBody(req: IncomingMessage): Promise<Buffer> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) {
+    chunks.push(typeof chunk === 'string' ? Buffer.from(chunk) : chunk);
+  }
+  return Buffer.concat(chunks);
+}
+
+/** Copy select headers from the incoming request, stripping hop-by-hop. */
+function forwardHeaders(
+  req: IncomingMessage,
+  overrides: Record<string, string>,
+): Record<string, string> {
+  const headers: Record<string, string> = {};
+  const HOP_BY_HOP = new Set([
+    'connection',
+    'keep-alive',
+    'proxy-authenticate',
+    'proxy-authorization',
+    'te',
+    'trailer',
+    'transfer-encoding',
+    'upgrade',
+    'host',
+  ]);
+  for (const [key, value] of Object.entries(req.headers)) {
+    if (HOP_BY_HOP.has(key.toLowerCase())) continue;
+    if (value !== undefined) {
+      headers[key] = Array.isArray(value) ? value.join(', ') : value;
+    }
+  }
+  // Remove auth headers that carry fake keys.
+  delete headers['authorization'];
+  delete headers['x-api-key'];
+  // Apply overrides (real auth headers).
+  Object.assign(headers, overrides);
+  return headers;
+}
+
+// ---------------------------------------------------------------------------
+// AgentProxy class
+// ---------------------------------------------------------------------------
+
+export const SHIM_PLACEHOLDER = 'fp-shim-placeholder';
+
+export class AgentProxy {
+  private server: Server | null = null;
+  private readonly options: Required<AgentProxyOptions>;
+  /** Actual port the server is listening on (differs from options.port when port=0). */
+  private boundPort = 0;
+
+  constructor(options: AgentProxyOptions) {
+    this.options = {
+      host: '0.0.0.0',
+      hostAddr: options.hostAddr || detectHostAddress(),
+      ...options,
+    };
+  }
+
+  /** The actual port the proxy is listening on. Equals `options.port` unless port 0 was used. */
+  get listeningPort(): number {
+    return this.boundPort || this.options.port;
+  }
+
+  /** The URL the container should use to reach this proxy. */
+  get proxyUrl(): string {
+    return `http://${this.options.hostAddr}:${this.listeningPort}`;
+  }
+
+  /**
+   * Build the environment variables to inject into the container.
+   *
+   * - Fake API keys (placeholder values)
+   * - `*_BASE_URL` pointing to local reverse proxy routes
+   * - `HTTP_PROXY` / `HTTPS_PROXY` for CONNECT tunnelling
+   */
+  buildContainerEnv(): Record<string, string> {
+    const base = this.proxyUrl;
+    const env: Record<string, string> = {
+      HOME: '/home/boxlite',
+      PATH: process.env.PATH || '/usr/local/bin:/usr/bin:/bin',
+      HTTP_PROXY: base,
+      HTTPS_PROXY: base,
+      // Ensure the proxy itself is not proxied (avoid loops).
+      NO_PROXY: this.options.hostAddr,
+    };
+
+    if (this.options.apiKeys.anthropic) {
+      env.ANTHROPIC_API_KEY = SHIM_PLACEHOLDER;
+      env.ANTHROPIC_BASE_URL = `${base}/anthropic`;
+    }
+
+    if (this.options.apiKeys.openai) {
+      env.OPENAI_API_KEY = SHIM_PLACEHOLDER;
+      env.OPENAI_BASE_URL = `${base}/openai`;
+    }
+
+    return env;
+  }
+
+  /**
+   * Build the OpenCode `opencode.json` config content for BASE_URL override.
+   * OpenCode does not read `*_BASE_URL` from env vars — it requires a config file.
+   */
+  buildOpenCodeConfig(): string {
+    const base = this.proxyUrl;
+
+    interface ProviderEntry {
+      options: { baseURL: string };
+    }
+    const providers: Record<string, ProviderEntry> = {};
+
+    if (this.options.apiKeys.anthropic) {
+      providers.anthropic = { options: { baseURL: `${base}/anthropic` } };
+    }
+    if (this.options.apiKeys.openai) {
+      providers.openai = { options: { baseURL: `${base}/openai` } };
+    }
+
+    return JSON.stringify({ provider: providers }, null, 2);
+  }
+
+  // -----------------------------------------------------------------------
+  // Server lifecycle
+  // -----------------------------------------------------------------------
+
+  async start(): Promise<void> {
+    if (this.server) return;
+
+    const server = createServer((req, res) => this.handleRequest(req, res));
+
+    // Handle CONNECT tunnels (forward proxy).
+    server.on('connect', (req: IncomingMessage, clientSocket: Socket, head: Buffer) => {
+      this.handleConnect(req, clientSocket, head);
+    });
+
+    this.server = server;
+
+    await new Promise<void>((resolve, reject) => {
+      server.on('error', reject);
+      server.listen(this.options.port, this.options.host, () => {
+        const addr = server.address();
+        if (addr && typeof addr === 'object') {
+          this.boundPort = addr.port;
+        }
+        resolve();
+      });
+    });
+  }
+
+  async stop(): Promise<void> {
+    const server = this.server;
+    if (!server) return;
+    this.server = null;
+    await new Promise<void>((resolve) => {
+      server.close(() => resolve());
+    });
+  }
+
+  // -----------------------------------------------------------------------
+  // HTTP request handler (reverse proxy routes)
+  // -----------------------------------------------------------------------
+
+  private async handleRequest(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    const url = req.url || '/';
+
+    // Health check
+    if (req.method === 'GET' && url === '/health') {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ status: 'ok' }));
+      return;
+    }
+
+    // Anthropic reverse proxy
+    if (url.startsWith('/anthropic/') || url === '/anthropic') {
+      await this.reverseProxy(req, res, {
+        upstream: 'https://api.anthropic.com',
+        pathPrefix: '/anthropic',
+        authHeader: this.options.apiKeys.anthropic
+          ? { 'x-api-key': this.options.apiKeys.anthropic }
+          : {},
+      });
+      return;
+    }
+
+    // OpenAI reverse proxy
+    if (url.startsWith('/openai/') || url === '/openai') {
+      await this.reverseProxy(req, res, {
+        upstream: 'https://api.openai.com',
+        pathPrefix: '/openai',
+        authHeader: this.options.apiKeys.openai
+          ? { Authorization: `Bearer ${this.options.apiKeys.openai}` }
+          : {},
+      });
+      return;
+    }
+
+    // Unknown route
+    res.writeHead(404, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'Not found' }));
+  }
+
+  private async reverseProxy(
+    req: IncomingMessage,
+    res: ServerResponse,
+    config: {
+      upstream: string;
+      pathPrefix: string;
+      authHeader: Record<string, string>;
+    },
+  ): Promise<void> {
+    const url = req.url || '/';
+    const upstreamPath = url.startsWith(config.pathPrefix)
+      ? url.slice(config.pathPrefix.length) || '/'
+      : url;
+    const upstreamUrl = `${config.upstream}${upstreamPath}`;
+
+    try {
+      const body = await collectBody(req);
+      const headers = forwardHeaders(req, config.authHeader);
+
+      const upstreamResponse = await fetch(upstreamUrl, {
+        method: req.method || 'POST',
+        headers,
+        body: ['GET', 'HEAD'].includes(req.method || '') ? undefined : body,
+      });
+
+      // Stream the response back.
+      const responseHeaders: Record<string, string> = {};
+      upstreamResponse.headers.forEach((value, key) => {
+        // Skip hop-by-hop headers from upstream.
+        if (!['transfer-encoding', 'connection', 'keep-alive'].includes(key.toLowerCase())) {
+          responseHeaders[key] = value;
+        }
+      });
+
+      res.writeHead(upstreamResponse.status, responseHeaders);
+
+      if (upstreamResponse.body) {
+        const reader = (upstreamResponse.body as ReadableStream<Uint8Array>).getReader();
+        try {
+          while (true) {
+            const { done, value } = await reader.read();
+            if (done) break;
+            res.write(Buffer.from(value));
+          }
+        } catch {
+          // Client may have disconnected.
+        } finally {
+          reader.releaseLock();
+        }
+      }
+
+      res.end();
+    } catch (error) {
+      if (!res.headersSent) {
+        res.writeHead(502, { 'Content-Type': 'application/json' });
+        res.end(
+          JSON.stringify({
+            error: 'Upstream request failed',
+            message: error instanceof Error ? error.message : String(error),
+          }),
+        );
+      }
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // CONNECT tunnel handler (forward proxy with deny-list)
+  // -----------------------------------------------------------------------
+
+  private async handleConnect(
+    req: IncomingMessage,
+    clientSocket: Socket,
+    head: Buffer,
+  ): Promise<void> {
+    const target = req.url || '';
+    const colonIdx = target.lastIndexOf(':');
+    const hostname = colonIdx > 0 ? target.slice(0, colonIdx) : target;
+    const port = colonIdx > 0 ? Number(target.slice(colonIdx + 1)) : 443;
+
+    if (Number.isNaN(port) || port <= 0 || port > 65535) {
+      clientSocket.write('HTTP/1.1 400 Bad Request\r\n\r\n');
+      clientSocket.destroy();
+      return;
+    }
+
+    // Deny-list check.
+    const denied = await resolveAndCheckDenied(hostname);
+    if (denied) {
+      clientSocket.write(
+        'HTTP/1.1 403 Forbidden\r\n' +
+          'Content-Type: text/plain\r\n' +
+          '\r\n' +
+          `Connection to ${hostname} is denied by network policy.\n`,
+      );
+      clientSocket.destroy();
+      return;
+    }
+
+    // Establish tunnel.
+    const serverSocket = connect(port, hostname, () => {
+      clientSocket.write('HTTP/1.1 200 Connection Established\r\n\r\n');
+      if (head.length > 0) {
+        serverSocket.write(head);
+      }
+      serverSocket.pipe(clientSocket);
+      clientSocket.pipe(serverSocket);
+    });
+
+    serverSocket.on('error', () => {
+      clientSocket.write('HTTP/1.1 502 Bad Gateway\r\n\r\n');
+      clientSocket.destroy();
+    });
+
+    clientSocket.on('error', () => {
+      serverSocket.destroy();
+    });
+  }
+}

--- a/packages/cli/src/lib/agent-proxy.ts
+++ b/packages/cli/src/lib/agent-proxy.ts
@@ -22,6 +22,7 @@ import { lookup } from 'node:dns/promises';
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
 import { connect, type Socket } from 'node:net';
 import { networkInterfaces } from 'node:os';
+import { Readable } from 'node:stream';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -30,7 +31,7 @@ import { networkInterfaces } from 'node:os';
 export interface AgentProxyOptions {
   /** Port the proxy listens on. */
   port: number;
-  /** Host/IP the proxy binds to (default `0.0.0.0`). */
+  /** Host/IP the proxy binds to (default: auto-detected hostAddr or `127.0.0.1`). */
   host?: string;
   /**
    * Address that the **container** uses to reach this proxy.
@@ -100,25 +101,97 @@ const DENIED_CIDRS: CidrEntry[] = DENIED_CIDRS_RAW.map(parseCidr).filter(
   (entry): entry is CidrEntry => entry !== undefined,
 );
 
-/** IPv6 addresses that are always denied. */
-const DENIED_IPV6_PREFIXES = [
-  '::1', // loopback
-  'fc', // unique local (fc00::/7)
-  'fd', // unique local (fc00::/7)
-  'fe80:', // link-local (fe80::/10)
+/**
+ * Parse an IPv6 address into a 128-bit bigint.
+ * Handles compressed (`::`) and IPv4-mapped (`::ffff:1.2.3.4`) forms.
+ */
+function parseIpv6ToBigInt(ip: string): bigint | undefined {
+  // Handle IPv4-mapped IPv6 (e.g. ::ffff:192.168.1.1)
+  const v4MappedMatch = ip.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/i);
+  if (v4MappedMatch) {
+    const v4 = parseIpv4ToBigInt(v4MappedMatch[1]);
+    if (v4 === undefined) return undefined;
+    return (0xffffn << 32n) | v4;
+  }
+
+  // Expand :: notation
+  const halves = ip.split('::');
+  if (halves.length > 2) return undefined;
+
+  let groups: string[];
+  if (halves.length === 2) {
+    const left = halves[0] ? halves[0].split(':') : [];
+    const right = halves[1] ? halves[1].split(':') : [];
+    const missing = 8 - left.length - right.length;
+    if (missing < 0) return undefined;
+    groups = [...left, ...Array(missing).fill('0'), ...right];
+  } else {
+    groups = ip.split(':');
+  }
+
+  if (groups.length !== 8) return undefined;
+
+  let result = 0n;
+  for (const group of groups) {
+    const n = parseInt(group, 16);
+    if (Number.isNaN(n) || n < 0 || n > 0xffff) return undefined;
+    result = (result << 16n) | BigInt(n);
+  }
+  return result;
+}
+
+/** IPv6 CIDR ranges to deny. */
+interface Ipv6CidrEntry {
+  addr: bigint;
+  mask: bigint;
+}
+
+const IPV6_MAX = (1n << 128n) - 1n;
+
+function parseIpv6Cidr(cidr: string): Ipv6CidrEntry | undefined {
+  const [ipPart, prefixPart] = cidr.split('/');
+  if (!ipPart || !prefixPart) return undefined;
+  const prefix = Number(prefixPart);
+  if (Number.isNaN(prefix) || prefix < 0 || prefix > 128) return undefined;
+  const addr = parseIpv6ToBigInt(ipPart);
+  if (addr === undefined) return undefined;
+  const mask = prefix === 0 ? 0n : (IPV6_MAX << BigInt(128 - prefix)) & IPV6_MAX;
+  return { addr: addr & mask, mask };
+}
+
+const DENIED_IPV6_CIDRS_RAW = [
+  '::1/128', // loopback
+  'fc00::/7', // unique local
+  'fe80::/10', // link-local
+  '::ffff:127.0.0.0/104', // IPv4-mapped loopback  — handled via v4 check
+  '::ffff:10.0.0.0/104', // IPv4-mapped RFC-1918  — handled via v4 check
+  '::ffff:172.16.0.0/108', // IPv4-mapped RFC-1918  — handled via v4 check
+  '::ffff:192.168.0.0/112', // IPv4-mapped RFC-1918  — handled via v4 check
+  '::ffff:169.254.0.0/112', // IPv4-mapped link-local — handled via v4 check
+  '::ffff:0.0.0.0/104', // IPv4-mapped "this" network
 ];
+
+const DENIED_IPV6_CIDRS: Ipv6CidrEntry[] = DENIED_IPV6_CIDRS_RAW.map(parseIpv6Cidr).filter(
+  (entry): entry is Ipv6CidrEntry => entry !== undefined,
+);
 
 /**
  * Check whether an IP address string falls within the deny-list.
- * Supports both IPv4 and IPv6.
+ * Supports both IPv4, IPv6, and IPv4-mapped IPv6 addresses.
  */
 export function isDeniedAddress(ip: string): boolean {
-  // IPv6 check (simple prefix match — sufficient for loopback/ULA/link-local)
+  // Handle IPv4-mapped IPv6 — extract the embedded v4 address and check it.
+  const v4MappedMatch = ip.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/i);
+  if (v4MappedMatch) {
+    return isDeniedAddress(v4MappedMatch[1]);
+  }
+
+  // IPv6 check
   if (ip.includes(':')) {
-    const lower = ip.toLowerCase();
-    if (lower === '::1') return true;
-    for (const prefix of DENIED_IPV6_PREFIXES) {
-      if (lower.startsWith(prefix)) return true;
+    const addr = parseIpv6ToBigInt(ip);
+    if (addr === undefined) return false;
+    for (const cidr of DENIED_IPV6_CIDRS) {
+      if ((addr & cidr.mask) === cidr.addr) return true;
     }
     return false;
   }
@@ -134,21 +207,41 @@ export function isDeniedAddress(ip: string): boolean {
 
 /**
  * DNS-resolve a hostname and check whether **any** of its addresses
- * fall within the deny-list.
+ * fall within the deny-list. Returns the first allowed resolved IP
+ * if any, or `null` if all are denied or DNS fails.
  *
- * @returns `true` if the hostname resolves to a denied address.
+ * Uses `{ all: true }` to resolve all A/AAAA records and denies
+ * if **any** resolved address is in the deny-list (fail-closed).
+ *
+ * @returns The first allowed IP address, or `null` if denied / unresolvable.
  */
-export async function resolveAndCheckDenied(hostname: string): Promise<boolean> {
-  // If the hostname is already a raw IP, skip DNS.
-  if (isDeniedAddress(hostname)) return true;
+export async function resolveAllAndCheck(hostname: string): Promise<string | null> {
+  // If the hostname is already a raw IP, check directly.
+  if (isDeniedAddress(hostname)) return null;
+  // If it's a raw IP that's allowed, return it as-is.
+  if (parseIpv4ToBigInt(hostname) !== undefined || hostname.includes(':')) {
+    return hostname;
+  }
 
   try {
-    const { address } = await lookup(hostname);
-    return isDeniedAddress(address);
+    const results = await lookup(hostname, { all: true });
+    // Deny if ANY resolved address is in the deny-list (fail-closed).
+    for (const result of results) {
+      if (isDeniedAddress(result.address)) return null;
+    }
+    // Return the first resolved address to connect to (avoids TOCTOU).
+    return results.length > 0 ? results[0].address : null;
   } catch {
     // DNS failure — deny by default (fail-closed).
-    return true;
+    return null;
   }
+}
+
+/**
+ * @deprecated Use `resolveAllAndCheck` instead. Kept for backward compatibility.
+ */
+export async function resolveAndCheckDenied(hostname: string): Promise<boolean> {
+  return (await resolveAllAndCheck(hostname)) === null;
 }
 
 // ---------------------------------------------------------------------------
@@ -177,15 +270,6 @@ export function detectHostAddress(): string {
 // ---------------------------------------------------------------------------
 // Reverse proxy helpers
 // ---------------------------------------------------------------------------
-
-/** Pipe an incoming Node request body to an outgoing fetch-style request. */
-async function collectBody(req: IncomingMessage): Promise<Buffer> {
-  const chunks: Buffer[] = [];
-  for await (const chunk of req) {
-    chunks.push(typeof chunk === 'string' ? Buffer.from(chunk) : chunk);
-  }
-  return Buffer.concat(chunks);
-}
 
 /** Copy select headers from the incoming request, stripping hop-by-hop. */
 function forwardHeaders(
@@ -231,9 +315,12 @@ export class AgentProxy {
   private boundPort = 0;
 
   constructor(options: AgentProxyOptions) {
+    const hostAddr = options.hostAddr || detectHostAddress();
     this.options = {
-      host: '0.0.0.0',
-      hostAddr: options.hostAddr || detectHostAddress(),
+      // Bind to the detected host address by default, not 0.0.0.0,
+      // to avoid exposing an open proxy on all interfaces.
+      host: options.host || hostAddr,
+      hostAddr,
       ...options,
     };
   }
@@ -333,6 +420,10 @@ export class AgentProxy {
     const server = this.server;
     if (!server) return;
     this.server = null;
+    // Force-close active CONNECT tunnels so the server doesn't hang.
+    if (typeof server.closeAllConnections === 'function') {
+      server.closeAllConnections();
+    }
     await new Promise<void>((resolve) => {
       server.close(() => resolve());
     });
@@ -397,13 +488,17 @@ export class AgentProxy {
     const upstreamUrl = `${config.upstream}${upstreamPath}`;
 
     try {
-      const body = await collectBody(req);
       const headers = forwardHeaders(req, config.authHeader);
+      const isBodyless = ['GET', 'HEAD'].includes(req.method || '');
+
+      // Stream the request body directly instead of buffering it entirely.
+      const body = isBodyless ? undefined : (Readable.toWeb(req) as ReadableStream);
 
       const upstreamResponse = await fetch(upstreamUrl, {
         method: req.method || 'POST',
         headers,
-        body: ['GET', 'HEAD'].includes(req.method || '') ? undefined : body,
+        body,
+        duplex: isBodyless ? undefined : 'half',
       });
 
       // Stream the response back.
@@ -418,21 +513,19 @@ export class AgentProxy {
       res.writeHead(upstreamResponse.status, responseHeaders);
 
       if (upstreamResponse.body) {
-        const reader = (upstreamResponse.body as ReadableStream<Uint8Array>).getReader();
-        try {
-          while (true) {
-            const { done, value } = await reader.read();
-            if (done) break;
-            res.write(Buffer.from(value));
-          }
-        } catch {
-          // Client may have disconnected.
-        } finally {
-          reader.releaseLock();
-        }
+        // Pipe the upstream response through a Node Readable to handle backpressure.
+        const nodeStream = Readable.fromWeb(
+          upstreamResponse.body as import('stream/web').ReadableStream,
+        );
+        nodeStream.pipe(res);
+        await new Promise<void>((resolve, reject) => {
+          nodeStream.on('end', resolve);
+          nodeStream.on('error', reject);
+          res.on('error', () => nodeStream.destroy());
+        });
+      } else {
+        res.end();
       }
-
-      res.end();
     } catch (error) {
       if (!res.headersSent) {
         res.writeHead(502, { 'Content-Type': 'application/json' });
@@ -466,9 +559,10 @@ export class AgentProxy {
       return;
     }
 
-    // Deny-list check.
-    const denied = await resolveAndCheckDenied(hostname);
-    if (denied) {
+    // Resolve DNS once and use the resolved IP for both the deny-list
+    // check and the actual connection to prevent TOCTOU / DNS rebinding.
+    const resolvedIp = await resolveAllAndCheck(hostname);
+    if (!resolvedIp) {
       clientSocket.write(
         'HTTP/1.1 403 Forbidden\r\n' +
           'Content-Type: text/plain\r\n' +
@@ -479,8 +573,13 @@ export class AgentProxy {
       return;
     }
 
-    // Establish tunnel.
-    const serverSocket = connect(port, hostname, () => {
+    // Track whether we've sent the 200 response.
+    let tunnelEstablished = false;
+
+    // Establish tunnel to the resolved IP (not the hostname) to
+    // prevent a second DNS resolution from yielding a different address.
+    const serverSocket = connect(port, resolvedIp, () => {
+      tunnelEstablished = true;
       clientSocket.write('HTTP/1.1 200 Connection Established\r\n\r\n');
       if (head.length > 0) {
         serverSocket.write(head);
@@ -490,7 +589,10 @@ export class AgentProxy {
     });
 
     serverSocket.on('error', () => {
-      clientSocket.write('HTTP/1.1 502 Bad Gateway\r\n\r\n');
+      // Only send an error response if we haven't sent 200 yet.
+      if (!tunnelEstablished) {
+        clientSocket.write('HTTP/1.1 502 Bad Gateway\r\n\r\n');
+      }
       clientSocket.destroy();
     });
 

--- a/packages/cli/src/lib/agent-serve.test.ts
+++ b/packages/cli/src/lib/agent-serve.test.ts
@@ -70,6 +70,8 @@ const baseOptions: AgentServeOptions = {
   rootKey: 'a'.repeat(64),
   boxliteUrl: 'http://localhost:8100',
   boxliteBoxId: 'test-box',
+  proxyPort: '0',
+  proxyHostAddr: '127.0.0.1',
 };
 
 interface SessionEnvelope {
@@ -87,6 +89,7 @@ function queueSuccessfulIsolationPreflight() {
   mockExec.mockResolvedValueOnce({ stdout: '', stderr: '', exit_code: 0 });
   mockExec.mockResolvedValueOnce({ stdout: 'isolation-probe-ok', stderr: '', exit_code: 0 });
   mockExec.mockResolvedValueOnce({ stdout: '1000000 50%', stderr: '', exit_code: 0 });
+  mockExec.mockResolvedValueOnce({ stdout: '', stderr: '', exit_code: 0 }); // opencode config
 }
 
 async function startTestServer(options: Partial<AgentServeOptions> = {}) {
@@ -618,7 +621,7 @@ describe('runAgentServeCommand', () => {
       expect(execOptions.env).toBeDefined();
       const env = execOptions.env as Record<string, string>;
       expect(env.FIBER_RPC_BISCUIT_TOKEN).toBeUndefined();
-      expect(env.OPENAI_API_KEY).toBe('openai-key');
+      expect(env.OPENAI_API_KEY).toBe('fp-shim-placeholder');
       expect(env.PATH).toBe('/usr/bin');
       expect(env.HOME).toBe('/home/boxlite');
 
@@ -705,6 +708,7 @@ describe('runAgentServeCommand', () => {
       mockExec.mockResolvedValueOnce({ stdout: '', stderr: '', exit_code: 0 });
       mockExec.mockResolvedValueOnce({ stdout: 'isolation-probe-ok', stderr: '', exit_code: 0 });
       mockExec.mockResolvedValueOnce({ stdout: '1000000 50%', stderr: '', exit_code: 0 });
+      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '', exit_code: 0 }); // opencode config
       mockExec.mockResolvedValueOnce({ stdout: '', stderr: '', exit_code: 0 });
       mockExec.mockResolvedValueOnce({ stdout: 'wrapped result', stderr: '', exit_code: 0 });
       // Default fallback for any subsequent fire-and-forget cleanup calls
@@ -722,9 +726,9 @@ describe('runAgentServeCommand', () => {
       const body = (await response.json()) as { response: string };
       expect(body.response).toBe('wrapped result');
 
-      const agentExecCall = mockExec.mock.calls[4];
+      const agentExecCall = mockExec.mock.calls[5];
       expect(agentExecCall[0]).toBe('sh');
-      const unshareCall = mockExec.mock.calls[5];
+      const unshareCall = mockExec.mock.calls[6];
       expect(unshareCall[0]).toBe('unshare');
       const unshareArgs = unshareCall[1] as string[];
       expect(unshareArgs).toContain('--user');
@@ -757,6 +761,7 @@ describe('runAgentServeCommand', () => {
       mockExec.mockResolvedValueOnce({ stdout: '', stderr: '', exit_code: 0 });
       mockExec.mockResolvedValueOnce({ stdout: 'isolation-probe-ok', stderr: '', exit_code: 0 });
       mockExec.mockResolvedValueOnce({ stdout: '1000000 50%', stderr: '', exit_code: 0 });
+      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '', exit_code: 0 }); // opencode config
       mockExec.mockResolvedValueOnce({ stdout: '', stderr: '', exit_code: 0 });
       mockExec.mockResolvedValueOnce({ stdout: 'bootstrap', stderr: '', exit_code: 0 });
       mockExec.mockResolvedValue({ stdout: '', stderr: '', exit_code: 0 });

--- a/packages/cli/src/lib/agent-serve.ts
+++ b/packages/cli/src/lib/agent-serve.ts
@@ -30,6 +30,7 @@ import type { Currency } from '@fiber-pay/sdk';
 import { createL402Middleware, FiberRpcClient } from '@fiber-pay/sdk/node';
 import cors from 'cors';
 import express from 'express';
+import { AgentProxy } from './agent-proxy.js';
 import { BoxliteClient, BoxliteError } from './boxlite-client.js';
 import type { CliConfig } from './config.js';
 import { printJsonError, printJsonSuccess } from './format.js';
@@ -54,6 +55,12 @@ export interface AgentServeOptions {
   workspaceTtl?: string;
   /** Minimum free space (in MB) required on /workspace before accepting a new session. */
   workspaceMinFreeMb?: string;
+  /** Port for the host-side proxy (default 8111). */
+  proxyPort?: string;
+  /** Address the container uses to reach the host (auto-detected if omitted). */
+  proxyHostAddr?: string;
+  /** Set to false via --no-proxy to disable the host-side proxy. */
+  proxy?: boolean;
 }
 
 interface AgentServeRequest extends express.Request {
@@ -131,7 +138,23 @@ function parseJsonLines(text: string): Array<Record<string, unknown>> | undefine
   }
 }
 
-function buildSafeEnv(): Record<string, string> {
+/**
+ * Build the environment variables passed into the BoxLite container.
+ *
+ * When `proxyEnv` is provided (the proxy is enabled), the container receives:
+ *   - Fake API keys (`fp-shim-placeholder`)
+ *   - `*_BASE_URL` pointing to the host proxy's reverse-proxy routes
+ *   - `HTTP_PROXY` / `HTTPS_PROXY` for outbound traffic filtering
+ *
+ * When `proxyEnv` is `undefined` (proxy disabled via `--no-proxy`),
+ * real API keys from the host process are passed through directly.
+ */
+function buildSafeEnv(proxyEnv?: Record<string, string>): Record<string, string> {
+  if (proxyEnv) {
+    return { ...proxyEnv };
+  }
+
+  // Fallback: no proxy — pass real keys (less secure, for debugging only).
   const allowed = [
     'PATH',
     'OPENAI_API_KEY',
@@ -484,6 +507,7 @@ async function runAcpx(
     format?: string;
     signal?: AbortSignal;
     onChunk?: (chunk: { type: 'stdout' | 'stderr'; text: string }) => void;
+    proxyEnv?: Record<string, string>;
   },
 ): Promise<{ stdout: string; stderr: string; exitCode: number }> {
   const client = new BoxliteClient(options.boxliteUrl, options.boxliteBoxId);
@@ -519,7 +543,7 @@ async function runAcpx(
     const execArgs = buildIsolationWrapArgs('acpx', acpxArgs, sessionDir, sessionTmpDir);
 
     const execOptions = {
-      env: buildSafeEnv(),
+      env: buildSafeEnv(options.proxyEnv),
       timeout: options.timeoutSeconds,
       signal: options.signal,
     };
@@ -569,7 +593,7 @@ async function runAcpx(
           `cd /workspace && acpx ${shellQuote(agent)} sessions close ${shellQuote(options.sessionId)}`,
         ],
         {
-          env: buildSafeEnv(),
+          env: buildSafeEnv(options.proxyEnv),
           timeout: 10,
         },
       );
@@ -592,7 +616,7 @@ async function runAcpx(
           `cd /workspace && acpx ${shellQuote(agent)} sessions ensure --name ${shellQuote(options.sessionId)}`,
         ],
         {
-          env: buildSafeEnv(),
+          env: buildSafeEnv(options.proxyEnv),
           timeout: 10,
         },
       );
@@ -619,7 +643,7 @@ async function runAcpx(
             `cd /workspace && acpx ${shellQuote(agent)} sessions ensure --name ${shellQuote(options.sessionId)}`,
           ],
           {
-            env: buildSafeEnv(),
+            env: buildSafeEnv(options.proxyEnv),
             timeout: 10,
           },
         );
@@ -669,17 +693,6 @@ export async function runAgentServeCommand(
   const boxliteUrl = options.boxliteUrl || process.env.BOXLITE_URL || 'http://localhost:8100';
   const boxliteBoxId = options.boxliteBoxId || process.env.BOXLITE_BOX_ID || 'fiber-pay-agent';
 
-  // TODO: BoxLite only supports an allowNet whitelist, which is either too
-  // permissive or too restrictive for production agents that need to browse.
-  // A better long-term approach is to run a small host-side HTTP proxy that
-  // supports a denyList (e.g. localhost / 127.0.0.1 / RFC-1918 IPs) and let
-  // the Box route all outbound traffic through it. This gives us blacklist
-  // semantics for security while keeping the agent free to search and fetch.
-  //
-  // The same proxy can also act as an API-key shim: the Box talks to a
-  // host-local pseudo-provider endpoint (e.g. http://host:8101/v1/chat) so
-  // the real ANTHROPIC_API_KEY never enters the sandbox at all. This removes
-  // the prompt-injection key-exfiltration vector entirely.
   const rootKey = options.rootKey || process.env.L402_ROOT_KEY;
 
   const parsePositiveIntegerOption = (
@@ -902,6 +915,67 @@ export async function runAgentServeCommand(
     }
   }
 
+  // ---------------------------------------------------------------------------
+  // Host-side proxy: API-key shim + network deny-list
+  // ---------------------------------------------------------------------------
+  const proxyEnabled = options.proxy !== false;
+  let agentProxy: AgentProxy | undefined;
+  let proxyEnv: Record<string, string> | undefined;
+
+  if (proxyEnabled) {
+    const proxyPort = parseInt(options.proxyPort || '8111', 10);
+    const apiKeys: { anthropic?: string; openai?: string } = {};
+    if (process.env.ANTHROPIC_API_KEY) apiKeys.anthropic = process.env.ANTHROPIC_API_KEY;
+    if (process.env.OPENAI_API_KEY) apiKeys.openai = process.env.OPENAI_API_KEY;
+
+    agentProxy = new AgentProxy({
+      port: proxyPort,
+      hostAddr: options.proxyHostAddr,
+      apiKeys,
+    });
+
+    try {
+      await agentProxy.start();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      const displayMessage = `Failed to start host-side proxy: ${message}`;
+      if (asJson) {
+        printJsonError({
+          code: 'AGENT_SERVE_PROXY_ERROR',
+          message: displayMessage,
+          recoverable: true,
+          suggestion: `Check if port ${proxyPort} is available, or use --proxy-port to choose a different port.`,
+        });
+      } else {
+        console.error(`Error: ${displayMessage}`);
+      }
+      process.exit(1);
+    }
+
+    proxyEnv = agentProxy.buildContainerEnv();
+
+    // Write OpenCode config file into the container.
+    // OpenCode reads BASE_URL from a config file, not from env vars.
+    try {
+      const opencodeConfig = agentProxy.buildOpenCodeConfig();
+      await client.exec(
+        'sh',
+        [
+          '-c',
+          `mkdir -p /home/boxlite/.config/opencode && cat > /home/boxlite/.config/opencode/opencode.json << 'PROXYEOF'
+${opencodeConfig}
+PROXYEOF`,
+        ],
+        { timeout: 5 },
+      );
+    } catch {
+      // Non-fatal: OpenCode config is best-effort.
+      if (!asJson) {
+        console.warn('Warning: Failed to write OpenCode proxy config into the container.');
+      }
+    }
+  }
+
   const rpcClient = new FiberRpcClient({
     url: config.rpcUrl,
     biscuitToken: config.rpcBiscuitToken,
@@ -1088,6 +1162,7 @@ export async function runAgentServeCommand(
           onChunk: (chunk) => {
             sendSse('chunk', chunk);
           },
+          proxyEnv,
         });
 
         if (clientClosed) {
@@ -1137,6 +1212,7 @@ export async function runAgentServeCommand(
         boxliteBoxId,
         sessionId: session.sessionId,
         format: requestFormat,
+        proxyEnv,
       });
 
       const durationMs = Date.now() - startTime;
@@ -1188,7 +1264,7 @@ export async function runAgentServeCommand(
               `cd /workspace && acpx ${shellQuote(options.agent)} sessions close ${shellQuote(session.sessionId)}`,
             ],
             {
-              env: buildSafeEnv(),
+              env: buildSafeEnv(proxyEnv),
               timeout: 10,
             },
           );
@@ -1296,6 +1372,7 @@ export async function runAgentServeCommand(
       fiberRpcUrl: config.rpcUrl,
       boxliteUrl,
       boxliteBoxId,
+      proxy: agentProxy ? { url: agentProxy.proxyUrl, port: agentProxy.listeningPort } : undefined,
     });
   } else {
     const isolationLabel = 'namespace (PID + mount + user)';
@@ -1309,6 +1386,11 @@ export async function runAgentServeCommand(
     console.log(`  Fiber RPC:  ${config.rpcUrl}`);
     console.log(`  BoxLite:    ${boxliteUrl} (box: ${boxliteBoxId})`);
     console.log(`  Isolation:  ${isolationLabel}`);
+    if (agentProxy) {
+      console.log(`  Proxy:      ${agentProxy.proxyUrl} (API key shim + network deny-list)`);
+    } else {
+      console.log('  Proxy:      disabled (--no-proxy)');
+    }
     console.log('');
     console.log('Endpoint:');
     console.log(`  POST ${listenUrl}/  {"prompt": "your question"}`);
@@ -1322,7 +1404,10 @@ export async function runAgentServeCommand(
     if (!asJson) {
       console.log('\nStopping agent service...');
     }
-    server.close(() => {
+    server.close(async () => {
+      if (agentProxy) {
+        await agentProxy.stop();
+      }
       if (asJson) {
         printJsonSuccess({ status: 'stopped' });
       } else {

--- a/packages/cli/src/lib/agent-serve.ts
+++ b/packages/cli/src/lib/agent-serve.ts
@@ -923,7 +923,22 @@ export async function runAgentServeCommand(
   let proxyEnv: Record<string, string> | undefined;
 
   if (proxyEnabled) {
-    const proxyPort = parseInt(options.proxyPort || '8111', 10);
+    const rawProxyPort = options.proxyPort || '8111';
+    const proxyPort = Number.parseInt(rawProxyPort, 10);
+    if (!Number.isInteger(proxyPort) || proxyPort < 0 || proxyPort > 65535) {
+      const message = `Invalid --proxy-port value "${rawProxyPort}". Expected an integer between 1 and 65535.`;
+      if (asJson) {
+        printJsonError({
+          code: 'AGENT_SERVE_INVALID_PROXY_PORT',
+          message,
+          recoverable: true,
+          suggestion: 'Provide a valid TCP port with --proxy-port, for example --proxy-port 8111.',
+        });
+      } else {
+        console.error(`Error: ${message}`);
+      }
+      process.exit(1);
+    }
     const apiKeys: { anthropic?: string; openai?: string } = {};
     if (process.env.ANTHROPIC_API_KEY) apiKeys.anthropic = process.env.ANTHROPIC_API_KEY;
     if (process.env.OPENAI_API_KEY) apiKeys.openai = process.env.OPENAI_API_KEY;

--- a/scripts/boxlite-setup.sh
+++ b/scripts/boxlite-setup.sh
@@ -56,6 +56,10 @@ mkdir -p /tmp/fiber-sessions
 chmod 1777 /tmp/fiber-sessions
 echo "      /tmp/fiber-sessions       OK"
 
+mkdir -p /home/boxlite/.config/opencode
+chown -R boxlite:boxlite /home/boxlite/.config || true
+echo "      OpenCode proxy config dir OK"
+
 echo ""
 
 # ---------------------------------------------------------------------------

--- a/skills/fiber-pay/references/l402-agent.md
+++ b/skills/fiber-pay/references/l402-agent.md
@@ -169,12 +169,15 @@ fiber-pay --profile user agent call http://127.0.0.1:8402 --prompt "say hello"
 
 ## Security model summary
 
-| Threat | With mandatory namespace isolation |
+| Threat | Mitigation |
 | ------ | ---------------------------------- |
 | Agent reads another session's `/workspace` | ❌ path not visible in mount namespace |
 | Agent sees other sessions' processes | ❌ PID namespace hides them |
 | Agent pollutes shared `/tmp` | ❌ private `/tmp` per session |
 | Deliberate path traversal by known abs path | ⚠️ same UID; use UUID session IDs |
+| Agent steals API key via `env`/`printenv` | ❌ proxy injects `fp-shim-placeholder` |
+| Agent accesses host internal services | ❌ proxy CONNECT tunnel deny-list |
+| Agent accesses private network (RFC-1918) | ❌ proxy CONNECT tunnel deny-list |
 
 Session IDs are generated server-side and signed into a `sessionToken`.
 Resuming a session requires both fields (`sessionId` + `sessionToken`), and


### PR DESCRIPTION
## Description

This PR introduces a host-side HTTP proxy for the `agent serve` command to enhance security when running BoxLite containers.

- **API Key Shim**: Safely replaces placeholder API keys within the container environment with real keys via the host-side reverse proxy.
- **Network Security**: Uses a CONNECT tunnel to filter outbound traffic with a hardcoded CIDR deny-list to block RFC-1918 private network access.
- **Dynamic Configuration**: Supports `--proxy-port`, `--proxy-host-addr` and auto-injects an `opencode.json` config into the container.