### PR TITLE
feat(cli): add session-scoped workspace static file serving

### DIFF
--- a/.changeset/static-list-header-session-auth.md
+++ b/.changeset/static-list-header-session-auth.md
@@ -1,0 +1,5 @@
+---
+'@fiber-pay/cli': patch
+---
+
+Switch `agent serve` workspace static and directory list session auth to header-only (`x-session-id` and `x-session-token`), and remove URL-based session token/sessionId usage for these endpoints.

--- a/docs/agent-serve-backend-setup.md
+++ b/docs/agent-serve-backend-setup.md
@@ -7,7 +7,8 @@ This guide provides a comprehensive overview of how to set up the backend enviro
 Use this checklist when installing on a new server:
 
 1. Install and run BoxLite REST server (`boxlite serve`).
-2. Create a persistent Box (`node:22-alpine`, disk >= 10 GB, strict `allowNet`).
+2. Create a persistent Box (`node:22-alpine`, disk >= 10 GB, strict `allowNet`) and prefer no host bind mount.
+   - If a mount is unavoidable, use a dedicated least-privilege directory only (never repo root, `$HOME`, or sensitive paths).
 3. Install required tools in Box:
     - `acpx@0.5.3`
     - `opencode-ai@latest`
@@ -47,6 +48,7 @@ When you run `fiber-pay agent serve`, the process involves several layers of iso
    - Executes the actual AI agent via `acpx`.
    - Never sees the real API keys (receives `fp-shim-placeholder` instead).
    - All network traffic is forced through the Host-side Proxy via `HTTP_PROXY` and `HTTPS_PROXY`.
+   - For filesystem safety, prefer container-local persistent disk and avoid host bind mounts unless strictly required.
 
 3. **Per-Session Linux Namespaces**:
    - Every request is wrapped in a Linux namespace using `unshare`.

--- a/docs/agent-serve-backend-setup.md
+++ b/docs/agent-serve-backend-setup.md
@@ -182,6 +182,29 @@ The server routinely checks the container's `/workspace` disk space.
 - If disk usage exceeds 90%, the service automatically drops the TTL to 1 hour and accelerates the cleanup interval.
 - If disk usage exceeds 95%, the service will crash proactively to prevent corruption. Use `--workspace-min-free-mb` to enforce a buffer.
 
+### Session-scoped static workspace serving
+
+`agent serve` now supports a simple static endpoint for session workspace files:
+
+```http
+GET /workspace/static/:sessionId/<path>
+```
+
+Auth:
+
+- `x-session-token: <token>` header (preferred), or
+- `?sessionToken=<token>` query.
+
+Security behavior:
+
+- Token must verify and match the requested `sessionId`.
+- File access is constrained to `/workspace/sessions/<sessionId>/`.
+- Path traversal and path escape are rejected.
+- Directory path requests fallback to `index.html`.
+
+Token validity uses the same session token TTL rule as chat session resume.
+By default (no `--workspace-ttl` override), effective token window is 24 hours.
+
 ## 6. Real-World Pitfalls And Fixes
 
 ### A. Warning: No provider API keys found for proxy injection

--- a/docs/agent-serve-backend-setup.md
+++ b/docs/agent-serve-backend-setup.md
@@ -187,20 +187,29 @@ The server routinely checks the container's `/workspace` disk space.
 `agent serve` now supports a simple static endpoint for session workspace files:
 
 ```http
-GET /workspace/static/:sessionId/<path>
+GET /workspace/static/<path>
 ```
 
 Auth:
 
-- `x-session-token: <token>` header (preferred), or
-- `?sessionToken=<token>` query.
+- `x-session-id: <sessionId>` header.
+- `x-session-token: <token>` header.
 
 Security behavior:
 
-- Token must verify and match the requested `sessionId`.
+- Token must verify and match `x-session-id`.
 - File access is constrained to `/workspace/sessions/<sessionId>/`.
 - Path traversal and path escape are rejected.
 - Directory path requests fallback to `index.html`.
+
+Directory listing endpoint:
+
+```http
+GET /workspace/static/list?path=<relative-directory>
+```
+
+Response includes `entries` (`file` / `dir` / `symlink`), current relative path,
+and whether the result was truncated by server-side limit.
 
 Token validity uses the same session token TTL rule as chat session resume.
 By default (no `--workspace-ttl` override), effective token window is 24 hours.

--- a/docs/agent-serve-frontend-integration.md
+++ b/docs/agent-serve-frontend-integration.md
@@ -101,6 +101,33 @@ When using SSE, `done` and `error` events include `session` as well.
 
 This lets streaming clients keep session state in sync.
 
+### 4) Workspace static file access
+
+The service exposes session-scoped static files from the Box workspace:
+
+```http
+GET /workspace/static/:sessionId/<path>
+```
+
+Auth requirement:
+
+- Provide session token via `x-session-token` header, or
+- Provide `sessionToken` query parameter.
+
+Example:
+
+```http
+GET /workspace/static/sess-.../index.html
+x-session-token: fpst....
+```
+
+Behavior:
+
+- Access is allowed only when `sessionToken` matches `sessionId`.
+- Files are resolved under `/workspace/sessions/<sessionId>/` only.
+- Path traversal is rejected.
+- Directory path falls back to `index.html`.
+
 ## Error codes you must handle
 
 Session contract failures:

--- a/docs/agent-serve-frontend-integration.md
+++ b/docs/agent-serve-frontend-integration.md
@@ -106,32 +106,74 @@ This lets streaming clients keep session state in sync.
 The service exposes session-scoped static files from the Box workspace:
 
 ```http
-GET /workspace/static/:sessionId/<path>
+GET /workspace/static/<path>
 ```
 
 Auth requirement:
 
-- Provide session token via `x-session-token` header, or
-- Provide `sessionToken` query parameter.
+- Provide `x-session-id` header.
+- Provide `x-session-token` header.
 
 Example:
 
 ```http
-GET /workspace/static/sess-.../index.html
+GET /workspace/static/index.html
+x-session-id: sess-...
 x-session-token: fpst....
 ```
 
 Behavior:
 
-- Access is allowed only when `sessionToken` matches `sessionId`.
+- Access is allowed only when `x-session-token` matches `x-session-id`.
 - Files are resolved under `/workspace/sessions/<sessionId>/` only.
 - Path traversal is rejected.
 - Directory path falls back to `index.html`.
+
+### 5) Workspace directory listing
+
+To discover available files before loading static assets:
+
+```http
+GET /workspace/static/list
+```
+
+Optional query:
+
+- `path=<relative-directory>` for listing a sub-directory
+
+Example:
+
+```http
+GET /workspace/static/list?path=src
+x-session-id: sess-...
+x-session-token: fpst....
+```
+
+Response shape:
+
+```json
+{
+  "sessionId": "sess-...",
+  "path": "src",
+  "entries": [
+    {
+      "name": "main.ts",
+      "path": "src/main.ts",
+      "type": "file",
+      "sizeBytes": 128,
+      "mtimeEpochSeconds": 1710000003
+    }
+  ],
+  "truncated": false,
+  "limit": 500
+}
+```
 
 ## Error codes you must handle
 
 Session contract failures:
 
+- `400 SESSION_MISSING_ID`
 - `400 SESSION_MISSING_TOKEN`
 - `400 SESSION_INVALID_INPUT`
 - `400 SESSION_INVALID_ID`

--- a/docs/boxlite-agent-setup.md
+++ b/docs/boxlite-agent-setup.md
@@ -100,6 +100,18 @@ The server runs in the foreground. Leave this terminal open, or run it inside a 
 
 Create a Box using the `node:22-alpine` image with a **persistent disk**. The default ephemeral rootfs is only ~223 MB, which is not enough to install `acpx`, `opencode-ai`, and their dependencies.
 
+Security recommendation:
+
+- Prefer **not** mounting host directories into the Box. Rely on the Box persistent disk instead.
+- Host bind mounts significantly increase blast radius if the sandbox is misconfigured or compromised.
+- Never mount repository root, user home, or sensitive system paths.
+
+Forbidden mount sources (examples):
+
+- `.` / project root (for example `~/code/fiber-pay`)
+- `$HOME` / user home (for example `/Users/alice`)
+- system and secret paths (for example `/etc`, `/var/lib`, `~/.ssh`, cloud credentials dirs)
+
 ```bash
 curl -X POST http://localhost:8100/v1/default/boxes \
   -H 'Content-Type: application/json' \
@@ -142,19 +154,31 @@ curl -X POST http://localhost:8100/v1/default/boxes \
         "dev.to"
       ]
     },
-    "volumes": [
-      {
-        "source": "./agent-workspace",
-        "destination": "/workspace",
-        "mode": "rw"
-      }
-    ],
     "env": {
       "NODE_ENV": "production"
     },
     "memory_mib": 1024,
     "disk_size_gb": 10
   }'
+```
+
+If you must mount a host directory (for explicit file exchange), enforce minimum privilege:
+
+1. Use a dedicated empty directory only for agent exchange (for example `/var/lib/fiber-pay/agent-workspace`).
+2. Do not reuse repository, home, or shared developer directories.
+3. Restrict host permissions to the service user.
+4. Mount read-only when possible.
+
+Example (only when required):
+
+```json
+"volumes": [
+  {
+    "source": "/var/lib/fiber-pay/agent-workspace",
+    "destination": "/workspace",
+    "mode": "rw"
+  }
+]
 ```
 
 Example response:

--- a/packages/cli/src/lib/agent-serve.test.ts
+++ b/packages/cli/src/lib/agent-serve.test.ts
@@ -969,6 +969,7 @@ describe('runAgentServeCommand', () => {
 
       expect(response.status).toBe(200);
       expect(response.headers.get('content-type')).toContain('text/html');
+      expect(response.headers.get('cache-control')).toContain('no-store');
       expect(await response.text()).toBe(html);
 
       server?.close();
@@ -1176,9 +1177,8 @@ describe('runAgentServeCommand', () => {
       );
       expect(listCall).toBeDefined();
       const listScript = ((listCall?.[1] as string[]) || [])[1] || '';
-      expect(listScript).toContain('for ENTRY in');
-      expect(listScript).not.toContain('&& for ENTRY in');
-      expect(listScript).not.toContain('do &&');
+      expect(listScript).toContain('find "$REAL_DIR" -mindepth 1 -maxdepth 1 -print');
+      expect(listScript).toContain('while IFS= read -r ENTRY; do');
 
       server?.close();
     });

--- a/packages/cli/src/lib/agent-serve.test.ts
+++ b/packages/cli/src/lib/agent-serve.test.ts
@@ -933,6 +933,180 @@ describe('runAgentServeCommand', () => {
     });
   });
 
+  describe('GET /workspace/static', () => {
+    beforeEach(() => {
+      queueSuccessfulIsolationPreflight();
+    });
+
+    it('serves a workspace file when session token is valid', async () => {
+      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '', exit_code: 0 });
+      mockExec.mockResolvedValueOnce({ stdout: 'bootstrap', stderr: '', exit_code: 0 });
+      const html = '<!doctype html><h1>ok</h1>';
+      const base64 = Buffer.from(html, 'utf-8').toString('base64');
+      mockExec.mockResolvedValueOnce({
+        stdout: `__META__:${Buffer.byteLength(html, 'utf-8')}:1710000000\n${base64}\n`,
+        stderr: '',
+        exit_code: 0,
+      });
+
+      const { server, url } = await startTestServer();
+
+      const sessionResponse = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ prompt: 'bootstrap' }),
+      });
+      expect(sessionResponse.status).toBe(200);
+      const sessionBody = (await sessionResponse.json()) as { session: unknown };
+      const session = readSession(sessionBody);
+
+      const response = await fetch(`${url}/workspace/static/${session.id}/index.html`, {
+        headers: {
+          'x-session-token': session.token,
+        },
+      });
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get('content-type')).toContain('text/html');
+      expect(await response.text()).toBe(html);
+
+      server?.close();
+    });
+
+    it('rejects workspace static request without session token', async () => {
+      const { server, url } = await startTestServer();
+
+      const response = await fetch(`${url}/workspace/static/sess-test/index.html`);
+
+      expect(response.status).toBe(400);
+      const body = (await response.json()) as { code?: string };
+      expect(body.code).toBe('SESSION_MISSING_TOKEN');
+
+      server?.close();
+    });
+
+    it('rejects workspace static request with tampered session token', async () => {
+      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '', exit_code: 0 });
+      mockExec.mockResolvedValueOnce({ stdout: 'bootstrap', stderr: '', exit_code: 0 });
+
+      const { server, url } = await startTestServer();
+
+      const sessionResponse = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ prompt: 'bootstrap' }),
+      });
+      expect(sessionResponse.status).toBe(200);
+      const sessionBody = (await sessionResponse.json()) as { session: unknown };
+      const session = readSession(sessionBody);
+
+      const response = await fetch(`${url}/workspace/static/${session.id}/index.html`, {
+        headers: {
+          'x-session-token': `${session.token}tampered`,
+        },
+      });
+
+      expect(response.status).toBe(403);
+      const body = (await response.json()) as { code?: string };
+      expect(body.code).toBe('SESSION_INVALID_TOKEN');
+
+      server?.close();
+    });
+
+    it('rejects path traversal for workspace static request', async () => {
+      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '', exit_code: 0 });
+      mockExec.mockResolvedValueOnce({ stdout: 'bootstrap', stderr: '', exit_code: 0 });
+
+      const { server, url } = await startTestServer();
+
+      const sessionResponse = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ prompt: 'bootstrap' }),
+      });
+      expect(sessionResponse.status).toBe(200);
+      const sessionBody = (await sessionResponse.json()) as { session: unknown };
+      const session = readSession(sessionBody);
+
+      const response = await fetch(
+        `${url}/workspace/static/${session.id}/..%2F..%2Fetc%2Fpasswd?sessionToken=${encodeURIComponent(session.token)}`,
+      );
+
+      expect(response.status).toBe(400);
+      const body = (await response.json()) as { code?: string };
+      expect(body.code).toBe('WORKSPACE_STATIC_INVALID_PATH');
+
+      server?.close();
+    });
+
+    it('returns 413 when workspace static file exceeds size limit', async () => {
+      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '', exit_code: 0 });
+      mockExec.mockResolvedValueOnce({ stdout: 'bootstrap', stderr: '', exit_code: 0 });
+      mockExec.mockResolvedValueOnce({
+        stdout: '__ERR__:TOO_LARGE:7340032\n',
+        stderr: '',
+        exit_code: 0,
+      });
+
+      const { server, url } = await startTestServer();
+
+      const sessionResponse = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ prompt: 'bootstrap' }),
+      });
+      expect(sessionResponse.status).toBe(200);
+      const sessionBody = (await sessionResponse.json()) as { session: unknown };
+      const session = readSession(sessionBody);
+
+      const response = await fetch(`${url}/workspace/static/${session.id}/big.bin`, {
+        headers: {
+          'x-session-token': session.token,
+        },
+      });
+
+      expect(response.status).toBe(413);
+      const body = (await response.json()) as { code?: string };
+      expect(body.code).toBe('WORKSPACE_STATIC_TOO_LARGE');
+
+      server?.close();
+    });
+
+    it('falls back to index.html for workspace static directory path', async () => {
+      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '', exit_code: 0 });
+      mockExec.mockResolvedValueOnce({ stdout: 'bootstrap', stderr: '', exit_code: 0 });
+      const html = '<html>index</html>';
+      const base64 = Buffer.from(html, 'utf-8').toString('base64');
+      mockExec.mockResolvedValueOnce({
+        stdout: `__META__:${Buffer.byteLength(html, 'utf-8')}:1710000000\n${base64}\n`,
+        stderr: '',
+        exit_code: 0,
+      });
+
+      const { server, url } = await startTestServer();
+
+      const sessionResponse = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ prompt: 'bootstrap' }),
+      });
+      expect(sessionResponse.status).toBe(200);
+      const sessionBody = (await sessionResponse.json()) as { session: unknown };
+      const session = readSession(sessionBody);
+
+      const response = await fetch(`${url}/workspace/static/${session.id}/`, {
+        headers: {
+          'x-session-token': session.token,
+        },
+      });
+
+      expect(response.status).toBe(200);
+      expect(await response.text()).toBe(html);
+
+      server?.close();
+    });
+  });
+
   // ---------------------------------------------------------------------------
   // Isolation-specific behaviour
   // ---------------------------------------------------------------------------

--- a/packages/cli/src/lib/agent-serve.test.ts
+++ b/packages/cli/src/lib/agent-serve.test.ts
@@ -960,8 +960,9 @@ describe('runAgentServeCommand', () => {
       const sessionBody = (await sessionResponse.json()) as { session: unknown };
       const session = readSession(sessionBody);
 
-      const response = await fetch(`${url}/workspace/static/${session.id}/index.html`, {
+      const response = await fetch(`${url}/workspace/static/index.html`, {
         headers: {
+          'x-session-id': session.id,
           'x-session-token': session.token,
         },
       });
@@ -976,7 +977,11 @@ describe('runAgentServeCommand', () => {
     it('rejects workspace static request without session token', async () => {
       const { server, url } = await startTestServer();
 
-      const response = await fetch(`${url}/workspace/static/sess-test/index.html`);
+      const response = await fetch(`${url}/workspace/static/index.html`, {
+        headers: {
+          'x-session-id': 'sess-test',
+        },
+      });
 
       expect(response.status).toBe(400);
       const body = (await response.json()) as { code?: string };
@@ -1000,8 +1005,9 @@ describe('runAgentServeCommand', () => {
       const sessionBody = (await sessionResponse.json()) as { session: unknown };
       const session = readSession(sessionBody);
 
-      const response = await fetch(`${url}/workspace/static/${session.id}/index.html`, {
+      const response = await fetch(`${url}/workspace/static/index.html`, {
         headers: {
+          'x-session-id': session.id,
           'x-session-token': `${session.token}tampered`,
         },
       });
@@ -1028,9 +1034,12 @@ describe('runAgentServeCommand', () => {
       const sessionBody = (await sessionResponse.json()) as { session: unknown };
       const session = readSession(sessionBody);
 
-      const response = await fetch(
-        `${url}/workspace/static/${session.id}/..%2F..%2Fetc%2Fpasswd?sessionToken=${encodeURIComponent(session.token)}`,
-      );
+      const response = await fetch(`${url}/workspace/static/..%2F..%2Fetc%2Fpasswd`, {
+        headers: {
+          'x-session-id': session.id,
+          'x-session-token': session.token,
+        },
+      });
 
       expect(response.status).toBe(400);
       const body = (await response.json()) as { code?: string };
@@ -1059,8 +1068,9 @@ describe('runAgentServeCommand', () => {
       const sessionBody = (await sessionResponse.json()) as { session: unknown };
       const session = readSession(sessionBody);
 
-      const response = await fetch(`${url}/workspace/static/${session.id}/big.bin`, {
+      const response = await fetch(`${url}/workspace/static/big.bin`, {
         headers: {
+          'x-session-id': session.id,
           'x-session-token': session.token,
         },
       });
@@ -1094,14 +1104,186 @@ describe('runAgentServeCommand', () => {
       const sessionBody = (await sessionResponse.json()) as { session: unknown };
       const session = readSession(sessionBody);
 
-      const response = await fetch(`${url}/workspace/static/${session.id}/`, {
+      const response = await fetch(`${url}/workspace/static`, {
         headers: {
+          'x-session-id': session.id,
           'x-session-token': session.token,
         },
       });
 
       expect(response.status).toBe(200);
       expect(await response.text()).toBe(html);
+
+      server?.close();
+    });
+  });
+
+  describe('GET /workspace/static/list', () => {
+    beforeEach(() => {
+      queueSuccessfulIsolationPreflight();
+    });
+
+    it('lists root workspace directory entries when session token is valid', async () => {
+      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '', exit_code: 0 });
+      mockExec.mockResolvedValueOnce({ stdout: 'bootstrap', stderr: '', exit_code: 0 });
+      const dirName = Buffer.from('assets', 'utf-8').toString('base64');
+      const fileName = Buffer.from('index.html', 'utf-8').toString('base64');
+      mockExec.mockResolvedValueOnce({
+        stdout:
+          `__ENTRY__:${dirName}:dir:0:1710000001\n` +
+          `__ENTRY__:${fileName}:file:512:1710000002\n` +
+          '__TRUNCATED__:0\n',
+        stderr: '',
+        exit_code: 0,
+      });
+
+      const { server, url } = await startTestServer();
+
+      const sessionResponse = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ prompt: 'bootstrap' }),
+      });
+      expect(sessionResponse.status).toBe(200);
+      const sessionBody = (await sessionResponse.json()) as { session: unknown };
+      const session = readSession(sessionBody);
+
+      const response = await fetch(`${url}/workspace/static/list`, {
+        headers: {
+          'x-session-id': session.id,
+          'x-session-token': session.token,
+        },
+      });
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get('cache-control')).toContain('no-store');
+      const body = (await response.json()) as {
+        entries: Array<{ name: string; path: string; type: string }>;
+        truncated: boolean;
+      };
+      expect(body.truncated).toBe(false);
+      expect(body.entries.map((entry) => entry.name)).toEqual(['assets', 'index.html']);
+      expect(body.entries[0]?.type).toBe('dir');
+      expect(body.entries[1]?.path).toBe('index.html');
+
+      const listCall = mockExec.mock.calls.find(
+        (call) =>
+          call[0] === 'sh' &&
+          Array.isArray(call[1]) &&
+          (call[1] as string[])[0] === '-c' &&
+          typeof (call[1] as string[])[1] === 'string' &&
+          ((call[1] as string[])[1] as string).includes('__ENTRY__'),
+      );
+      expect(listCall).toBeDefined();
+      const listScript = ((listCall?.[1] as string[]) || [])[1] || '';
+      expect(listScript).toContain('for ENTRY in');
+      expect(listScript).not.toContain('&& for ENTRY in');
+      expect(listScript).not.toContain('do &&');
+
+      server?.close();
+    });
+
+    it('lists sub-directory when path query is provided', async () => {
+      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '', exit_code: 0 });
+      mockExec.mockResolvedValueOnce({ stdout: 'bootstrap', stderr: '', exit_code: 0 });
+      const fileName = Buffer.from('main.ts', 'utf-8').toString('base64');
+      mockExec.mockResolvedValueOnce({
+        stdout: `__ENTRY__:${fileName}:file:128:1710000003\n__TRUNCATED__:0\n`,
+        stderr: '',
+        exit_code: 0,
+      });
+
+      const { server, url } = await startTestServer();
+
+      const sessionResponse = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ prompt: 'bootstrap' }),
+      });
+      const sessionBody = (await sessionResponse.json()) as { session: unknown };
+      const session = readSession(sessionBody);
+
+      const response = await fetch(
+        `${url}/workspace/static/list?path=${encodeURIComponent('src')}`,
+        {
+          headers: {
+            'x-session-id': session.id,
+            'x-session-token': session.token,
+          },
+        },
+      );
+
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as { path: string; entries: Array<{ path: string }> };
+      expect(body.path).toBe('src');
+      expect(body.entries[0]?.path).toBe('src/main.ts');
+
+      server?.close();
+    });
+
+    it('rejects directory listing with invalid path traversal query', async () => {
+      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '', exit_code: 0 });
+      mockExec.mockResolvedValueOnce({ stdout: 'bootstrap', stderr: '', exit_code: 0 });
+
+      const { server, url } = await startTestServer();
+
+      const sessionResponse = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ prompt: 'bootstrap' }),
+      });
+      const sessionBody = (await sessionResponse.json()) as { session: unknown };
+      const session = readSession(sessionBody);
+
+      const response = await fetch(
+        `${url}/workspace/static/list?path=${encodeURIComponent('../etc')}`,
+        {
+          headers: {
+            'x-session-id': session.id,
+            'x-session-token': session.token,
+          },
+        },
+      );
+
+      expect(response.status).toBe(400);
+      const body = (await response.json()) as { code?: string };
+      expect(body.code).toBe('WORKSPACE_LIST_INVALID_PATH');
+
+      server?.close();
+    });
+
+    it('returns 400 when listing path points to a file', async () => {
+      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '', exit_code: 0 });
+      mockExec.mockResolvedValueOnce({ stdout: 'bootstrap', stderr: '', exit_code: 0 });
+      mockExec.mockResolvedValueOnce({
+        stdout: '__ERR__:NOT_DIRECTORY\n',
+        stderr: '',
+        exit_code: 0,
+      });
+
+      const { server, url } = await startTestServer();
+
+      const sessionResponse = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ prompt: 'bootstrap' }),
+      });
+      const sessionBody = (await sessionResponse.json()) as { session: unknown };
+      const session = readSession(sessionBody);
+
+      const response = await fetch(
+        `${url}/workspace/static/list?path=${encodeURIComponent('index.html')}`,
+        {
+          headers: {
+            'x-session-id': session.id,
+            'x-session-token': session.token,
+          },
+        },
+      );
+
+      expect(response.status).toBe(400);
+      const body = (await response.json()) as { code?: string };
+      expect(body.code).toBe('WORKSPACE_LIST_NOT_DIRECTORY');
 
       server?.close();
     });

--- a/packages/cli/src/lib/agent-serve.ts
+++ b/packages/cli/src/lib/agent-serve.ts
@@ -88,6 +88,20 @@ interface WorkspaceStaticFile {
   mtimeEpochSeconds: number;
 }
 
+interface WorkspaceDirectoryEntry {
+  name: string;
+  path: string;
+  type: 'file' | 'dir' | 'symlink';
+  sizeBytes: number;
+  mtimeEpochSeconds: number;
+}
+
+interface WorkspaceDirectoryListing {
+  path: string;
+  entries: WorkspaceDirectoryEntry[];
+  truncated: boolean;
+}
+
 type WorkspaceStaticReadResult =
   | { ok: true; file: WorkspaceStaticFile }
   | {
@@ -102,9 +116,23 @@ type WorkspaceStaticReadResult =
       message?: string;
     };
 
+type WorkspaceDirectoryListResult =
+  | { ok: true; listing: WorkspaceDirectoryListing }
+  | {
+      ok: false;
+      code:
+        | 'SESSION_NOT_FOUND'
+        | 'NOT_FOUND'
+        | 'NOT_DIRECTORY'
+        | 'PATH_OUTSIDE_SESSION'
+        | 'EXEC_FAILED';
+      message?: string;
+    };
+
 const SESSION_TOKEN_PREFIX = 'fpst';
 const MIN_SESSION_TOKEN_TTL_SECONDS = 300;
 const MAX_STATIC_FILE_BYTES = 5 * 1024 * 1024;
+const MAX_DIRECTORY_LIST_ENTRIES = 500;
 const RECONNECT_PATTERN = /agent needs reconnect/i;
 const SECCOMP_NOT_AVAILABLE_PATTERN = /\bseccomp\b.*\bnot available\b/i;
 
@@ -473,13 +501,65 @@ function getStaticRequestSessionToken(req: express.Request): string | undefined 
     return headerToken.trim();
   }
 
-  const queryToken = req.query?.sessionToken;
-  const token = Array.isArray(queryToken) ? queryToken[0] : queryToken;
-  if (typeof token === 'string' && token.trim().length > 0) {
-    return token.trim();
+  return undefined;
+}
+
+function getStaticRequestSessionId(req: express.Request): string | undefined {
+  const fromHeader = req.headers['x-session-id'];
+  const headerSessionId = Array.isArray(fromHeader) ? fromHeader[0] : fromHeader;
+  if (typeof headerSessionId === 'string' && headerSessionId.trim().length > 0) {
+    return headerSessionId.trim();
   }
 
   return undefined;
+}
+
+function resolveWorkspaceSessionAccess(
+  rawSessionId: string | string[] | undefined,
+  sessionToken: string | undefined,
+  secret: Buffer,
+): { ok: true; sessionId: string } | { ok: false; status: number; code: string; message: string } {
+  const rawSessionIdValue = Array.isArray(rawSessionId) ? rawSessionId[0] : rawSessionId;
+  const sessionId = typeof rawSessionIdValue === 'string' ? rawSessionIdValue.trim() : '';
+
+  if (sessionId.length === 0) {
+    return {
+      ok: false,
+      status: 400,
+      code: 'SESSION_MISSING_ID',
+      message: 'Missing session id. Provide x-session-id header.',
+    };
+  }
+
+  if (!isValidSessionId(sessionId)) {
+    return {
+      ok: false,
+      status: 400,
+      code: 'SESSION_INVALID_ID',
+      message: 'Invalid "sessionId" format.',
+    };
+  }
+
+  if (!sessionToken) {
+    return {
+      ok: false,
+      status: 400,
+      code: 'SESSION_MISSING_TOKEN',
+      message: 'Missing session token. Provide x-session-token header.',
+    };
+  }
+
+  const tokenVerifyResult = verifySessionToken(sessionId, sessionToken, secret);
+  if (!tokenVerifyResult.valid) {
+    return {
+      ok: false,
+      status: 403,
+      code: 'SESSION_INVALID_TOKEN',
+      message: tokenVerifyResult.reason,
+    };
+  }
+
+  return { ok: true, sessionId };
 }
 
 function normalizeWorkspaceStaticPath(rawPath: string | undefined): string | undefined {
@@ -494,6 +574,32 @@ function normalizeWorkspaceStaticPath(rawPath: string | undefined): string | und
 
   const normalized = pathPosix.normalize(candidate);
   if (normalized.length === 0 || normalized === '.' || normalized === '..') {
+    return undefined;
+  }
+
+  if (
+    pathPosix.isAbsolute(normalized) ||
+    normalized.startsWith('../') ||
+    normalized.includes('/../')
+  ) {
+    return undefined;
+  }
+
+  return normalized;
+}
+
+function normalizeWorkspaceDirectoryPath(rawPath: string | undefined): string | undefined {
+  if (rawPath?.includes('\0')) {
+    return undefined;
+  }
+
+  const candidate = (rawPath || '').replace(/\\/g, '/').replace(/^\/+/, '').replace(/\/+$/, '');
+  if (candidate.length === 0) {
+    return '';
+  }
+
+  const normalized = pathPosix.normalize(candidate);
+  if (normalized === '.' || normalized === '..') {
     return undefined;
   }
 
@@ -619,6 +725,132 @@ async function readWorkspaceStaticFile(
       content,
       sizeBytes: Number.isFinite(sizeBytes) ? sizeBytes : content.length,
       mtimeEpochSeconds: Number.isFinite(mtimeEpochSeconds) ? mtimeEpochSeconds : 0,
+    },
+  };
+}
+
+async function listWorkspaceDirectory(
+  client: BoxliteClient,
+  sessionId: string,
+  relativeDirPath: string,
+  maxEntries: number,
+): Promise<WorkspaceDirectoryListResult> {
+  const safeSessionId = sanitizeSessionId(sessionId);
+  const sessionDir = `/workspace/sessions/${safeSessionId}`;
+  const sessionDirQuoted = shellQuote(sessionDir).trimEnd();
+  const relativeDirQuoted = shellQuote(relativeDirPath).trimEnd();
+
+  const result = await client.exec(
+    'sh',
+    [
+      '-c',
+      [
+        'set -eu',
+        `SESSION_DIR=${sessionDirQuoted}`,
+        `REL_DIR=${relativeDirQuoted}`,
+        `MAX_ENTRIES=${Math.floor(maxEntries)}`,
+        'BASE="$(readlink -f "$SESSION_DIR" 2>/dev/null || true)"',
+        'if [ -z "$BASE" ]; then echo "__ERR__:SESSION_NOT_FOUND"; exit 0; fi',
+        'TARGET="$BASE"',
+        'if [ -n "$REL_DIR" ]; then TARGET="$BASE/$REL_DIR"; fi',
+        'REAL_DIR="$(readlink -f "$TARGET" 2>/dev/null || true)"',
+        'if [ -z "$REAL_DIR" ]; then echo "__ERR__:NOT_FOUND"; exit 0; fi',
+        'case "$REAL_DIR" in "$BASE"|"$BASE"/*) ;; *) echo "__ERR__:PATH_OUTSIDE_SESSION"; exit 0 ;; esac',
+        'if [ ! -d "$REAL_DIR" ]; then echo "__ERR__:NOT_DIRECTORY"; exit 0; fi',
+        'TRUNCATED=0',
+        'COUNT=0',
+        'for ENTRY in "$REAL_DIR"/* "$REAL_DIR"/.*; do',
+        '  [ -e "$ENTRY" ] || continue',
+        '  NAME="$(basename "$ENTRY")"',
+        '  [ "$NAME" = "." ] && continue',
+        '  [ "$NAME" = ".." ] && continue',
+        '  if [ "$COUNT" -ge "$MAX_ENTRIES" ]; then TRUNCATED=1; break; fi',
+        '  COUNT=$((COUNT + 1))',
+        '  if [ -L "$ENTRY" ]; then TYPE="symlink"; SIZE=0;',
+        '  elif [ -d "$ENTRY" ]; then TYPE="dir"; SIZE=0;',
+        '  else TYPE="file"; SIZE="$(wc -c < "$ENTRY" | tr -d "[:space:]")"; fi',
+        '  [ -z "$SIZE" ] && SIZE=0',
+        '  MTIME="$(stat -c %Y "$ENTRY" 2>/dev/null || stat -f %m "$ENTRY" 2>/dev/null || echo 0)"',
+        '  NAME_B64="$(printf %s "$NAME" | base64 | tr -d "\\n")"',
+        '  printf "__ENTRY__:%s:%s:%s:%s\\n" "$NAME_B64" "$TYPE" "$SIZE" "$MTIME"',
+        'done',
+        'printf "__TRUNCATED__:%s\\n" "$TRUNCATED"',
+      ].join('\n'),
+    ],
+    { timeout: 30 },
+  );
+
+  if (result.exit_code !== 0) {
+    return {
+      ok: false,
+      code: 'EXEC_FAILED',
+      message: result.stderr.trim().slice(0, 300),
+    };
+  }
+
+  const lines = result.stdout
+    .replace(/\r/g, '')
+    .split('\n')
+    .filter((line) => line.length > 0);
+  const firstLine = lines[0] || '';
+
+  if (firstLine.startsWith('__ERR__:')) {
+    const detail = firstLine.slice('__ERR__:'.length);
+    if (detail === 'SESSION_NOT_FOUND') return { ok: false, code: 'SESSION_NOT_FOUND' };
+    if (detail === 'NOT_FOUND') return { ok: false, code: 'NOT_FOUND' };
+    if (detail === 'NOT_DIRECTORY') return { ok: false, code: 'NOT_DIRECTORY' };
+    if (detail === 'PATH_OUTSIDE_SESSION') return { ok: false, code: 'PATH_OUTSIDE_SESSION' };
+    return { ok: false, code: 'EXEC_FAILED', message: detail };
+  }
+
+  const entries: WorkspaceDirectoryEntry[] = [];
+  let truncated = false;
+
+  for (const line of lines) {
+    if (line.startsWith('__ENTRY__:')) {
+      const payload = line.slice('__ENTRY__:'.length);
+      const [nameB64 = '', type = 'file', sizePart = '0', mtimePart = '0'] = payload.split(':');
+
+      let name = '';
+      try {
+        name = Buffer.from(nameB64, 'base64').toString('utf-8');
+      } catch {
+        name = '';
+      }
+
+      if (name.length === 0) {
+        continue;
+      }
+
+      const sizeBytes = Number.parseInt(sizePart, 10);
+      const mtimeEpochSeconds = Number.parseInt(mtimePart, 10);
+      const normalizedType: WorkspaceDirectoryEntry['type'] =
+        type === 'dir' || type === 'symlink' ? type : 'file';
+      const relativePath = relativeDirPath.length > 0 ? `${relativeDirPath}/${name}` : name;
+
+      entries.push({
+        name,
+        path: relativePath,
+        type: normalizedType,
+        sizeBytes: Number.isFinite(sizeBytes) ? sizeBytes : 0,
+        mtimeEpochSeconds: Number.isFinite(mtimeEpochSeconds) ? mtimeEpochSeconds : 0,
+      });
+      continue;
+    }
+
+    if (line === '__TRUNCATED__:1') {
+      truncated = true;
+    }
+  }
+
+  entries.sort((left, right) => left.name.localeCompare(right.name));
+
+  return {
+    ok: true,
+    listing: {
+      path: relativeDirPath,
+      entries,
+      truncated,
     },
   };
 }
@@ -1474,33 +1706,122 @@ PROXYEOF`,
   });
 
   // L402 payment gate on all routes
+  const serveWorkspaceDirectoryList = async (req: AgentServeRequest, res: express.Response) => {
+    const requestId = getRequestId(req);
+    const sessionId = getStaticRequestSessionId(req);
+    const sessionToken = getStaticRequestSessionToken(req);
+    const sessionAccess = resolveWorkspaceSessionAccess(
+      sessionId,
+      sessionToken,
+      sessionSigningSecret,
+    );
+
+    if (!sessionAccess.ok) {
+      res.status(sessionAccess.status).json({
+        error: sessionAccess.message,
+        code: sessionAccess.code,
+      });
+      return;
+    }
+
+    const rawPathParam = req.query.path;
+    const rawPath = Array.isArray(rawPathParam) ? rawPathParam[0] : rawPathParam;
+    const relativeDirPath = normalizeWorkspaceDirectoryPath(
+      typeof rawPath === 'string' ? rawPath : undefined,
+    );
+
+    if (relativeDirPath === undefined) {
+      res.status(400).json({
+        error: 'Invalid workspace directory path.',
+        code: 'WORKSPACE_LIST_INVALID_PATH',
+      });
+      return;
+    }
+
+    try {
+      const listingResult = await listWorkspaceDirectory(
+        client,
+        sessionAccess.sessionId,
+        relativeDirPath,
+        MAX_DIRECTORY_LIST_ENTRIES,
+      );
+
+      if (!listingResult.ok) {
+        if (!asJson) {
+          console.log(
+            `[REQ ${requestId}] workspace list failed session=${sessionAccess.sessionId} path=${relativeDirPath} code=${listingResult.code}`,
+          );
+        }
+
+        if (listingResult.code === 'SESSION_NOT_FOUND' || listingResult.code === 'NOT_FOUND') {
+          res.status(404).json({
+            error: 'Workspace directory not found.',
+            code: 'WORKSPACE_LIST_NOT_FOUND',
+          });
+          return;
+        }
+
+        if (listingResult.code === 'NOT_DIRECTORY') {
+          res.status(400).json({
+            error: 'Requested path is not a directory.',
+            code: 'WORKSPACE_LIST_NOT_DIRECTORY',
+          });
+          return;
+        }
+
+        if (listingResult.code === 'PATH_OUTSIDE_SESSION') {
+          res.status(403).json({
+            error: 'Path escapes session workspace.',
+            code: 'WORKSPACE_LIST_FORBIDDEN',
+          });
+          return;
+        }
+
+        res.status(502).json({
+          error: 'Failed to list workspace directory from BoxLite.',
+          code: 'WORKSPACE_LIST_FAILED',
+          details: listingResult.message,
+        });
+        return;
+      }
+
+      res.setHeader('Cache-Control', 'no-store, no-cache, must-revalidate');
+      res.setHeader('Pragma', 'no-cache');
+      res.json({
+        sessionId: sessionAccess.sessionId,
+        path: listingResult.listing.path,
+        entries: listingResult.listing.entries,
+        truncated: listingResult.listing.truncated,
+        limit: MAX_DIRECTORY_LIST_ENTRIES,
+      });
+    } catch (error) {
+      if (!asJson) {
+        console.log(
+          `[REQ ${requestId}] workspace list error session=${sessionAccess.sessionId} path=${relativeDirPath}: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+
+      res.status(502).json({
+        error: 'Failed to list workspace directory from BoxLite.',
+        code: 'WORKSPACE_LIST_FAILED',
+      });
+    }
+  };
+
   const serveWorkspaceStatic = async (req: AgentServeRequest, res: express.Response) => {
     const requestId = getRequestId(req);
-    const rawSessionId = req.params.sessionId;
-    const sessionId = typeof rawSessionId === 'string' ? rawSessionId.trim() : '';
+    const sessionId = getStaticRequestSessionId(req);
     const sessionToken = getStaticRequestSessionToken(req);
+    const sessionAccess = resolveWorkspaceSessionAccess(
+      sessionId,
+      sessionToken,
+      sessionSigningSecret,
+    );
 
-    if (!isValidSessionId(sessionId)) {
-      res.status(400).json({
-        error: 'Invalid "sessionId" format.',
-        code: 'SESSION_INVALID_ID',
-      });
-      return;
-    }
-
-    if (!sessionToken) {
-      res.status(400).json({
-        error: 'Missing session token. Provide x-session-token header or sessionToken query param.',
-        code: 'SESSION_MISSING_TOKEN',
-      });
-      return;
-    }
-
-    const tokenVerifyResult = verifySessionToken(sessionId, sessionToken, sessionSigningSecret);
-    if (!tokenVerifyResult.valid) {
-      res.status(403).json({
-        error: tokenVerifyResult.reason,
-        code: 'SESSION_INVALID_TOKEN',
+    if (!sessionAccess.ok) {
+      res.status(sessionAccess.status).json({
+        error: sessionAccess.message,
+        code: sessionAccess.code,
       });
       return;
     }
@@ -1523,7 +1844,7 @@ PROXYEOF`,
     try {
       const fileReadResult = await readWorkspaceStaticFile(
         client,
-        sessionId,
+        sessionAccess.sessionId,
         relativePath,
         MAX_STATIC_FILE_BYTES,
       );
@@ -1531,7 +1852,7 @@ PROXYEOF`,
       if (!fileReadResult.ok) {
         if (!asJson) {
           console.log(
-            `[REQ ${requestId}] workspace static read failed session=${sessionId} path=${relativePath} code=${fileReadResult.code}`,
+            `[REQ ${requestId}] workspace static read failed session=${sessionAccess.sessionId} path=${relativePath} code=${fileReadResult.code}`,
           );
         }
 
@@ -1579,7 +1900,7 @@ PROXYEOF`,
     } catch (error) {
       if (!asJson) {
         console.log(
-          `[REQ ${requestId}] workspace static read error session=${sessionId} path=${relativePath}: ${error instanceof Error ? error.message : String(error)}`,
+          `[REQ ${requestId}] workspace static read error session=${sessionAccess.sessionId} path=${relativePath}: ${error instanceof Error ? error.message : String(error)}`,
         );
       }
       res.status(502).json({
@@ -1589,8 +1910,9 @@ PROXYEOF`,
     }
   };
 
-  app.get('/workspace/static/:sessionId', serveWorkspaceStatic);
-  app.get('/workspace/static/:sessionId/*filePath', serveWorkspaceStatic);
+  app.get('/workspace/static/list', serveWorkspaceDirectoryList);
+  app.get('/workspace/static', serveWorkspaceStatic);
+  app.get('/workspace/static/*filePath', serveWorkspaceStatic);
 
   // L402 payment gate on all paid routes
   app.use(

--- a/packages/cli/src/lib/agent-serve.ts
+++ b/packages/cli/src/lib/agent-serve.ts
@@ -26,6 +26,7 @@
 
 import { createHmac, randomUUID, timingSafeEqual } from 'node:crypto';
 import { createServer, type Server } from 'node:http';
+import { extname, posix as pathPosix } from 'node:path';
 import type { Currency } from '@fiber-pay/sdk';
 import { createL402Middleware, FiberRpcClient } from '@fiber-pay/sdk/node';
 import cors from 'cors';
@@ -81,10 +82,54 @@ interface SessionTokenPayload {
   exp: number;
 }
 
+interface WorkspaceStaticFile {
+  content: Buffer;
+  sizeBytes: number;
+  mtimeEpochSeconds: number;
+}
+
+type WorkspaceStaticReadResult =
+  | { ok: true; file: WorkspaceStaticFile }
+  | {
+      ok: false;
+      code:
+        | 'SESSION_NOT_FOUND'
+        | 'NOT_FOUND'
+        | 'PATH_OUTSIDE_SESSION'
+        | 'TOO_LARGE'
+        | 'EXEC_FAILED';
+      sizeBytes?: number;
+      message?: string;
+    };
+
 const SESSION_TOKEN_PREFIX = 'fpst';
 const MIN_SESSION_TOKEN_TTL_SECONDS = 300;
+const MAX_STATIC_FILE_BYTES = 5 * 1024 * 1024;
 const RECONNECT_PATTERN = /agent needs reconnect/i;
 const SECCOMP_NOT_AVAILABLE_PATTERN = /\bseccomp\b.*\bnot available\b/i;
+
+const STATIC_CONTENT_TYPE_BY_EXT: Record<string, string> = {
+  '.html': 'text/html; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.js': 'application/javascript; charset=utf-8',
+  '.mjs': 'application/javascript; charset=utf-8',
+  '.cjs': 'application/javascript; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.map': 'application/json; charset=utf-8',
+  '.txt': 'text/plain; charset=utf-8',
+  '.svg': 'image/svg+xml',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.webp': 'image/webp',
+  '.ico': 'image/x-icon',
+  '.wasm': 'application/wasm',
+  '.woff': 'font/woff',
+  '.woff2': 'font/woff2',
+  '.ttf': 'font/ttf',
+  '.otf': 'font/otf',
+};
 
 function getClientIp(req: AgentServeRequest): string {
   const forwarded = req.headers['x-forwarded-for'];
@@ -417,6 +462,163 @@ function resolveSessionCredentials(
       sessionId,
       sessionToken,
       created: false,
+    },
+  };
+}
+
+function getStaticRequestSessionToken(req: express.Request): string | undefined {
+  const fromHeader = req.headers['x-session-token'];
+  const headerToken = Array.isArray(fromHeader) ? fromHeader[0] : fromHeader;
+  if (typeof headerToken === 'string' && headerToken.trim().length > 0) {
+    return headerToken.trim();
+  }
+
+  const queryToken = req.query?.sessionToken;
+  const token = Array.isArray(queryToken) ? queryToken[0] : queryToken;
+  if (typeof token === 'string' && token.trim().length > 0) {
+    return token.trim();
+  }
+
+  return undefined;
+}
+
+function normalizeWorkspaceStaticPath(rawPath: string | undefined): string | undefined {
+  if (rawPath?.includes('\0')) {
+    return undefined;
+  }
+
+  let candidate = (rawPath || '').replace(/\\/g, '/').replace(/^\/+/, '');
+  if (candidate.length === 0 || candidate.endsWith('/')) {
+    candidate = `${candidate}index.html`;
+  }
+
+  const normalized = pathPosix.normalize(candidate);
+  if (normalized.length === 0 || normalized === '.' || normalized === '..') {
+    return undefined;
+  }
+
+  if (
+    pathPosix.isAbsolute(normalized) ||
+    normalized.startsWith('../') ||
+    normalized.includes('/../')
+  ) {
+    return undefined;
+  }
+
+  return normalized;
+}
+
+function getStaticContentType(filePath: string): string {
+  const ext = extname(filePath).toLowerCase();
+  return STATIC_CONTENT_TYPE_BY_EXT[ext] || 'application/octet-stream';
+}
+
+async function readWorkspaceStaticFile(
+  client: BoxliteClient,
+  sessionId: string,
+  relativePath: string,
+  maxBytes: number,
+): Promise<WorkspaceStaticReadResult> {
+  const safeSessionId = sanitizeSessionId(sessionId);
+  const sessionDir = `/workspace/sessions/${safeSessionId}`;
+  const sessionDirQuoted = shellQuote(sessionDir).trimEnd();
+  const relativePathQuoted = shellQuote(relativePath).trimEnd();
+
+  const result = await client.exec(
+    'sh',
+    [
+      '-c',
+      [
+        'set -eu',
+        `SESSION_DIR=${sessionDirQuoted}`,
+        `REL_PATH=${relativePathQuoted}`,
+        `MAX_BYTES=${Math.floor(maxBytes)}`,
+        'BASE="$(readlink -f "$SESSION_DIR" 2>/dev/null || true)"',
+        'if [ -z "$BASE" ]; then echo "__ERR__:SESSION_NOT_FOUND"; exit 0; fi',
+        'TARGET="$BASE/$REL_PATH"',
+        'REAL_TARGET="$(readlink -f "$TARGET" 2>/dev/null || true)"',
+        'if [ -z "$REAL_TARGET" ]; then echo "__ERR__:NOT_FOUND"; exit 0; fi',
+        'case "$REAL_TARGET" in "$BASE"|"$BASE"/*) ;; *) echo "__ERR__:PATH_OUTSIDE_SESSION"; exit 0 ;; esac',
+        'if [ -d "$REAL_TARGET" ]; then REAL_TARGET="$REAL_TARGET/index.html"; fi',
+        'if [ ! -f "$REAL_TARGET" ]; then echo "__ERR__:NOT_FOUND"; exit 0; fi',
+        'SIZE="$(wc -c < "$REAL_TARGET" | tr -d "[:space:]")"',
+        'if [ -z "$SIZE" ]; then SIZE=0; fi',
+        'if [ "$SIZE" -gt "$MAX_BYTES" ]; then echo "__ERR__:TOO_LARGE:$SIZE"; exit 0; fi',
+        'MTIME="$(stat -c %Y "$REAL_TARGET" 2>/dev/null || stat -f %m "$REAL_TARGET" 2>/dev/null || echo 0)"',
+        'printf "__META__:%s:%s\\n" "$SIZE" "$MTIME"',
+        'base64 "$REAL_TARGET"',
+      ].join(' && '),
+    ],
+    { timeout: 30 },
+  );
+
+  if (result.exit_code !== 0) {
+    return {
+      ok: false,
+      code: 'EXEC_FAILED',
+      message: result.stderr.trim().slice(0, 300),
+    };
+  }
+
+  const lines = result.stdout.replace(/\r/g, '').split('\n');
+  const firstLine = (lines.shift() || '').trim();
+
+  if (firstLine.startsWith('__ERR__:')) {
+    const detail = firstLine.slice('__ERR__:'.length);
+    if (detail === 'SESSION_NOT_FOUND') {
+      return { ok: false, code: 'SESSION_NOT_FOUND' };
+    }
+    if (detail === 'NOT_FOUND') {
+      return { ok: false, code: 'NOT_FOUND' };
+    }
+    if (detail === 'PATH_OUTSIDE_SESSION') {
+      return { ok: false, code: 'PATH_OUTSIDE_SESSION' };
+    }
+    if (detail.startsWith('TOO_LARGE:')) {
+      const rawSize = detail.slice('TOO_LARGE:'.length);
+      const sizeBytes = Number.parseInt(rawSize, 10);
+      return {
+        ok: false,
+        code: 'TOO_LARGE',
+        sizeBytes: Number.isFinite(sizeBytes) ? sizeBytes : undefined,
+      };
+    }
+
+    return {
+      ok: false,
+      code: 'EXEC_FAILED',
+      message: detail,
+    };
+  }
+
+  if (!firstLine.startsWith('__META__:')) {
+    return {
+      ok: false,
+      code: 'EXEC_FAILED',
+      message: 'Unexpected workspace static response format.',
+    };
+  }
+
+  const [, sizePart = '0', mtimePart = '0'] = firstLine.split(':');
+  const sizeBytes = Number.parseInt(sizePart, 10);
+  const mtimeEpochSeconds = Number.parseInt(mtimePart, 10);
+  const base64Payload = lines.join('').trim();
+  const content = Buffer.from(base64Payload, 'base64');
+
+  if (Number.isFinite(sizeBytes) && content.length !== sizeBytes) {
+    return {
+      ok: false,
+      code: 'EXEC_FAILED',
+      message: 'Workspace static file size mismatch.',
+    };
+  }
+
+  return {
+    ok: true,
+    file: {
+      content,
+      sizeBytes: Number.isFinite(sizeBytes) ? sizeBytes : content.length,
+      mtimeEpochSeconds: Number.isFinite(mtimeEpochSeconds) ? mtimeEpochSeconds : 0,
     },
   };
 }
@@ -1272,6 +1474,125 @@ PROXYEOF`,
   });
 
   // L402 payment gate on all routes
+  const serveWorkspaceStatic = async (req: AgentServeRequest, res: express.Response) => {
+    const requestId = getRequestId(req);
+    const rawSessionId = req.params.sessionId;
+    const sessionId = typeof rawSessionId === 'string' ? rawSessionId.trim() : '';
+    const sessionToken = getStaticRequestSessionToken(req);
+
+    if (!isValidSessionId(sessionId)) {
+      res.status(400).json({
+        error: 'Invalid "sessionId" format.',
+        code: 'SESSION_INVALID_ID',
+      });
+      return;
+    }
+
+    if (!sessionToken) {
+      res.status(400).json({
+        error: 'Missing session token. Provide x-session-token header or sessionToken query param.',
+        code: 'SESSION_MISSING_TOKEN',
+      });
+      return;
+    }
+
+    const tokenVerifyResult = verifySessionToken(sessionId, sessionToken, sessionSigningSecret);
+    if (!tokenVerifyResult.valid) {
+      res.status(403).json({
+        error: tokenVerifyResult.reason,
+        code: 'SESSION_INVALID_TOKEN',
+      });
+      return;
+    }
+
+    const wildcardParam = req.params.filePath;
+    const wildcardPath = Array.isArray(wildcardParam)
+      ? wildcardParam.join('/')
+      : typeof wildcardParam === 'string'
+        ? wildcardParam
+        : '';
+    const relativePath = normalizeWorkspaceStaticPath(wildcardPath);
+    if (!relativePath) {
+      res.status(400).json({
+        error: 'Invalid static file path.',
+        code: 'WORKSPACE_STATIC_INVALID_PATH',
+      });
+      return;
+    }
+
+    try {
+      const fileReadResult = await readWorkspaceStaticFile(
+        client,
+        sessionId,
+        relativePath,
+        MAX_STATIC_FILE_BYTES,
+      );
+
+      if (!fileReadResult.ok) {
+        if (!asJson) {
+          console.log(
+            `[REQ ${requestId}] workspace static read failed session=${sessionId} path=${relativePath} code=${fileReadResult.code}`,
+          );
+        }
+
+        if (fileReadResult.code === 'NOT_FOUND' || fileReadResult.code === 'SESSION_NOT_FOUND') {
+          res
+            .status(404)
+            .json({ error: 'Workspace file not found.', code: 'WORKSPACE_STATIC_NOT_FOUND' });
+          return;
+        }
+
+        if (fileReadResult.code === 'PATH_OUTSIDE_SESSION') {
+          res
+            .status(403)
+            .json({ error: 'Path escapes session workspace.', code: 'WORKSPACE_STATIC_FORBIDDEN' });
+          return;
+        }
+
+        if (fileReadResult.code === 'TOO_LARGE') {
+          res.status(413).json({
+            error: `Workspace file exceeds max size ${MAX_STATIC_FILE_BYTES} bytes.`,
+            code: 'WORKSPACE_STATIC_TOO_LARGE',
+            sizeBytes: fileReadResult.sizeBytes,
+            maxBytes: MAX_STATIC_FILE_BYTES,
+          });
+          return;
+        }
+
+        res.status(502).json({
+          error: 'Failed to read workspace file from BoxLite.',
+          code: 'WORKSPACE_STATIC_READ_FAILED',
+          details: fileReadResult.message,
+        });
+        return;
+      }
+
+      const { file } = fileReadResult;
+      res.setHeader('Content-Type', getStaticContentType(relativePath));
+      res.setHeader('Cache-Control', 'private, max-age=60');
+      res.setHeader('X-Content-Type-Options', 'nosniff');
+      res.setHeader('Content-Length', String(file.sizeBytes));
+      if (file.mtimeEpochSeconds > 0) {
+        res.setHeader('Last-Modified', new Date(file.mtimeEpochSeconds * 1000).toUTCString());
+      }
+      res.status(200).send(file.content);
+    } catch (error) {
+      if (!asJson) {
+        console.log(
+          `[REQ ${requestId}] workspace static read error session=${sessionId} path=${relativePath}: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+      res.status(502).json({
+        error: 'Failed to read workspace file from BoxLite.',
+        code: 'WORKSPACE_STATIC_READ_FAILED',
+      });
+    }
+  };
+
+  app.get('/workspace/static/:sessionId', serveWorkspaceStatic);
+  app.get('/workspace/static/:sessionId/*filePath', serveWorkspaceStatic);
+
+  // L402 payment gate on all paid routes
   app.use(
     createL402Middleware({
       rootKey,

--- a/packages/cli/src/lib/agent-serve.ts
+++ b/packages/cli/src/lib/agent-serve.ts
@@ -757,13 +757,13 @@ async function listWorkspaceDirectory(
         'if [ -z "$REAL_DIR" ]; then echo "__ERR__:NOT_FOUND"; exit 0; fi',
         'case "$REAL_DIR" in "$BASE"|"$BASE"/*) ;; *) echo "__ERR__:PATH_OUTSIDE_SESSION"; exit 0 ;; esac',
         'if [ ! -d "$REAL_DIR" ]; then echo "__ERR__:NOT_DIRECTORY"; exit 0; fi',
+        'LIST_FILE="$(mktemp)"',
+        'find "$REAL_DIR" -mindepth 1 -maxdepth 1 -print > "$LIST_FILE"',
         'TRUNCATED=0',
         'COUNT=0',
-        'for ENTRY in "$REAL_DIR"/* "$REAL_DIR"/.*; do',
-        '  [ -e "$ENTRY" ] || continue',
+        'while IFS= read -r ENTRY; do',
+        '  [ -n "$ENTRY" ] || continue',
         '  NAME="$(basename "$ENTRY")"',
-        '  [ "$NAME" = "." ] && continue',
-        '  [ "$NAME" = ".." ] && continue',
         '  if [ "$COUNT" -ge "$MAX_ENTRIES" ]; then TRUNCATED=1; break; fi',
         '  COUNT=$((COUNT + 1))',
         '  if [ -L "$ENTRY" ]; then TYPE="symlink"; SIZE=0;',
@@ -773,7 +773,8 @@ async function listWorkspaceDirectory(
         '  MTIME="$(stat -c %Y "$ENTRY" 2>/dev/null || stat -f %m "$ENTRY" 2>/dev/null || echo 0)"',
         '  NAME_B64="$(printf %s "$NAME" | base64 | tr -d "\\n")"',
         '  printf "__ENTRY__:%s:%s:%s:%s\\n" "$NAME_B64" "$TYPE" "$SIZE" "$MTIME"',
-        'done',
+        'done < "$LIST_FILE"',
+        'rm -f "$LIST_FILE"',
         'printf "__TRUNCATED__:%s\\n" "$TRUNCATED"',
       ].join('\n'),
     ],
@@ -1705,7 +1706,8 @@ PROXYEOF`,
     next();
   });
 
-  // L402 payment gate on all routes
+  // Workspace static/list handlers are registered before L402 middleware.
+  // These routes are session-token protected but not payment-gated.
   const serveWorkspaceDirectoryList = async (req: AgentServeRequest, res: express.Response) => {
     const requestId = getRequestId(req);
     const sessionId = getStaticRequestSessionId(req);
@@ -1890,7 +1892,7 @@ PROXYEOF`,
 
       const { file } = fileReadResult;
       res.setHeader('Content-Type', getStaticContentType(relativePath));
-      res.setHeader('Cache-Control', 'private, max-age=60');
+      res.setHeader('Cache-Control', 'no-store');
       res.setHeader('X-Content-Type-Options', 'nosniff');
       res.setHeader('Content-Length', String(file.sizeBytes));
       if (file.mtimeEpochSeconds > 0) {


### PR DESCRIPTION
## Summary\n- migrate workspace static/list session auth from URL/query usage to header-based contract\n- update agent-serve tests to use x-session-id and x-session-token\n- refresh backend/frontend docs to reflect the new header-only flow\n\n## Validation\n- full repo checks passed in pre-commit pipeline: format, lint, build, typecheck, and tests