### PR TITLE
feat(react): improve connect button downstream integration

### DIFF
--- a/.changeset/connect-button-node-info-panel.md
+++ b/.changeset/connect-button-node-info-panel.md
@@ -5,6 +5,7 @@
 feat(react): add ConnectButton, NodeInfoPanel components and enhance useFiberNode
 
 - Add `<ConnectButton>` component with standalone and external-hook modes, supporting passkey/password/rawKey/auto strategies
+- Add `renderConnectedDropdown` and `dropdownStyle` to `<ConnectButton>` so apps can inject project-specific connected menus while reusing SDK lifecycle logic
 - Add `<NodeInfoPanel>` component for displaying node stats, QR code, and copy-to-clipboard
 - Add `startWithRawKey()` to `useFiberNode` hook for `RawKeyCredentialProvider` support
 - Add `isStarting` and `isRunning` computed convenience booleans to `useFiberNode`

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -11,7 +11,7 @@ pnpm add @fiber-pay/react react
 ## One-line import
 
 ```tsx
-import { FiberPayQuickCard, useFiberNode, useFiberPayment } from '@fiber-pay/react';
+import { ConnectButton, FiberPayQuickCard, useFiberNode, useFiberPayment } from '@fiber-pay/react';
 ```
 
 ## Quick start
@@ -32,6 +32,43 @@ export function App() {
 - `onInvoiceCreated(invoice)`
 - `onPaymentResult(result)`
 - `onError({ scope, message })`
+
+## ConnectButton
+
+Use `ConnectButton` with an existing `useFiberNode` result for drop-in integration.
+
+```tsx
+import { ConnectButton, useFiberNode } from '@fiber-pay/react';
+import { Fiber } from '@nervosnetwork/fiber-js';
+
+export function HeaderWallet() {
+  const fiber = useFiberNode({ network: 'testnet', wasmFactory: () => new Fiber() });
+  return <ConnectButton fiber={fiber} />;
+}
+```
+
+For custom connected-state panels (for example peer/channel controls), use `renderConnectedDropdown`:
+
+```tsx
+<ConnectButton
+  fiber={fiber}
+  dropdownStyle={{ width: 320 }}
+  renderConnectedDropdown={({ fiber, disconnect, closeDropdown }) => (
+    <div>
+      <div>State: {fiber.state}</div>
+      <button
+        type="button"
+        onClick={() => {
+          void disconnect();
+          closeDropdown();
+        }}
+      >
+        Disconnect
+      </button>
+    </div>
+  )}
+/>
+```
 
 ## Hooks
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -53,14 +53,13 @@ For custom connected-state panels (for example peer/channel controls), use `rend
 <ConnectButton
   fiber={fiber}
   dropdownStyle={{ width: 320 }}
-  renderConnectedDropdown={({ fiber, disconnect, closeDropdown }) => (
+  renderConnectedDropdown={({ fiber, disconnect }) => (
     <div>
       <div>State: {fiber.state}</div>
       <button
         type="button"
         onClick={() => {
           void disconnect();
-          closeDropdown();
         }}
       >
         Disconnect

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -16,7 +16,7 @@
     "README.md"
   ],
   "scripts": {
-    "build": "tsup",
+    "build": "pnpm --filter @fiber-pay/sdk build && tsup",
     "dev": "tsup --watch",
     "typecheck": "tsc --noEmit",
     "test": "vitest run --config vitest.config.ts"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -16,7 +16,7 @@
     "README.md"
   ],
   "scripts": {
-    "build": "pnpm --filter @fiber-pay/sdk build && tsup",
+    "build": "tsup",
     "dev": "tsup --watch",
     "typecheck": "tsc --noEmit",
     "test": "vitest run --config vitest.config.ts"

--- a/packages/react/src/connect-button.tsx
+++ b/packages/react/src/connect-button.tsx
@@ -78,6 +78,16 @@ export interface ConnectButtonProps {
   /** Inline styles for the root container. */
   style?: CSSProperties;
 
+  /** Inline styles for the connected dropdown container. */
+  dropdownStyle?: CSSProperties;
+
+  /**
+   * Optional custom renderer for the connected dropdown content.
+   * Use this to inject project-specific controls (for example peer/channel actions)
+   * while reusing the SDK's connect/disconnect lifecycle button.
+   */
+  renderConnectedDropdown?: (context: ConnectButtonConnectedDropdownContext) => ReactNode;
+
   /**
    * Called when the node reaches the "running" state.
    * Receives the `FiberBrowserNode` instance and its `NodeInfoResult`.
@@ -89,6 +99,12 @@ export interface ConnectButtonProps {
 
   /** Called when an error occurs. */
   onError?: (error: string) => void;
+}
+
+export interface ConnectButtonConnectedDropdownContext {
+  fiber: UseFiberNodeResult;
+  closeDropdown: () => void;
+  disconnect: () => Promise<void>;
 }
 
 // =============================================================================
@@ -290,6 +306,8 @@ export function ConnectButton(props: ConnectButtonProps) {
     nodeConfig,
     className,
     style,
+    dropdownStyle,
+    renderConnectedDropdown,
     onConnect,
     onDisconnect,
     onError,
@@ -430,6 +448,10 @@ export function ConnectButton(props: ConnectButtonProps) {
     }
   }, [stop, onError]);
 
+  const closeDropdown = useCallback(() => {
+    setShowDropdown(false);
+  }, []);
+
   // --- Render ---------------------------------------------------------------
 
   const hasError = !!(error || localError);
@@ -501,44 +523,54 @@ export function ConnectButton(props: ConnectButtonProps) {
           </button>
 
           {showDropdown && (
-            <div style={styles.dropdown}>
-              {/* Node info */}
-              {nodeInfo && (
+            <div style={{ ...styles.dropdown, ...dropdownStyle }}>
+              {renderConnectedDropdown ? (
+                renderConnectedDropdown({
+                  fiber,
+                  closeDropdown,
+                  disconnect: handleDisconnect,
+                })
+              ) : (
                 <>
-                  <div style={styles.infoRow}>
-                    <span style={styles.infoLabel}>Pubkey</span>
-                    <span style={styles.infoValue}>{truncateNodeId(nodeInfo.pubkey)}</span>
-                  </div>
-                  <div style={styles.infoRow}>
-                    <span style={styles.infoLabel}>State</span>
-                    <span style={styles.infoValue}>{state}</span>
-                  </div>
+                  {/* Node info */}
+                  {nodeInfo && (
+                    <>
+                      <div style={styles.infoRow}>
+                        <span style={styles.infoLabel}>Pubkey</span>
+                        <span style={styles.infoValue}>{truncateNodeId(nodeInfo.pubkey)}</span>
+                      </div>
+                      <div style={styles.infoRow}>
+                        <span style={styles.infoLabel}>State</span>
+                        <span style={styles.infoValue}>{state}</span>
+                      </div>
+                    </>
+                  )}
+
+                  <div style={styles.separator} />
+
+                  {/* Disconnect */}
+                  <button
+                    type="button"
+                    onClick={() => void handleDisconnect()}
+                    style={styles.disconnectButton}
+                  >
+                    <span>Disconnect</span>
+                    <svg
+                      width="14"
+                      height="14"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      aria-hidden="true"
+                    >
+                      <path d="M9 18l6-6-6-6" />
+                    </svg>
+                  </button>
                 </>
               )}
-
-              <div style={styles.separator} />
-
-              {/* Disconnect */}
-              <button
-                type="button"
-                onClick={() => void handleDisconnect()}
-                style={styles.disconnectButton}
-              >
-                <span>Disconnect</span>
-                <svg
-                  width="14"
-                  height="14"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  aria-hidden="true"
-                >
-                  <path d="M9 18l6-6-6-6" />
-                </svg>
-              </button>
             </div>
           )}
         </div>

--- a/packages/react/src/connect-button.tsx
+++ b/packages/react/src/connect-button.tsx
@@ -83,8 +83,10 @@ export interface ConnectButtonProps {
 
   /**
    * Optional custom renderer for the connected dropdown content.
-   * Use this to inject project-specific controls (for example peer/channel actions)
-   * while reusing the SDK's connect/disconnect lifecycle button.
+   * Use this to render project-specific controls (for example peer/channel actions)
+   * while reusing the SDK's connect/disconnect lifecycle logic via the provided context.
+   * When set, this replaces the default dropdown content, so custom renderers must
+   * render their own disconnect UI if they want to expose disconnect actions.
    */
   renderConnectedDropdown?: (context: ConnectButtonConnectedDropdownContext) => ReactNode;
 

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -23,7 +23,11 @@ export {
   shannonsToCkb,
   toHex,
 } from '@fiber-pay/sdk/browser';
-export type { ConnectButtonProps, ConnectStrategy } from './connect-button.js';
+export type {
+  ConnectButtonConnectedDropdownContext,
+  ConnectButtonProps,
+  ConnectStrategy,
+} from './connect-button.js';
 export { ConnectButton } from './connect-button.js';
 export type { FiberPayQuickCardProps } from './fiber-pay-quick-card.js';
 export { FiberPayQuickCard } from './fiber-pay-quick-card.js';


### PR DESCRIPTION
## Summary
- add ConnectButton connected dropdown extension points via renderConnectedDropdown and dropdownStyle
- export ConnectButtonConnectedDropdownContext from @fiber-pay/react entrypoint
- document ConnectButton integration/customization examples in React README
- make react package build invoke sdk build first for more reliable local monorepo packaging
- update changeset notes

## Downstream validation
- created an isolated clone at /Users/retric/Desktop/calling-agent-copilot-test (did not use the in-progress desktop repo)
- verified current npm @fiber-pay/react@0.2.3 cannot be directly swapped in downstream because ConnectButton export is missing
- switched downstream to local linked packages and verified replacement build passes

## Verification
- pnpm --filter @fiber-pay/react build
- pnpm --filter @fiber-pay/react typecheck
- pnpm --filter @fiber-pay/react test