### PR TITLE
fix(sdk): normalize channel state_name on browser/WASM path

### DIFF
--- a/.changeset/normalize-channel-state-browser.md
+++ b/.changeset/normalize-channel-state-browser.md
@@ -1,0 +1,18 @@
+---
+'@fiber-pay/sdk': patch
+'@fiber-pay/react': patch
+'@fiber-pay/node': patch
+'@fiber-pay/runtime': patch
+'@fiber-pay/cli': patch
+'@fiber-pay/agent': patch
+---
+
+fix(sdk): normalize channel `state.state_name` on the browser/WASM path so it
+matches the `ChannelState` enum (SCREAMING_SNAKE_CASE) returned by the RPC
+client. This fixes `FiberBrowserNode.waitForChannelReady` and any consumer that
+compares `channel.state.state_name === ChannelState.ChannelReady` on the
+browser path.
+
+Internal: extracted `normalizeChannel` / `normalizeChannelStateName` from
+`FiberRpcClient` into a shared `rpc/normalize-channel` module used by both the
+RPC client and the WASM adapter.

--- a/packages/sdk/src/browser/wasm-adapter.ts
+++ b/packages/sdk/src/browser/wasm-adapter.ts
@@ -12,6 +12,7 @@
  */
 
 import { FiberRpcError } from '../rpc/client.js';
+import { normalizeChannel } from '../rpc/normalize-channel.js';
 import type {
   AbandonChannelParams,
   AcceptChannelParams,
@@ -220,7 +221,11 @@ export class FiberWasmAdapter {
   }
 
   async listChannels(params?: ListChannelsParams): Promise<ListChannelsResult> {
-    return this.invoke<ListChannelsResult>('list_channels', [params ?? {}]);
+    const result = await this.invoke<ListChannelsResult>('list_channels', [params ?? {}]);
+    return {
+      ...result,
+      channels: result.channels.map((channel) => normalizeChannel(channel)),
+    };
   }
 
   async shutdownChannel(params: ShutdownChannelParams): Promise<void> {

--- a/packages/sdk/src/rpc/client.ts
+++ b/packages/sdk/src/rpc/client.ts
@@ -55,6 +55,7 @@ import type {
   UpdateChannelParams,
 } from '../types/index.js';
 import { ChannelState } from '../types/index.js';
+import { normalizeChannel } from './normalize-channel.js';
 
 // =============================================================================
 // RPC Client Configuration
@@ -102,17 +103,6 @@ export class FiberRpcError extends Error {
 export class FiberRpcClient implements IFiberClient {
   private requestId = 0;
   private config: Required<Pick<RpcClientConfig, 'url' | 'timeout'>> & RpcClientConfig;
-
-  private readonly channelStateAliases: Record<string, ChannelState> = {
-    NEGOTIATING_FUNDING: ChannelState.NegotiatingFunding,
-    COLLABORATING_FUNDING_TX: ChannelState.CollaboratingFundingTx,
-    SIGNING_COMMITMENT: ChannelState.SigningCommitment,
-    AWAITING_TX_SIGNATURES: ChannelState.AwaitingTxSignatures,
-    AWAITING_CHANNEL_READY: ChannelState.AwaitingChannelReady,
-    CHANNEL_READY: ChannelState.ChannelReady,
-    SHUTTING_DOWN: ChannelState.ShuttingDown,
-    CLOSED: ChannelState.Closed,
-  };
 
   constructor(config: RpcClientConfig) {
     this.config = {
@@ -240,32 +230,7 @@ export class FiberRpcClient implements IFiberClient {
     const result = await this.call<ListChannelsResult>('list_channels', params ? [params] : [{}]);
     return {
       ...result,
-      channels: result.channels.map((channel) => this.normalizeChannel(channel)),
-    };
-  }
-
-  private normalizeChannelStateName(stateName: string): ChannelState {
-    const alias = this.channelStateAliases[stateName];
-    if (alias) return alias;
-
-    const normalizedInput = stateName.replace(/[^a-zA-Z0-9]/g, '').toLowerCase();
-    for (const value of Object.values(ChannelState)) {
-      const normalizedValue = value.replace(/[^a-zA-Z0-9]/g, '').toLowerCase();
-      if (normalizedValue === normalizedInput) {
-        return value;
-      }
-    }
-
-    return stateName as ChannelState;
-  }
-
-  private normalizeChannel(channel: Channel): Channel {
-    return {
-      ...channel,
-      state: {
-        ...channel.state,
-        state_name: this.normalizeChannelStateName(channel.state.state_name),
-      },
+      channels: result.channels.map((channel) => normalizeChannel(channel)),
     };
   }
 

--- a/packages/sdk/src/rpc/normalize-channel.ts
+++ b/packages/sdk/src/rpc/normalize-channel.ts
@@ -22,6 +22,18 @@ const CHANNEL_STATE_ALIASES: Record<string, ChannelState> = {
 };
 
 /**
+ * Pre-computed lookup of normalized (alphanumeric, lowercased) `ChannelState`
+ * values to their canonical enum value. Used as the fallback path when an
+ * input does not match the alias table directly.
+ */
+const CHANNEL_STATE_LOOKUP: Record<string, ChannelState> = Object.fromEntries(
+  Object.values(ChannelState).map((value) => [
+    value.replace(/[^a-zA-Z0-9]/g, '').toLowerCase(),
+    value,
+  ]),
+);
+
+/**
  * Normalize a channel state name to the canonical `ChannelState` enum value.
  *
  * Accepts SCREAMING_SNAKE_CASE (e.g. `"CHANNEL_READY"`), PascalCase
@@ -36,14 +48,7 @@ export function normalizeChannelStateName(stateName: string): ChannelState {
   if (alias) return alias;
 
   const normalizedInput = stateName.replace(/[^a-zA-Z0-9]/g, '').toLowerCase();
-  for (const value of Object.values(ChannelState)) {
-    const normalizedValue = value.replace(/[^a-zA-Z0-9]/g, '').toLowerCase();
-    if (normalizedValue === normalizedInput) {
-      return value;
-    }
-  }
-
-  return stateName as ChannelState;
+  return CHANNEL_STATE_LOOKUP[normalizedInput] ?? (stateName as ChannelState);
 }
 
 /**

--- a/packages/sdk/src/rpc/normalize-channel.ts
+++ b/packages/sdk/src/rpc/normalize-channel.ts
@@ -1,0 +1,60 @@
+/**
+ * Channel normalization helpers.
+ *
+ * The Fiber node may return channel `state_name` in different casings depending
+ * on the transport (JSON-RPC over HTTP vs WASM adapter). These helpers normalize
+ * the value to the canonical SCREAMING_SNAKE_CASE `ChannelState` enum so that
+ * consumers can rely on `=== ChannelState.X` comparisons regardless of which
+ * client they use.
+ */
+
+import { type Channel, ChannelState } from '../types/index.js';
+
+const CHANNEL_STATE_ALIASES: Record<string, ChannelState> = {
+  NEGOTIATING_FUNDING: ChannelState.NegotiatingFunding,
+  COLLABORATING_FUNDING_TX: ChannelState.CollaboratingFundingTx,
+  SIGNING_COMMITMENT: ChannelState.SigningCommitment,
+  AWAITING_TX_SIGNATURES: ChannelState.AwaitingTxSignatures,
+  AWAITING_CHANNEL_READY: ChannelState.AwaitingChannelReady,
+  CHANNEL_READY: ChannelState.ChannelReady,
+  SHUTTING_DOWN: ChannelState.ShuttingDown,
+  CLOSED: ChannelState.Closed,
+};
+
+/**
+ * Normalize a channel state name to the canonical `ChannelState` enum value.
+ *
+ * Accepts SCREAMING_SNAKE_CASE (e.g. `"CHANNEL_READY"`), PascalCase
+ * (e.g. `"ChannelReady"`), and other variants by stripping non-alphanumeric
+ * characters and comparing case-insensitively.
+ *
+ * Falls back to returning the input unchanged (cast to `ChannelState`) if no
+ * match is found, so unknown future states do not throw.
+ */
+export function normalizeChannelStateName(stateName: string): ChannelState {
+  const alias = CHANNEL_STATE_ALIASES[stateName];
+  if (alias) return alias;
+
+  const normalizedInput = stateName.replace(/[^a-zA-Z0-9]/g, '').toLowerCase();
+  for (const value of Object.values(ChannelState)) {
+    const normalizedValue = value.replace(/[^a-zA-Z0-9]/g, '').toLowerCase();
+    if (normalizedValue === normalizedInput) {
+      return value;
+    }
+  }
+
+  return stateName as ChannelState;
+}
+
+/**
+ * Return a copy of `channel` with its `state.state_name` normalized.
+ */
+export function normalizeChannel(channel: Channel): Channel {
+  return {
+    ...channel,
+    state: {
+      ...channel.state,
+      state_name: normalizeChannelStateName(channel.state.state_name),
+    },
+  };
+}

--- a/packages/sdk/tests/normalize-channel.test.ts
+++ b/packages/sdk/tests/normalize-channel.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+
+import { normalizeChannel, normalizeChannelStateName } from '../src/rpc/normalize-channel.js';
+import { type Channel, ChannelState } from '../src/types/index.js';
+
+describe('normalizeChannelStateName', () => {
+  it('maps SCREAMING_SNAKE_CASE aliases to enum values', () => {
+    expect(normalizeChannelStateName('CHANNEL_READY')).toBe(ChannelState.ChannelReady);
+    expect(normalizeChannelStateName('NEGOTIATING_FUNDING')).toBe(ChannelState.NegotiatingFunding);
+    expect(normalizeChannelStateName('AWAITING_TX_SIGNATURES')).toBe(
+      ChannelState.AwaitingTxSignatures,
+    );
+    expect(normalizeChannelStateName('CLOSED')).toBe(ChannelState.Closed);
+  });
+
+  it('passes through canonical PascalCase values', () => {
+    expect(normalizeChannelStateName('ChannelReady')).toBe(ChannelState.ChannelReady);
+    expect(normalizeChannelStateName('NegotiatingFunding')).toBe(ChannelState.NegotiatingFunding);
+  });
+
+  it('normalizes mixed punctuation/casing variants', () => {
+    expect(normalizeChannelStateName('channel-ready')).toBe(ChannelState.ChannelReady);
+    expect(normalizeChannelStateName('channel_ready')).toBe(ChannelState.ChannelReady);
+  });
+
+  it('falls back to the input for unknown states', () => {
+    expect(normalizeChannelStateName('SomeUnknownState')).toBe('SomeUnknownState');
+  });
+});
+
+describe('normalizeChannel', () => {
+  it('normalizes state.state_name and preserves other fields', () => {
+    const channel = {
+      channel_id: '0xabc',
+      state: {
+        state_name: 'CHANNEL_READY',
+        state_flags: [],
+      },
+      foo: 'bar',
+    } as unknown as Channel;
+
+    const result = normalizeChannel(channel);
+    expect(result.state.state_name).toBe(ChannelState.ChannelReady);
+    expect(result.channel_id).toBe('0xabc');
+    expect((result as unknown as { foo: string }).foo).toBe('bar');
+    // does not mutate input
+    expect(channel.state.state_name).toBe('CHANNEL_READY');
+  });
+});

--- a/packages/sdk/tests/normalize-channel.test.ts
+++ b/packages/sdk/tests/normalize-channel.test.ts
@@ -13,7 +13,7 @@ describe('normalizeChannelStateName', () => {
     expect(normalizeChannelStateName('CLOSED')).toBe(ChannelState.Closed);
   });
 
-  it('passes through canonical PascalCase values', () => {
+  it('converts PascalCase to canonical SCREAMING_SNAKE_CASE enum values', () => {
     expect(normalizeChannelStateName('ChannelReady')).toBe(ChannelState.ChannelReady);
     expect(normalizeChannelStateName('NegotiatingFunding')).toBe(ChannelState.NegotiatingFunding);
   });

--- a/packages/sdk/tests/wasm-adapter.test.ts
+++ b/packages/sdk/tests/wasm-adapter.test.ts
@@ -203,6 +203,32 @@ describe('FiberWasmAdapter', () => {
 			expect(result.channels).toEqual([]);
 		});
 
+		it('should normalize PascalCase channel state_name returned by WASM', async () => {
+			(mockInstance.invokeCommand as ReturnType<typeof vi.fn>).mockImplementationOnce(
+				(method: string) => {
+					expect(method).toBe('list_channels');
+					return Promise.resolve({
+						channels: [
+							{
+								channel_id: '0xabc',
+								state: { state_name: 'ChannelReady', state_flags: [] },
+							},
+							{
+								channel_id: '0xdef',
+								state: { state_name: 'NegotiatingFunding', state_flags: [] },
+							},
+						],
+					});
+				},
+			);
+
+			const result = await adapter.listChannels();
+			expect(result.channels.map((c) => c.state.state_name)).toEqual([
+				'CHANNEL_READY',
+				'NEGOTIATING_FUNDING',
+			]);
+		});
+
 		it('should throw when node is not running', async () => {
 			await adapter.stop();
 			await expect(adapter.nodeInfo()).rejects.toThrow('not running');


### PR DESCRIPTION
## Summary

The browser path of `@fiber-pay/sdk` returns `channel.state.state_name` as-is from fiber-js (e.g. `"ChannelReady"`), while the RPC client (node path) and the `ChannelState` enum use SCREAMING_SNAKE_CASE values (e.g. `"CHANNEL_READY"` is mapped to `ChannelState.ChannelReady`).

This inconsistency breaks any consumer comparing `state_name` to the `ChannelState` enum on the browser path, including the SDK's own `FiberBrowserNode.waitForChannelReady`, which never resolves because the comparison `channel.state.state_name === ChannelState.ChannelReady` is always `false`.

I hit this in a downstream app ([calling-agent](https://github.com/RetricSu/calling-agent)) where the channel-readiness check stayed stuck in "in progress · ChannelReady" forever even though the channel was already open. Workaround on the app side was to re-implement the same normalization logic that `FiberRpcClient` already has internally.

## Root cause

- `FiberRpcClient.listChannels` (node path) runs every channel through a private `normalizeChannel` / `normalizeChannelStateName` (see `packages/sdk/src/rpc/client.ts`), which maps both the SCREAMING_SNAKE_CASE alias table and a regex-based fallback to the canonical `ChannelState` values.
- `WasmAdapter.listChannels` (browser path) does **not** apply any normalization, so consumers (including `FiberBrowserNode.waitForChannelReady`) get a different shape depending on transport.

## Fix

- Extract `channelStateAliases`, `normalizeChannelStateName`, and `normalizeChannel` from `FiberRpcClient` into a shared module `packages/sdk/src/rpc/normalize-channel.ts`.
- Apply `normalizeChannel` in `WasmAdapter.listChannels` so the browser path returns enum-correct `state_name` values, matching the RPC client.
- Add unit tests for the normalizer (`packages/sdk/tests/normalize-channel.test.ts`).

After this change, `FiberBrowserNode.waitForChannelReady` works correctly without any extra change because it consumes `adapter.listChannels` results.

## Verification

- `pnpm build` (sdk) — green
- `pnpm test` (sdk) — 189 passed (15 files), including 5 new tests for `normalizeChannelStateName` / `normalizeChannel` covering SCREAMING_SNAKE_CASE aliases, canonical PascalCase, mixed punctuation/casing variants, and unknown-state fallback.
- Pre-commit hook (`lint-staged` + `format:check` + `lint` + `build` + `typecheck` + `test` across the workspace) — green.

## Compat

Public API surface unchanged. Behavior is now consistent across node and browser paths; consumers that previously compared against PascalCase strings on the browser path would have already been broken on the node path, so no regression is expected.