### PR TITLE
feat(sdk): export normalizeChannel / normalizeChannelStateName from public entries

### DIFF
--- a/.changeset/export-normalize-helpers.md
+++ b/.changeset/export-normalize-helpers.md
@@ -1,0 +1,9 @@
+---
+'@fiber-pay/sdk': patch
+---
+
+feat(sdk): re-export `normalizeChannel` and `normalizeChannelStateName` from
+both `@fiber-pay/sdk` and `@fiber-pay/sdk/browser`. Consumers that bypass
+`listChannels` (e.g. by calling the WASM adapter or a custom transport
+directly) can now use the SDK's canonical normalization helpers instead of
+re-implementing the same fallback logic.

--- a/packages/sdk/src/browser/index.ts
+++ b/packages/sdk/src/browser/index.ts
@@ -67,6 +67,7 @@ export {
   FiberRpcClient as BrowserRpcClient,
   FiberRpcError,
 } from '../rpc/client.js';
+export { normalizeChannel, normalizeChannelStateName } from '../rpc/normalize-channel.js';
 export { ckbHash, derivePublicKey } from '../security/crypto.js';
 export type { IFiberClient } from '../types/fiber-client.js';
 export type {

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -13,6 +13,7 @@ export type { LiquidityReport } from './funds/liquidity-analyzer.js';
 export { LiquidityAnalyzer } from './funds/liquidity-analyzer.js';
 // RPC client
 export { FiberRpcClient, FiberRpcError } from './rpc/index.js';
+export { normalizeChannel, normalizeChannelStateName } from './rpc/normalize-channel.js';
 export type {
   BiscuitAction,
   BiscuitMethodRule,

--- a/packages/sdk/src/rpc/index.ts
+++ b/packages/sdk/src/rpc/index.ts
@@ -1,1 +1,2 @@
 export * from './client.js';
+export { normalizeChannel, normalizeChannelStateName } from './normalize-channel.js';

--- a/packages/sdk/src/rpc/normalize-channel.ts
+++ b/packages/sdk/src/rpc/normalize-channel.ts
@@ -10,21 +10,12 @@
 
 import { type Channel, ChannelState } from '../types/index.js';
 
-const CHANNEL_STATE_ALIASES: Record<string, ChannelState> = {
-  NEGOTIATING_FUNDING: ChannelState.NegotiatingFunding,
-  COLLABORATING_FUNDING_TX: ChannelState.CollaboratingFundingTx,
-  SIGNING_COMMITMENT: ChannelState.SigningCommitment,
-  AWAITING_TX_SIGNATURES: ChannelState.AwaitingTxSignatures,
-  AWAITING_CHANNEL_READY: ChannelState.AwaitingChannelReady,
-  CHANNEL_READY: ChannelState.ChannelReady,
-  SHUTTING_DOWN: ChannelState.ShuttingDown,
-  CLOSED: ChannelState.Closed,
-};
-
 /**
  * Pre-computed lookup of normalized (alphanumeric, lowercased) `ChannelState`
- * values to their canonical enum value. Used as the fallback path when an
- * input does not match the alias table directly.
+ * values to their canonical enum value.
+ *
+ * Generated dynamically from `ChannelState` so new enum values are picked up
+ * automatically without manual maintenance.
  */
 const CHANNEL_STATE_LOOKUP: Record<string, ChannelState> = Object.fromEntries(
   Object.values(ChannelState).map((value) => [
@@ -44,9 +35,6 @@ const CHANNEL_STATE_LOOKUP: Record<string, ChannelState> = Object.fromEntries(
  * match is found, so unknown future states do not throw.
  */
 export function normalizeChannelStateName(stateName: string): ChannelState {
-  const alias = CHANNEL_STATE_ALIASES[stateName];
-  if (alias) return alias;
-
   const normalizedInput = stateName.replace(/[^a-zA-Z0-9]/g, '').toLowerCase();
   return CHANNEL_STATE_LOOKUP[normalizedInput] ?? (stateName as ChannelState);
 }

--- a/packages/sdk/tests/export-boundary.test.ts
+++ b/packages/sdk/tests/export-boundary.test.ts
@@ -29,7 +29,7 @@ describe('SDK export boundaries', () => {
     expect(browserEntry).toHaveProperty('FiberRpcClient');
   });
 
-  it('exposes channel state normalization helpers from root and browser entries', () => {
+  it('exposes channel state normalization helpers from root, browser, and node entries', () => {
     for (const entry of [rootEntry, browserEntry, nodeEntry]) {
       expect(entry).toHaveProperty('normalizeChannel');
       expect(entry).toHaveProperty('normalizeChannelStateName');

--- a/packages/sdk/tests/export-boundary.test.ts
+++ b/packages/sdk/tests/export-boundary.test.ts
@@ -28,4 +28,13 @@ describe('SDK export boundaries', () => {
     expect(nodeEntry).toHaveProperty('FiberRpcClient');
     expect(browserEntry).toHaveProperty('FiberRpcClient');
   });
+
+  it('exposes channel state normalization helpers from root and browser entries', () => {
+    for (const entry of [rootEntry, browserEntry, nodeEntry]) {
+      expect(entry).toHaveProperty('normalizeChannel');
+      expect(entry).toHaveProperty('normalizeChannelStateName');
+      expect(typeof (entry as Record<string, unknown>).normalizeChannel).toBe('function');
+      expect(typeof (entry as Record<string, unknown>).normalizeChannelStateName).toBe('function');
+    }
+  });
 });


### PR DESCRIPTION
## Summary

Re-export the channel state normalization helpers from the public SDK entry points so downstream consumers don't have to re-implement them.

Closes #133.

## Why

After #131, `normalizeChannel` / `normalizeChannelStateName` is the canonical implementation, but it's only reachable via internal paths. Apps that use `FiberWasmAdapter.invoke('list_channels', ...)` directly, or that receive raw channel objects from custom transports/streams (e.g. the `calling-agent` SSE stream that triggered #132), still have to copy the regex-based fallback by hand.

## Changes

- `packages/sdk/src/index.ts` — re-export `normalizeChannel`, `normalizeChannelStateName`.
- `packages/sdk/src/browser/index.ts` — same, on the browser entry.
- `packages/sdk/src/rpc/index.ts` — re-export from the internal barrel as well, for symmetry with `FiberRpcClient` / `FiberRpcError`.
- `packages/sdk/tests/export-boundary.test.ts` — assert the helpers exist on `@fiber-pay/sdk`, `@fiber-pay/sdk/browser`, and `@fiber-pay/sdk/node`.
- `.changeset/export-normalize-helpers.md` — `patch` for `@fiber-pay/sdk`.

## Verification

- `pnpm test` (sdk) — 191 passed (15 files), including the new export-boundary assertion.
- `pnpm typecheck` — green.
- `pnpm lint` / `pnpm format:check` — green.

## Compat

Additive only. No existing exports renamed or removed.

## Stacking note

This branch is based on `fix/normalize-channel-state-browser` (#131). The diff against `master` therefore also includes that PR's commits; once #131 merges the diff will collapse to just this PR's three commits.
