### PR TITLE
chore(runtime): drop dead string-literal channel state fallbacks in channel-executor

### DIFF
--- a/.changeset/runtime-channel-state-cleanup.md
+++ b/.changeset/runtime-channel-state-cleanup.md
@@ -1,0 +1,10 @@
+---
+'@fiber-pay/runtime': patch
+---
+
+chore(runtime): remove legacy string-literal channel state fallbacks in
+`channel-executor`. `state_name` is always a canonical `ChannelState` enum
+value after normalization at the SDK boundary, so the redundant
+`String(...).toUpperCase()` coercions and `=== 'CLOSED'` /
+`=== 'SHUTTING_DOWN'` branches are dead. Tightens helper parameter types
+from `string` to `ChannelState`.

--- a/packages/runtime/src/jobs/executors/channel-executor.ts
+++ b/packages/runtime/src/jobs/executors/channel-executor.ts
@@ -113,7 +113,7 @@ export async function* runChannelJob(
         });
 
         const readyMatch = candidates.find(
-          (channel) => String(channel.state.state_name).toUpperCase() === 'CHANNEL_READY',
+          (channel) => channel.state.state_name === ChannelState.ChannelReady,
         );
 
         const activeMatch = candidates.find((channel) => !isClosed(channel.state.state_name));
@@ -198,7 +198,7 @@ export async function* runChannelJob(
           (channel) => channel.channel_id === shutdownParams.channel_id,
         );
 
-        if (!match || isTerminalClosed(String(match.state.state_name))) {
+        if (!match || isTerminalClosed(match.state.state_name)) {
           current = transitionJobState(current, channelStateMachine, 'channel_closed', {
             patch: {
               result: {
@@ -337,17 +337,12 @@ async function findTargetChannel(rpc: FiberRpcClient, pubkey: string, channelId?
   });
 }
 
-function isClosed(stateName: string): boolean {
-  return (
-    stateName === ChannelState.Closed ||
-    stateName === 'CLOSED' ||
-    stateName === ChannelState.ShuttingDown ||
-    stateName === 'SHUTTING_DOWN'
-  );
+function isClosed(stateName: ChannelState): boolean {
+  return stateName === ChannelState.Closed || stateName === ChannelState.ShuttingDown;
 }
 
-function isTerminalClosed(stateName: string): boolean {
-  return stateName === ChannelState.Closed || stateName === 'CLOSED';
+function isTerminalClosed(stateName: ChannelState): boolean {
+  return stateName === ChannelState.Closed;
 }
 
 function normalizePubkey(value: string): `0x${string}` {


### PR DESCRIPTION
## Summary

Remove legacy string-literal fallbacks in `packages/runtime/src/jobs/executors/channel-executor.ts` that pre-date channel state normalization at the SDK boundary.

Closes #134.

## Why

`FiberRpcClient.listChannels` always normalizes `state_name` to a canonical `ChannelState` enum value (and after #131, `FiberWasmAdapter.listChannels` does the same). The runtime executor only consumes the RPC client, so:

- `String(channel.state.state_name).toUpperCase() === 'CHANNEL_READY'`
- `String(match.state.state_name)` cast in the shutdown polling loop
- `=== 'CLOSED'` / `=== 'SHUTTING_DOWN'` literal branches inside `isClosed` / `isTerminalClosed`

…are all dead code. They duplicate the enum comparison (`ChannelState.Closed === 'CLOSED'`) and obscure the actual state-machine logic.

## Changes

- Use `ChannelState.ChannelReady` directly for the ready match.
- Drop redundant `String(...)` wrapping at the shutdown polling site.
- Tighten `isClosed` / `isTerminalClosed` parameter types from `string` to `ChannelState`, and collapse their bodies to enum-only comparisons.
- `.changeset/runtime-channel-state-cleanup.md` — `patch` for `@fiber-pay/runtime`.

## Verification

- `pnpm typecheck` — green (parameter tightening compiles cleanly).
- `pnpm test` (runtime) — 101 tests pass (18 files), including `channel-monitor.test.ts` and the channel executor coverage.
- `pnpm lint` / `pnpm format:check` — green.

## Compat

No runtime behavior change for normalized inputs (the only inputs the SDK now produces). Independent of #131 — applies on top of `master` directly.
