### PR TITLE
feat(cli): migration-first node upgrade for custom binary paths

### DIFF
--- a/.changeset/issue-123-migrate-first.md
+++ b/.changeset/issue-123-migrate-first.md
@@ -1,0 +1,9 @@
+---
+'@fiber-pay/cli': patch
+---
+
+feat(cli): make `node upgrade` migration-first for custom binary paths.
+
+- Keep profile-managed binaries on download + migrate flow.
+- Run custom binary mode as migrate-only (skip binary download).
+- Improve migration guidance for custom binary setups and validate that custom `binaryPath` includes an explicit directory path for migration tooling.

--- a/docs/human-quickstart.md
+++ b/docs/human-quickstart.md
@@ -33,6 +33,13 @@ fiber-pay runtime status --json
 
 This initializes binary/config/key/runtime automatically for first-time local bootstrap.
 
+This quickstart assumes the default profile-managed binary path. If you set `--binary-path` (or profile `binaryPath`), `node start` uses your binary as-is and `node upgrade` becomes migration-first (migrate-only for custom binaries).
+
+See details:
+
+- [Profile & Multi-Node Guide](../skills/fiber-pay/references/profile.md)
+- [Upgrade & Migration](../skills/fiber-pay/references/upgrade.md)
+
 ## 3) Connect peer and open a channel
 
 ```bash

--- a/packages/cli/src/commands/node.ts
+++ b/packages/cli/src/commands/node.ts
@@ -61,7 +61,9 @@ export function createNodeCommand(config: CliConfig): Command {
 
   node
     .command('upgrade')
-    .description('Upgrade the Fiber node binary and migrate the database if needed')
+    .description(
+      'Run migration-aware upgrade flow (managed binaries download+upgrade; custom binaries migrate-only)',
+    )
     .option('--version <version>', 'Target Fiber version (default: latest)')
     .option('--no-backup', 'Skip creating a store backup before migration')
     .option('--check-only', 'Only check if migration is needed, do not migrate')

--- a/packages/cli/src/lib/migrate-binary-policy.ts
+++ b/packages/cli/src/lib/migrate-binary-policy.ts
@@ -1,0 +1,109 @@
+import { existsSync } from 'node:fs';
+import { dirname } from 'node:path';
+import { BinaryManager } from '@fiber-pay/node';
+
+export type NodeBinaryMode = 'managed-download' | 'custom-migrate-only';
+
+interface MigrateBinaryErrorInfo {
+  code: 'BINARY_PATH_INCOMPATIBLE' | 'MIGRATION_TOOL_MISSING';
+  message: string;
+  suggestion: string;
+  recoverable: boolean;
+}
+
+export type UpgradeMigrateBinaryResolution =
+  | {
+      ok: true;
+      migrateBinaryPath: string;
+    }
+  | {
+      ok: false;
+      error: MigrateBinaryErrorInfo;
+    };
+
+export function getMigrateBinaryPathForBinary(binaryPath: string): string {
+  const binaryDir = dirname(binaryPath);
+  if (binaryDir === '.' || binaryDir.length === 0) {
+    throw new Error(
+      `Configured binaryPath "${binaryPath}" must include an explicit directory path. ` +
+        'Use an absolute path (for example /opt/fiber/fnn) or a relative path (for example ./fnn).',
+    );
+  }
+
+  return new BinaryManager(binaryDir).getMigrateBinaryPath();
+}
+
+function getMissingMigrateSuggestion(mode: NodeBinaryMode, binaryPath: string): string {
+  if (mode === 'custom-migrate-only') {
+    return (
+      `Place fnn-migrate next to configured binary in "${dirname(binaryPath)}", ` +
+      'or unset binaryPath to switch back to profile-managed binaries.'
+    );
+  }
+
+  return 'Run `fiber-pay node upgrade` to reinstall binaries, then retry `fiber-pay node upgrade --force-migrate`.';
+}
+
+export function resolveUpgradeMigrateBinary(
+  binaryPath: string,
+  mode: NodeBinaryMode,
+  storeExists: boolean,
+): UpgradeMigrateBinaryResolution {
+  let migrateBinaryPath: string;
+
+  try {
+    migrateBinaryPath = getMigrateBinaryPathForBinary(binaryPath);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      ok: false,
+      error: {
+        code: 'BINARY_PATH_INCOMPATIBLE',
+        message,
+        recoverable: true,
+        suggestion:
+          'Set binaryPath to an explicit file path (absolute or relative), or unset binaryPath to use profile-managed binaries.',
+      },
+    };
+  }
+
+  if (storeExists && !existsSync(migrateBinaryPath)) {
+    return {
+      ok: false,
+      error: {
+        code: 'MIGRATION_TOOL_MISSING',
+        message: `fnn-migrate binary not found at: ${migrateBinaryPath}`,
+        recoverable: true,
+        suggestion: getMissingMigrateSuggestion(mode, binaryPath),
+      },
+    };
+  }
+
+  return { ok: true, migrateBinaryPath };
+}
+
+export function resolveGuardMigrateBinary(
+  binaryPath: string,
+): { ok: true; migrateBinaryPath: string } | { ok: false; skippedReason: string } {
+  try {
+    const migrateBinaryPath = getMigrateBinaryPathForBinary(binaryPath);
+    if (!existsSync(migrateBinaryPath)) {
+      return { ok: false, skippedReason: 'fnn-migrate binary not available' };
+    }
+    return { ok: true, migrateBinaryPath };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return { ok: false, skippedReason: `migration guard skipped: ${message}` };
+  }
+}
+
+export function getMissingMigrateVerifySuggestion(
+  mode: NodeBinaryMode,
+  binaryPath: string,
+): string {
+  if (mode === 'custom-migrate-only') {
+    return `Verify fnn-migrate exists next to configured binary in "${dirname(binaryPath)}", then retry.`;
+  }
+
+  return 'Run `fiber-pay node upgrade` to reinstall binaries, then retry `fiber-pay node upgrade --force-migrate`.';
+}

--- a/packages/cli/src/lib/node-migration.ts
+++ b/packages/cli/src/lib/node-migration.ts
@@ -2,9 +2,9 @@
  * Shared migration-guard logic used by both `node start` and `node upgrade`.
  */
 
-import { dirname } from 'node:path';
-import { BinaryManager, type MigrationCheckResult, MigrationManager } from '@fiber-pay/node';
+import { type MigrationCheckResult, MigrationManager } from '@fiber-pay/node';
 import { printJsonError } from './format.js';
+import { resolveGuardMigrateBinary } from './migrate-binary-policy.js';
 import { replaceRawMigrateHint } from './migration-utils.js';
 
 // =============================================================================
@@ -57,9 +57,12 @@ export async function runMigrationGuard(
   }
 
   const storePath = MigrationManager.resolveStorePath(dataDir);
-  const binaryDir = dirname(binaryPath);
-  const bm = new BinaryManager(binaryDir);
-  const migrateBinPath = bm.getMigrateBinaryPath();
+  const migrateBinary = resolveGuardMigrateBinary(binaryPath);
+  if (!migrateBinary.ok) {
+    return { checked: false, skippedReason: migrateBinary.skippedReason };
+  }
+
+  const migrateBinPath = migrateBinary.migrateBinaryPath;
 
   let migrationCheck: MigrationCheckResult;
   try {

--- a/packages/cli/src/lib/node-start.ts
+++ b/packages/cli/src/lib/node-start.ts
@@ -19,6 +19,7 @@ import {
   startRuntimeDaemonFromNode,
   stopRuntimeDaemonFromNode,
 } from './node-runtime-daemon.js';
+import { resolveManagedStartVersion } from './node-version-policy.js';
 import { isProcessRunning, readPidFile, removePidFile, writePidFile } from './pid.js';
 import { createRpcClient } from './rpc.js';
 import { removeRuntimeFiles, writeRuntimeMeta, writeRuntimePid } from './runtime-meta.js';
@@ -169,7 +170,8 @@ export async function runNodeStartCommand(
   if (resolvedBinary.source === 'profile-managed') {
     const installDir = getBinaryManagerInstallDirOrThrow(resolvedBinary);
     const profile = loadProfileConfig(config.dataDir);
-    await ensureFiberBinary({ installDir, version: profile?.fiberVersion });
+    const managedStartVersion = resolveManagedStartVersion(profile);
+    await ensureFiberBinary({ installDir, version: managedStartVersion.version });
   }
   const binaryVersion = getBinaryVersion(binaryPath);
   const configFilePath = ensureNodeConfigFile(config.dataDir, config.network);

--- a/packages/cli/src/lib/node-upgrade.ts
+++ b/packages/cli/src/lib/node-upgrade.ts
@@ -2,12 +2,15 @@
  * Implementation of `fiber-pay node upgrade`.
  */
 
+import { dirname } from 'node:path';
 import { BinaryManager, type DownloadProgress, MigrationManager } from '@fiber-pay/node';
+import type { ResolvedBinaryPath } from './binary-path.js';
 import { getBinaryManagerInstallDirOrThrow, resolveBinaryPath } from './binary-path.js';
 import type { CliConfig } from './config.js';
 import { loadProfileConfig, saveProfileConfig } from './config.js';
 import { printJsonError, printJsonSuccess } from './format.js';
 import { normalizeMigrationCheck, replaceRawMigrateHint } from './migration-utils.js';
+import { getCustomBinaryState } from './node-runtime-daemon.js';
 import { isProcessRunning, readPidFile } from './pid.js';
 
 export interface NodeUpgradeOptions {
@@ -18,12 +21,110 @@ export interface NodeUpgradeOptions {
   json?: boolean;
 }
 
+export type NodeUpgradeMode = 'managed-download' | 'custom-migrate-only';
+
+export function getNodeUpgradeMode(resolvedBinary: ResolvedBinaryPath): NodeUpgradeMode {
+  return resolvedBinary.source === 'profile-managed' ? 'managed-download' : 'custom-migrate-only';
+}
+
+export function getMigrateBinaryPathForBinary(binaryPath: string): string {
+  return new BinaryManager(dirname(binaryPath)).getMigrateBinaryPath();
+}
+
+function stripVersionPrefix(version: string): string {
+  return version.startsWith('v') ? version.slice(1) : version;
+}
+
 export async function runNodeUpgradeCommand(
   config: CliConfig,
   options: NodeUpgradeOptions,
 ): Promise<void> {
   const json = Boolean(options.json);
   const resolvedBinary = resolveBinaryPath(config);
+  const mode = getNodeUpgradeMode(resolvedBinary);
+
+  // Step 1: Check if node is running — must be stopped before upgrade
+  const pid = readPidFile(config.dataDir);
+  if (pid && isProcessRunning(pid)) {
+    const msg = 'The Fiber node is currently running. Stop it before upgrading.';
+    if (json) {
+      printJsonError({
+        code: 'NODE_RUNNING',
+        message: msg,
+        recoverable: true,
+        suggestion: 'Run `fiber-pay node stop` first, then retry the upgrade.',
+      });
+    } else {
+      console.error(`❌ ${msg}`);
+      console.log('   Run: fiber-pay node stop');
+    }
+    process.exit(1);
+  }
+
+  // Step 4: Prepare migration-related paths
+  const storePath = MigrationManager.resolveStorePath(config.dataDir);
+  const migrateBinaryPath = getMigrateBinaryPathForBinary(resolvedBinary.binaryPath);
+  let migrationCheck: Awaited<ReturnType<MigrationManager['check']>> | null = null;
+
+  const storeExists = MigrationManager.storeExists(config.dataDir);
+
+  if (mode === 'custom-migrate-only') {
+    const currentInfo = getCustomBinaryState(resolvedBinary.binaryPath);
+    const customBinaryManager = new BinaryManager(dirname(resolvedBinary.binaryPath));
+    const targetTag = options.version
+      ? customBinaryManager.normalizeTag(options.version)
+      : undefined;
+    const targetVersion = targetTag ? stripVersionPrefix(targetTag) : undefined;
+
+    if (!json) {
+      console.log('🧭 Upgrade mode: custom binary (migration-only).');
+      console.log(`🧩 Binary: ${resolvedBinary.binaryPath}`);
+      if (currentInfo.ready) {
+        console.log(`🧩 Current version: ${currentInfo.version}`);
+      }
+      if (targetTag) {
+        console.log(
+          `📦 Target version requested: ${targetTag} (download skipped for custom binary)`,
+        );
+      }
+    }
+
+    if (storeExists) {
+      migrationCheck = await runMigrationAndReport({
+        migrateBinaryPath,
+        storePath,
+        json,
+        checkOnly: Boolean(options.checkOnly),
+        targetVersion: targetVersion ?? currentInfo.version,
+        backup: options.backup !== false,
+        forceMigrateAttempt: Boolean(options.forceMigrate),
+        mode,
+        binaryPath: resolvedBinary.binaryPath,
+      });
+    } else if (!json) {
+      console.log('📂 No existing store detected; migration check skipped.');
+    }
+
+    if (json) {
+      printJsonSuccess({
+        action: 'migrate-only',
+        mode,
+        source: resolvedBinary.source,
+        currentVersion: currentInfo.version,
+        targetVersion: targetVersion ?? null,
+        binaryPath: resolvedBinary.binaryPath,
+        migrateBinaryPath,
+        migration: migrationCheck,
+      });
+    } else {
+      console.log('\n✅ Upgrade flow complete (custom binary mode).');
+      console.log('   Binary download was skipped by design.');
+      console.log('   Migration checks were performed when a store was found.');
+    }
+
+    return;
+  }
+
   let installDir: string;
   try {
     installDir = getBinaryManagerInstallDirOrThrow(resolvedBinary);
@@ -45,24 +146,6 @@ export async function runNodeUpgradeCommand(
 
   const binaryManager = new BinaryManager(installDir);
 
-  // Step 1: Check if node is running — must be stopped before upgrade
-  const pid = readPidFile(config.dataDir);
-  if (pid && isProcessRunning(pid)) {
-    const msg = 'The Fiber node is currently running. Stop it before upgrading.';
-    if (json) {
-      printJsonError({
-        code: 'NODE_RUNNING',
-        message: msg,
-        recoverable: true,
-        suggestion: 'Run `fiber-pay node stop` first, then retry the upgrade.',
-      });
-    } else {
-      console.error(`❌ ${msg}`);
-      console.log('   Run: fiber-pay node stop');
-    }
-    process.exit(1);
-  }
-
   // Step 2: Resolve target version
   let targetTag: string;
   if (options.version) {
@@ -76,14 +159,7 @@ export async function runNodeUpgradeCommand(
 
   // Step 3: Check current version
   const currentInfo = await binaryManager.getBinaryInfo();
-  const targetVersion = targetTag.startsWith('v') ? targetTag.slice(1) : targetTag;
-
-  // Step 4: Prepare migration-related paths
-  const storePath = MigrationManager.resolveStorePath(config.dataDir);
-  const migrateBinaryPath = binaryManager.getMigrateBinaryPath();
-  let migrationCheck: Awaited<ReturnType<MigrationManager['check']>> | null = null;
-
-  const storeExists = MigrationManager.storeExists(config.dataDir);
+  const targetVersion = stripVersionPrefix(targetTag);
 
   if (!json && storeExists) {
     console.log('📂 Existing store detected.');
@@ -99,6 +175,8 @@ export async function runNodeUpgradeCommand(
         targetVersion,
         backup: options.backup !== false,
         forceMigrateAttempt: false,
+        mode,
+        binaryPath: resolvedBinary.binaryPath,
       });
     }
 
@@ -162,6 +240,8 @@ export async function runNodeUpgradeCommand(
       targetVersion,
       backup: options.backup !== false,
       forceMigrateAttempt: Boolean(options.forceMigrate),
+      mode,
+      binaryPath: resolvedBinary.binaryPath,
     });
   }
 
@@ -177,6 +257,7 @@ export async function runNodeUpgradeCommand(
   if (json) {
     printJsonSuccess({
       action: 'upgraded',
+      mode,
       previousVersion: currentInfo.ready ? currentInfo.version : null,
       currentVersion: newInfo.version,
       binaryPath: newInfo.path,
@@ -203,6 +284,8 @@ interface MigrationRunOptions {
   targetVersion: string;
   backup: boolean;
   forceMigrateAttempt: boolean;
+  mode: NodeUpgradeMode;
+  binaryPath: string;
 }
 
 /**
@@ -223,6 +306,8 @@ async function runMigrationAndReport(
     targetVersion,
     backup,
     forceMigrateAttempt,
+    mode,
+    binaryPath,
   } = opts;
 
   // Instantiate MigrationManager
@@ -237,13 +322,21 @@ async function runMigrationAndReport(
         message: msg,
         recoverable: true,
         suggestion:
-          'Run `fiber-pay node upgrade` to reinstall binaries, then retry `fiber-pay node upgrade --force-migrate`.',
+          mode === 'custom-migrate-only'
+            ? `Place fnn-migrate next to configured binary in "${dirname(binaryPath)}", or unset binaryPath to switch back to profile-managed binaries.`
+            : 'Run `fiber-pay node upgrade` to reinstall binaries, then retry `fiber-pay node upgrade --force-migrate`.',
       });
     } else {
       console.error(`\n⚠️  ${msg}`);
-      console.log(
-        '   Run `fiber-pay node upgrade` to reinstall binaries, then retry `fiber-pay node upgrade --force-migrate`.',
-      );
+      if (mode === 'custom-migrate-only') {
+        console.log(
+          `   Place fnn-migrate next to configured binary in "${dirname(binaryPath)}", or unset binaryPath to use profile-managed binaries.`,
+        );
+      } else {
+        console.log(
+          '   Run `fiber-pay node upgrade` to reinstall binaries, then retry `fiber-pay node upgrade --force-migrate`.',
+        );
+      }
     }
     process.exit(1);
   }
@@ -262,13 +355,21 @@ async function runMigrationAndReport(
         message: `Migration check failed: ${msg}`,
         recoverable: true,
         suggestion:
-          'Run `fiber-pay node upgrade` to reinstall binaries, then retry `fiber-pay node upgrade --force-migrate`.',
+          mode === 'custom-migrate-only'
+            ? `Verify fnn-migrate exists next to configured binary in "${dirname(binaryPath)}", then retry.`
+            : 'Run `fiber-pay node upgrade` to reinstall binaries, then retry `fiber-pay node upgrade --force-migrate`.',
       });
     } else {
       console.error(`\n⚠️  Migration check failed: ${msg}`);
-      console.log(
-        '   Run `fiber-pay node upgrade` to reinstall binaries, then retry `fiber-pay node upgrade --force-migrate`.',
-      );
+      if (mode === 'custom-migrate-only') {
+        console.log(
+          `   Verify fnn-migrate exists next to configured binary in "${dirname(binaryPath)}", then retry.`,
+        );
+      } else {
+        console.log(
+          '   Run `fiber-pay node upgrade` to reinstall binaries, then retry `fiber-pay node upgrade --force-migrate`.',
+        );
+      }
     }
     process.exit(1);
   }

--- a/packages/cli/src/lib/node-upgrade.ts
+++ b/packages/cli/src/lib/node-upgrade.ts
@@ -9,8 +9,15 @@ import { getBinaryManagerInstallDirOrThrow, resolveBinaryPath } from './binary-p
 import type { CliConfig } from './config.js';
 import { loadProfileConfig, saveProfileConfig } from './config.js';
 import { printJsonError, printJsonSuccess } from './format.js';
+import {
+  getMigrateBinaryPathForBinary,
+  getMissingMigrateVerifySuggestion,
+  type NodeBinaryMode,
+  resolveUpgradeMigrateBinary,
+} from './migrate-binary-policy.js';
 import { normalizeMigrationCheck, replaceRawMigrateHint } from './migration-utils.js';
 import { getCustomBinaryState } from './node-runtime-daemon.js';
+import { normalizeTargetVersion, resolveManagedUpgradeVersion } from './node-version-policy.js';
 import { isProcessRunning, readPidFile } from './pid.js';
 
 export interface NodeUpgradeOptions {
@@ -21,26 +28,13 @@ export interface NodeUpgradeOptions {
   json?: boolean;
 }
 
-export type NodeUpgradeMode = 'managed-download' | 'custom-migrate-only';
+export type NodeUpgradeMode = NodeBinaryMode;
 
 export function getNodeUpgradeMode(resolvedBinary: ResolvedBinaryPath): NodeUpgradeMode {
   return resolvedBinary.source === 'profile-managed' ? 'managed-download' : 'custom-migrate-only';
 }
 
-export function getMigrateBinaryPathForBinary(binaryPath: string): string {
-  const binaryDir = dirname(binaryPath);
-  if (binaryDir === '.' || binaryDir.length === 0) {
-    throw new Error(
-      `Configured binaryPath "${binaryPath}" must include an explicit directory path. ` +
-        'Use an absolute path (for example /opt/fiber/fnn) or a relative path (for example ./fnn).',
-    );
-  }
-  return new BinaryManager(binaryDir).getMigrateBinaryPath();
-}
-
-function stripVersionPrefix(version: string): string {
-  return version.startsWith('v') ? version.slice(1) : version;
-}
+export { getMigrateBinaryPathForBinary };
 
 export async function runNodeUpgradeCommand(
   config: CliConfig,
@@ -70,38 +64,34 @@ export async function runNodeUpgradeCommand(
 
   // Prepare migration-related paths
   const storePath = MigrationManager.resolveStorePath(config.dataDir);
-  let migrateBinaryPath: string;
-  try {
-    migrateBinaryPath = getMigrateBinaryPathForBinary(resolvedBinary.binaryPath);
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
+  const storeExists = MigrationManager.storeExists(config.dataDir);
+  const migrateBinaryResolution = resolveUpgradeMigrateBinary(
+    resolvedBinary.binaryPath,
+    mode,
+    storeExists,
+  );
+  if (!migrateBinaryResolution.ok) {
+    const { error } = migrateBinaryResolution;
     if (json) {
-      printJsonError({
-        code: 'BINARY_PATH_INCOMPATIBLE',
-        message,
-        recoverable: true,
-        suggestion:
-          'Set binaryPath to an explicit file path (absolute or relative), or unset binaryPath to use profile-managed binaries.',
-      });
+      printJsonError(error);
     } else {
-      console.error(`❌ ${message}`);
-      console.log(
-        '   Set binaryPath to an explicit file path (absolute or relative), or unset binaryPath to use profile-managed binaries.',
-      );
+      console.error(`❌ ${error.message}`);
+      console.log(`   ${error.suggestion}`);
     }
     process.exit(1);
   }
-  let migrationCheck: Awaited<ReturnType<MigrationManager['check']>> | null = null;
 
-  const storeExists = MigrationManager.storeExists(config.dataDir);
+  const migrateBinaryPath = migrateBinaryResolution.migrateBinaryPath;
+  let migrationCheck: Awaited<ReturnType<MigrationManager['check']>> | null = null;
 
   if (mode === 'custom-migrate-only') {
     const currentInfo = getCustomBinaryState(resolvedBinary.binaryPath);
     const customBinaryManager = new BinaryManager(dirname(resolvedBinary.binaryPath));
-    const targetTag = options.version
-      ? customBinaryManager.normalizeTag(options.version)
+    const normalizedTarget = options.version
+      ? normalizeTargetVersion(customBinaryManager, options.version)
       : undefined;
-    const targetVersion = targetTag ? stripVersionPrefix(targetTag) : undefined;
+    const targetTag = normalizedTarget?.targetTag;
+    const targetVersion = normalizedTarget?.targetVersion;
 
     if (!json) {
       console.log('🧭 Upgrade mode: custom binary (migration-only).');
@@ -174,19 +164,17 @@ export async function runNodeUpgradeCommand(
   const binaryManager = new BinaryManager(installDir);
 
   // Resolve target version
-  let targetTag: string;
-  if (options.version) {
-    targetTag = binaryManager.normalizeTag(options.version);
-  } else {
-    if (!json) console.log('🔍 Resolving latest Fiber release...');
-    targetTag = await binaryManager.getLatestTag();
+  const upgradeVersion = await resolveManagedUpgradeVersion(binaryManager, options.version);
+  const targetTag = upgradeVersion.targetTag;
+  const targetVersion = upgradeVersion.targetVersion;
+  if (upgradeVersion.source === 'latest' && !json) {
+    console.log('🔍 Resolving latest Fiber release...');
   }
 
   if (!json) console.log(`📦 Target version: ${targetTag}`);
 
   // Check current version
   const currentInfo = await binaryManager.getBinaryInfo();
-  const targetVersion = stripVersionPrefix(targetTag);
 
   if (!json && storeExists) {
     console.log('📂 Existing store detected.');
@@ -352,22 +340,11 @@ async function runMigrationAndReport(
         code: 'MIGRATION_TOOL_MISSING',
         message: `Migration check failed: ${msg}`,
         recoverable: true,
-        suggestion:
-          mode === 'custom-migrate-only'
-            ? `Verify fnn-migrate exists next to configured binary in "${dirname(binaryPath)}", then retry.`
-            : 'Run `fiber-pay node upgrade` to reinstall binaries, then retry `fiber-pay node upgrade --force-migrate`.',
+        suggestion: getMissingMigrateVerifySuggestion(mode, binaryPath),
       });
     } else {
       console.error(`\n⚠️  Migration check failed: ${msg}`);
-      if (mode === 'custom-migrate-only') {
-        console.log(
-          `   Verify fnn-migrate exists next to configured binary in "${dirname(binaryPath)}", then retry.`,
-        );
-      } else {
-        console.log(
-          '   Run `fiber-pay node upgrade` to reinstall binaries, then retry `fiber-pay node upgrade --force-migrate`.',
-        );
-      }
+      console.log(`   ${getMissingMigrateVerifySuggestion(mode, binaryPath)}`);
     }
     process.exit(1);
   }

--- a/packages/cli/src/lib/node-upgrade.ts
+++ b/packages/cli/src/lib/node-upgrade.ts
@@ -28,7 +28,14 @@ export function getNodeUpgradeMode(resolvedBinary: ResolvedBinaryPath): NodeUpgr
 }
 
 export function getMigrateBinaryPathForBinary(binaryPath: string): string {
-  return new BinaryManager(dirname(binaryPath)).getMigrateBinaryPath();
+  const binaryDir = dirname(binaryPath);
+  if (binaryDir === '.' || binaryDir.length === 0) {
+    throw new Error(
+      `Configured binaryPath "${binaryPath}" must include an explicit directory path. ` +
+        'Use an absolute path (for example /opt/fiber/fnn) or a relative path (for example ./fnn).',
+    );
+  }
+  return new BinaryManager(binaryDir).getMigrateBinaryPath();
 }
 
 function stripVersionPrefix(version: string): string {
@@ -43,7 +50,7 @@ export async function runNodeUpgradeCommand(
   const resolvedBinary = resolveBinaryPath(config);
   const mode = getNodeUpgradeMode(resolvedBinary);
 
-  // Step 1: Check if node is running — must be stopped before upgrade
+  // Pre-flight: node must be stopped before upgrade
   const pid = readPidFile(config.dataDir);
   if (pid && isProcessRunning(pid)) {
     const msg = 'The Fiber node is currently running. Stop it before upgrading.';
@@ -61,9 +68,29 @@ export async function runNodeUpgradeCommand(
     process.exit(1);
   }
 
-  // Step 4: Prepare migration-related paths
+  // Prepare migration-related paths
   const storePath = MigrationManager.resolveStorePath(config.dataDir);
-  const migrateBinaryPath = getMigrateBinaryPathForBinary(resolvedBinary.binaryPath);
+  let migrateBinaryPath: string;
+  try {
+    migrateBinaryPath = getMigrateBinaryPathForBinary(resolvedBinary.binaryPath);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (json) {
+      printJsonError({
+        code: 'BINARY_PATH_INCOMPATIBLE',
+        message,
+        recoverable: true,
+        suggestion:
+          'Set binaryPath to an explicit file path (absolute or relative), or unset binaryPath to use profile-managed binaries.',
+      });
+    } else {
+      console.error(`❌ ${message}`);
+      console.log(
+        '   Set binaryPath to an explicit file path (absolute or relative), or unset binaryPath to use profile-managed binaries.',
+      );
+    }
+    process.exit(1);
+  }
   let migrationCheck: Awaited<ReturnType<MigrationManager['check']>> | null = null;
 
   const storeExists = MigrationManager.storeExists(config.dataDir);
@@ -146,7 +173,7 @@ export async function runNodeUpgradeCommand(
 
   const binaryManager = new BinaryManager(installDir);
 
-  // Step 2: Resolve target version
+  // Resolve target version
   let targetTag: string;
   if (options.version) {
     targetTag = binaryManager.normalizeTag(options.version);
@@ -157,7 +184,7 @@ export async function runNodeUpgradeCommand(
 
   if (!json) console.log(`📦 Target version: ${targetTag}`);
 
-  // Step 3: Check current version
+  // Check current version
   const currentInfo = await binaryManager.getBinaryInfo();
   const targetVersion = stripVersionPrefix(targetTag);
 
@@ -209,7 +236,7 @@ export async function runNodeUpgradeCommand(
       console.log('📂 Existing store detected, will check migration after download.');
     }
 
-    // Step 5: Download new binary (this also extracts fnn-migrate)
+    // Download new binary (this also extracts fnn-migrate)
     if (!json) console.log('⬇️  Downloading new binary...');
 
     const showProgress = (progress: DownloadProgress) => {
@@ -230,7 +257,7 @@ export async function runNodeUpgradeCommand(
     console.log('🔁 --force-migrate enabled: attempting migration flow on existing binaries.');
   }
 
-  // Step 6: Check migration if store exists
+  // Check migration if store exists
   if (storeExists) {
     migrationCheck = await runMigrationAndReport({
       migrateBinaryPath,
@@ -245,7 +272,7 @@ export async function runNodeUpgradeCommand(
     });
   }
 
-  // Step 7: Final status
+  // Final status
   const newInfo = await binaryManager.getBinaryInfo();
 
   if (resolvedBinary.source === 'profile-managed') {
@@ -310,36 +337,7 @@ async function runMigrationAndReport(
     binaryPath,
   } = opts;
 
-  // Instantiate MigrationManager
-  let migrationManager: MigrationManager;
-  try {
-    migrationManager = new MigrationManager(migrateBinaryPath);
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : 'fnn-migrate binary not available';
-    if (json) {
-      printJsonError({
-        code: 'MIGRATION_TOOL_MISSING',
-        message: msg,
-        recoverable: true,
-        suggestion:
-          mode === 'custom-migrate-only'
-            ? `Place fnn-migrate next to configured binary in "${dirname(binaryPath)}", or unset binaryPath to switch back to profile-managed binaries.`
-            : 'Run `fiber-pay node upgrade` to reinstall binaries, then retry `fiber-pay node upgrade --force-migrate`.',
-      });
-    } else {
-      console.error(`\n⚠️  ${msg}`);
-      if (mode === 'custom-migrate-only') {
-        console.log(
-          `   Place fnn-migrate next to configured binary in "${dirname(binaryPath)}", or unset binaryPath to use profile-managed binaries.`,
-        );
-      } else {
-        console.log(
-          '   Run `fiber-pay node upgrade` to reinstall binaries, then retry `fiber-pay node upgrade --force-migrate`.',
-        );
-      }
-    }
-    process.exit(1);
-  }
+  const migrationManager = new MigrationManager(migrateBinaryPath);
 
   // Run check
   if (!json) console.log('🔍 Checking store compatibility...');

--- a/packages/cli/src/lib/node-version-policy.ts
+++ b/packages/cli/src/lib/node-version-policy.ts
@@ -1,0 +1,61 @@
+import type { BinaryManager } from '@fiber-pay/node';
+import type { ProfileConfig } from './config.js';
+
+export type ManagedStartVersionSource = 'profile' | 'default';
+
+export interface ManagedStartVersionDecision {
+  version: string | undefined;
+  source: ManagedStartVersionSource;
+}
+
+export type ManagedUpgradeVersionSource = 'requested' | 'latest';
+
+export interface ManagedUpgradeVersionDecision {
+  targetTag: string;
+  targetVersion: string;
+  source: ManagedUpgradeVersionSource;
+}
+
+export function stripVersionPrefix(version: string): string {
+  return version.startsWith('v') ? version.slice(1) : version;
+}
+
+export function normalizeTargetVersion(
+  binaryManager: BinaryManager,
+  version: string,
+): Pick<ManagedUpgradeVersionDecision, 'targetTag' | 'targetVersion'> {
+  const targetTag = binaryManager.normalizeTag(version);
+  return {
+    targetTag,
+    targetVersion: stripVersionPrefix(targetTag),
+  };
+}
+
+export async function resolveManagedUpgradeVersion(
+  binaryManager: BinaryManager,
+  requestedVersion?: string,
+): Promise<ManagedUpgradeVersionDecision> {
+  if (requestedVersion) {
+    const normalized = normalizeTargetVersion(binaryManager, requestedVersion);
+    return { ...normalized, source: 'requested' };
+  }
+
+  const targetTag = await binaryManager.getLatestTag();
+  return {
+    targetTag,
+    targetVersion: stripVersionPrefix(targetTag),
+    source: 'latest',
+  };
+}
+
+export function resolveManagedStartVersion(
+  profile: ProfileConfig | undefined,
+): ManagedStartVersionDecision {
+  const raw = profile?.fiberVersion;
+  const version = raw && raw.trim().length > 0 ? raw.trim() : undefined;
+
+  return {
+    version,
+    source: version ? 'profile' : 'default',
+  };
+}

--- a/packages/cli/tests/node-upgrade-mode.test.ts
+++ b/packages/cli/tests/node-upgrade-mode.test.ts
@@ -1,3 +1,4 @@
+import { basename, dirname, normalize } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import type { ResolvedBinaryPath } from '../src/lib/binary-path.js';
 import {
@@ -40,11 +41,16 @@ describe('node upgrade mode', () => {
   });
 
   it('resolves fnn-migrate path from configured binary directory', () => {
-    const migratePath = getMigrateBinaryPathForBinary('/opt/fiber/custom/my-fnn');
+    const binaryPath = '/opt/fiber/custom/my-fnn';
+    const migratePath = getMigrateBinaryPathForBinary(binaryPath);
 
-    expect(migratePath).toContain('/opt/fiber/custom/');
-    expect(migratePath.endsWith('/fnn-migrate') || migratePath.endsWith('\\fnn-migrate.exe')).toBe(
-      true,
+    expect(normalize(dirname(migratePath))).toBe(normalize(dirname(binaryPath)));
+    expect(basename(migratePath)).toBe(process.platform === 'win32' ? 'fnn-migrate.exe' : 'fnn-migrate');
+  });
+
+  it('rejects bare command names for migrate path derivation', () => {
+    expect(() => getMigrateBinaryPathForBinary('fnn')).toThrow(
+      /must include an explicit directory path/i,
     );
   });
 });

--- a/packages/cli/tests/node-upgrade-mode.test.ts
+++ b/packages/cli/tests/node-upgrade-mode.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import type { ResolvedBinaryPath } from '../src/lib/binary-path.js';
+import {
+  getMigrateBinaryPathForBinary,
+  getNodeUpgradeMode,
+  type NodeUpgradeMode,
+} from '../src/lib/node-upgrade.js';
+
+function createResolvedBinary(overrides: Partial<ResolvedBinaryPath> = {}): ResolvedBinaryPath {
+  return {
+    binaryPath: '/tmp/fiber-pay/bin/fnn',
+    installDir: '/tmp/fiber-pay/bin',
+    managedPath: '/tmp/fiber-pay/bin/fnn',
+    managedByBinaryManager: true,
+    source: 'profile-managed',
+    ...overrides,
+  };
+}
+
+describe('node upgrade mode', () => {
+  it('uses managed-download mode for profile-managed binary paths', () => {
+    const resolved = createResolvedBinary();
+
+    const mode: NodeUpgradeMode = getNodeUpgradeMode(resolved);
+
+    expect(mode).toBe('managed-download');
+  });
+
+  it('uses custom-migrate-only mode for configured binary paths', () => {
+    const resolved = createResolvedBinary({
+      source: 'configured-path',
+      binaryPath: '/opt/fiber/custom/my-fnn',
+      installDir: null,
+      managedByBinaryManager: false,
+    });
+
+    const mode: NodeUpgradeMode = getNodeUpgradeMode(resolved);
+
+    expect(mode).toBe('custom-migrate-only');
+  });
+
+  it('resolves fnn-migrate path from configured binary directory', () => {
+    const migratePath = getMigrateBinaryPathForBinary('/opt/fiber/custom/my-fnn');
+
+    expect(migratePath).toContain('/opt/fiber/custom/');
+    expect(migratePath.endsWith('/fnn-migrate') || migratePath.endsWith('\\fnn-migrate.exe')).toBe(
+      true,
+    );
+  });
+});

--- a/packages/cli/tests/node-version-policy.test.ts
+++ b/packages/cli/tests/node-version-policy.test.ts
@@ -1,0 +1,53 @@
+import { BinaryManager } from '@fiber-pay/node';
+import { describe, expect, it } from 'vitest';
+import {
+  normalizeTargetVersion,
+  resolveManagedStartVersion,
+  resolveManagedUpgradeVersion,
+} from '../src/lib/node-version-policy.js';
+
+describe('node version policy', () => {
+  it('uses profile fiberVersion for managed start when available', () => {
+    const decision = resolveManagedStartVersion({ fiberVersion: '0.8.1' });
+
+    expect(decision.version).toBe('0.8.1');
+    expect(decision.source).toBe('profile');
+  });
+
+  it('falls back to default-managed start version source when profile version is missing', () => {
+    const decision = resolveManagedStartVersion(undefined);
+
+    expect(decision.version).toBeUndefined();
+    expect(decision.source).toBe('default');
+  });
+
+  it('normalizes requested upgrade version tags', () => {
+    const manager = new BinaryManager('/tmp/fiber-pay-test-bin');
+    const normalized = normalizeTargetVersion(manager, '0.8.1');
+
+    expect(normalized.targetTag).toBe('v0.8.1');
+    expect(normalized.targetVersion).toBe('0.8.1');
+  });
+
+  it('resolves managed upgrade version from explicit request', async () => {
+    const manager = new BinaryManager('/tmp/fiber-pay-test-bin');
+    const decision = await resolveManagedUpgradeVersion(manager, 'v0.8.1');
+
+    expect(decision.targetTag).toBe('v0.8.1');
+    expect(decision.targetVersion).toBe('0.8.1');
+    expect(decision.source).toBe('requested');
+  });
+
+  it('resolves managed upgrade version from latest when not requested', async () => {
+    const manager = {
+      getLatestTag: async () => 'v0.9.0',
+      normalizeTag: (version: string) => (version.startsWith('v') ? version : `v${version}`),
+    } as unknown as BinaryManager;
+
+    const decision = await resolveManagedUpgradeVersion(manager);
+
+    expect(decision.targetTag).toBe('v0.9.0');
+    expect(decision.targetVersion).toBe('0.9.0');
+    expect(decision.source).toBe('latest');
+  });
+});

--- a/skills/fiber-pay/references/profile.md
+++ b/skills/fiber-pay/references/profile.md
@@ -77,7 +77,8 @@ fiber-pay --profile b node start
 
 ### What `node start` auto-handles
 
-- Binary: downloads if missing or version mismatch (via `ensureFiberBinary`)
+- Binary (profile-managed mode): ensures `<data-dir>/bin/fnn`; downloads if missing or version mismatch (via `ensureFiberBinary`)
+- Binary (custom `binaryPath` mode): uses the configured binary as-is; does not auto-download or replace it
 - Config: generates default `config.yml` if missing (via `ensureNodeConfigFile`)
 - Keys: generates `fiber/sk` if missing
 - Runtime: starts embedded runtime proxy + job orchestration

--- a/skills/fiber-pay/references/upgrade.md
+++ b/skills/fiber-pay/references/upgrade.md
@@ -43,10 +43,13 @@ fiber-pay node start
 
 `fiber-pay node start` automatically checks store compatibility before launching fnn. If migration is needed, it exits with `MIGRATION_REQUIRED` and directs the user to run `fiber-pay node upgrade --force-migrate`.
 
+If `fnn-migrate` is unavailable, startup guard pre-check can be skipped for that start attempt. In that case, the node may still fail later if the on-disk store is incompatible.
+
 ## Custom binary behavior
 
 - `node upgrade` does not overwrite custom binaries.
 - Migration still runs against the current store when present.
+- `binaryPath` must be an explicit file path (absolute like `/opt/fiber/fnn` or relative like `./fnn`), not a bare command name like `fnn`.
 - `fnn-migrate` is resolved from the configured binary directory. If missing, the command exits with an actionable error.
 
 ## When auto-migration fails

--- a/skills/fiber-pay/references/upgrade.md
+++ b/skills/fiber-pay/references/upgrade.md
@@ -6,6 +6,11 @@ Covers upgrading the Fiber node binary and migrating the on-disk database betwee
 
 Fiber's database schema may change between versions. The `fnn-migrate` binary (shipped alongside `fnn` in release archives) handles schema migration. fiber-pay automates the full upgrade flow via `fiber-pay node upgrade`.
 
+`fiber-pay node upgrade` is migration-first:
+
+- Managed binary mode (default profile-managed path): download/replace `fnn` when needed, then run migration checks.
+- Custom binary mode (`--binary-path` or profile `binaryPath`): skip binary download and run migration flow only.
+
 ## Upgrade flow
 
 ```bash
@@ -16,6 +21,9 @@ fiber-pay node stop
 fiber-pay node upgrade                    # latest version
 fiber-pay node upgrade --version v0.8.0   # specific version
 fiber-pay node upgrade --force-migrate    # force migration check/attempt
+
+# custom binary path: migration-only (no auto-download)
+fiber-pay --binary-path /opt/fiber/custom/fnn node upgrade --force-migrate
 
 # 3. Restart
 fiber-pay node start
@@ -34,6 +42,12 @@ fiber-pay node start
 ## Startup guard
 
 `fiber-pay node start` automatically checks store compatibility before launching fnn. If migration is needed, it exits with `MIGRATION_REQUIRED` and directs the user to run `fiber-pay node upgrade --force-migrate`.
+
+## Custom binary behavior
+
+- `node upgrade` does not overwrite custom binaries.
+- Migration still runs against the current store when present.
+- `fnn-migrate` is resolved from the configured binary directory. If missing, the command exits with an actionable error.
 
 ## When auto-migration fails
 


### PR DESCRIPTION
## Summary\n- make    Run: fiber-pay node stop migration-first\n- add custom binary mode: skip binary download and run migration flow only\n- improve custom-mode migration error suggestions when  is missing\n- update node upgrade command description and upgrade reference docs\n- add unit tests for upgrade mode resolution and migrate binary path derivation\n\n## Validation\n- 
> @fiber-pay/cli@0.2.4 test:run /Users/retric/Desktop/fiber-pay/packages/cli
> vitest run --config vitest.config.ts tests/node-upgrade-mode.test.ts tests/binary-path.test.ts


[1m[46m RUN [49m[22m [36mv4.0.18 [39m[90m/Users/retric/Desktop/fiber-pay/packages/cli[39m

 [32m✓[39m tests/binary-path.test.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 2[2mms[22m[39m
 [32m✓[39m tests/node-upgrade-mode.test.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 1[2mms[22m[39m

[2m Test Files [22m [1m[32m2 passed[39m[22m[90m (2)[39m
[2m      Tests [22m [1m[32m8 passed[39m[22m[90m (8)[39m
[2m   Start at [22m 13:26:03
[2m   Duration [22m 244ms[2m (transform 173ms, setup 0ms, import 280ms, tests 4ms, environment 0ms)[22m\n- 
> @fiber-pay/cli@0.2.4 typecheck /Users/retric/Desktop/fiber-pay/packages/cli
> tsc --noEmit\n- 
> @fiber-pay/cli@0.2.4 build /Users/retric/Desktop/fiber-pay/packages/cli
> tsup

CLI Building entry: {"cli":"src/index.ts"}
CLI Using tsconfig: tsconfig.json
CLI tsup v8.5.1
CLI Using tsup config: /Users/retric/Desktop/fiber-pay/packages/cli/tsup.config.ts
CLI Target: node20
CLI Cleaning output folder
ESM Build start
ESM dist/cli.js     337.92 KB
ESM dist/cli.js.map 627.35 KB
ESM ⚡️ Build success in 46ms
DTS Build start
DTS ⚡️ Build success in 1244ms
DTS dist/cli.d.ts 13.00 B\n- runtime acceptance (real CLI):\n  - custom binary + no store => succeeds with \n  - custom binary + store + missing fnn-migrate => exits with  and actionable suggestion\n\nCloses #123