### PR TITLE
feat: improve React demo and adopt ConnectButton in browser-wallet

### DIFF
--- a/.changeset/connect-button-explicit-strategy.md
+++ b/.changeset/connect-button-explicit-strategy.md
@@ -1,0 +1,5 @@
+---
+'@fiber-pay/react': minor
+---
+
+refactor(react): simplify `ConnectButton` strategy selection by requiring an explicit `password` or `passkey` strategy. The button no longer auto-selects credentials or exposes raw-key connection props; advanced raw-key flows remain available through `useFiberNode().startWithRawKey()`.

--- a/apps/browser-wallet/README.md
+++ b/apps/browser-wallet/README.md
@@ -18,6 +18,8 @@ pnpm -C apps/browser-wallet build
 
 After node startup, the app exposes common operational flows (similar to CLI workflows):
 
+- Connect entry: `ConnectButton` with explicit `password` / `passkey` strategy and custom dropdown actions
+
 - Node lifecycle: start/stop with password or passkey
 - Runtime snapshot: `node_info`, `list_peers`, `list_channels`
 - Peer operations: `connect_peer`, `disconnect_peer`

--- a/apps/browser-wallet/src/App.tsx
+++ b/apps/browser-wallet/src/App.tsx
@@ -6,7 +6,7 @@ import {
   getLockBalanceShannons,
   scriptToAddress,
 } from '@fiber-pay/sdk/browser';
-import { useFiberNode } from '@fiber-pay/react';
+import { ConnectButton, useFiberNode } from '@fiber-pay/react';
 import QRCode from 'qrcode';
 import { useFiberConsole } from './hooks/useFiberConsole';
 import {
@@ -18,14 +18,11 @@ import {
   Database,
   Globe,
   LoaderCircle,
-  Play,
   QrCode,
   RefreshCw,
   Server,
   Square,
   Wallet,
-  Eye,
-  EyeOff,
   XCircle,
 } from 'lucide-react';
 
@@ -69,21 +66,19 @@ function App() {
     return search.get('network') === 'mainnet' ? 'mainnet' : 'testnet';
   }, []);
 
+  const fiber = useFiberNode({
+    network: preferredNetwork,
+    walletId: `wallet-demo-${preferredNetwork}`,
+  });
   const {
-    startWithPassword,
-    startWithPasskey,
-    createPasskeyAndStart,
     stop,
     state,
     nodeInfo,
     node,
     isPasskeySupported,
     passkeyUnavailableReason,
-    hasPasskeyConfigured,
-  } = useFiberNode({
-    network: preferredNetwork,
-    walletId: `wallet-demo-${preferredNetwork}`,
-  });
+    error: nodeHookError,
+  } = fiber;
   const network = preferredNetwork;
   const {
     nodeInfo: latestNodeInfo,
@@ -110,6 +105,7 @@ function App() {
     queryPayment,
   } = useFiberConsole(node, state === 'running', network);
 
+  const [connectStrategy, setConnectStrategy] = useState<'password' | 'passkey'>('password');
   const [password, setPassword] = useState('demo-secret');
   const [connectAddress, setConnectAddress] = useState('');
   const [channelPeerId, setChannelPeerId] = useState('');
@@ -127,7 +123,6 @@ function App() {
   const [fundingBalanceShannons, setFundingBalanceShannons] = useState<bigint | null>(null);
   const [fundingBalanceError, setFundingBalanceError] = useState<string | null>(null);
   const [isFundingBalanceLoading, setIsFundingBalanceLoading] = useState(false);
-  const [showPassword, setShowPassword] = useState(false);
   const autoConnectTriedRef = useRef(false);
 
   const runtimeInfo = latestNodeInfo ?? nodeInfo;
@@ -313,65 +308,93 @@ function App() {
               )}
 
               <div className="auth-methods">
-                {isPasskeySupported && (
-                  <div className="auth-group auth-card">
-                    <p className="field-label">Passkey</p>
-                    <p className="auth-note">WebAuthn PRF derives an independent key pair from your authenticator.</p>
-                    {hasPasskeyConfigured ? (
-                      <button className="btn btn-primary" onClick={() => void startWithPasskey()} disabled={isBooting || isStopping}>
-                        <Play size={16} />
-                        Login with Passkey
-                      </button>
-                    ) : (
-                      <button className="btn btn-primary" onClick={() => void createPasskeyAndStart('DemoUser')} disabled={isBooting || isStopping}>
-                        <Play size={16} />
-                        Register Passkey
-                      </button>
-                    )}
-                  </div>
-                )}
+                <div className="auth-group auth-card">
+                  <p className="field-label">Connect Node</p>
+                  <p className="auth-note">
+                    Use <span className="mono">ConnectButton</span> as the primary auth entry, with custom UI for strategy and credentials.
+                  </p>
 
-                {!isPasskeySupported && (
-                  <div className="auth-group auth-card auth-card-disabled">
-                    <p className="field-label">Passkey</p>
-                    <p className="auth-note">Browser Passkey mode requires secure context, WebAuthn, and PRF support.</p>
-                    <div className="alert alert-warning">
+                  <div className="quick-actions">
+                    <button
+                      type="button"
+                      className={connectStrategy === 'password' ? 'btn' : 'btn btn-ghost'}
+                      onClick={() => setConnectStrategy('password')}
+                      disabled={isBooting || isStopping}
+                    >
+                      Password Strategy
+                    </button>
+                    <button
+                      type="button"
+                      className={connectStrategy === 'passkey' ? 'btn' : 'btn btn-ghost'}
+                      onClick={() => setConnectStrategy('passkey')}
+                      disabled={isBooting || isStopping}
+                    >
+                      Passkey Strategy
+                    </button>
+                  </div>
+
+                  {connectStrategy === 'password' && (
+                    <div className="password-row mt-4">
+                      <input
+                        type="password"
+                        className="input"
+                        value={password}
+                        onChange={(event) => setPassword(event.target.value)}
+                        placeholder="Unlock password"
+                        disabled={isBooting || isStopping}
+                      />
+                    </div>
+                  )}
+
+                  {connectStrategy === 'passkey' && !isPasskeySupported && (
+                    <div className="alert alert-warning mt-4">
                       <XCircle size={16} />
                       <span>{passkeyUnavailableReason ?? 'Passkey is unavailable in this browser/environment.'}</span>
                     </div>
-                  </div>
-                )}
+                  )}
 
-                {isPasskeySupported && (
-                  <div className="or-divider" aria-hidden="true">
-                    <span>OR</span>
-                  </div>
-                )}
+                  {nodeHookError && (
+                    <div className="alert alert-warning mt-4">
+                      <XCircle size={16} />
+                      <span>{nodeHookError}</span>
+                    </div>
+                  )}
 
-                <div className="auth-group auth-card">
-                  <p className="field-label">Password</p>
-                  <p className="auth-note">Password + local random salt (IndexedDB) derives another independent key pair.</p>
-                  <div className="password-row">
-                    <input
-                      type={showPassword ? 'text' : 'password'}
-                      className="input"
-                      value={password}
-                      onChange={(event) => setPassword(event.target.value)}
-                      placeholder="Unlock password"
+                  <div className="mt-4">
+                    <ConnectButton
+                      fiber={fiber}
+                      strategy={connectStrategy}
+                      password={connectStrategy === 'password' ? password : undefined}
+                      renderConnectedDropdown={({ disconnect, closeDropdown }) => (
+                        <div>
+                          <p className="field-label">Quick Actions</p>
+                          <p className="text-secondary mono">{shorten(runtimeInfo?.pubkey ?? '-', 18, 12)}</p>
+                          <div className="inline-actions mt-4">
+                            <button
+                              className="btn btn-ghost"
+                              type="button"
+                              onClick={() => {
+                                closeDropdown();
+                                void refreshSnapshot();
+                                void refreshGraph();
+                              }}
+                            >
+                              Refresh Snapshot
+                            </button>
+                            <button
+                              className="btn"
+                              type="button"
+                              onClick={() => {
+                                void disconnect();
+                              }}
+                            >
+                              Disconnect
+                            </button>
+                          </div>
+                        </div>
+                      )}
                     />
-                    <button
-                      type="button"
-                      className="btn btn-ghost btn-inline"
-                      onClick={() => setShowPassword((value) => !value)}
-                      aria-label={showPassword ? 'Hide password' : 'Show password'}
-                    >
-                      {showPassword ? <EyeOff size={14} /> : <Eye size={14} />}
-                    </button>
                   </div>
-                  <button className="btn" onClick={() => void startWithPassword(password)} disabled={isBooting || isStopping}>
-                    <Play size={16} />
-                    Start Node with Password
-                  </button>
                 </div>
               </div>
             </div>

--- a/apps/react-quick-card/README.md
+++ b/apps/react-quick-card/README.md
@@ -1,6 +1,6 @@
-# React Quick Card Demo
+# React SDK Demo (ConnectButton + QuickCard)
 
-A minimal Vite + React app demonstrating the `FiberPayQuickCard` component from `@fiber-pay/react`.
+A Vite + React app demonstrating both `ConnectButton` and `FiberPayQuickCard` from `@fiber-pay/react`.
 
 ## Run
 
@@ -12,10 +12,10 @@ Then open `http://localhost:5174`.
 
 ## What it demonstrates
 
-- One-line integration: `import { FiberPayQuickCard } from '@fiber-pay/react'`
-- Node startup with password or passkey
-- Create invoice and pay invoice directly in the card UI
-- Event hooks: `onInvoiceCreated`, `onPaymentResult`, `onError`
+- `ConnectButton` integration in external-hook mode via `useFiberNode`
+- Password-based connect/disconnect flow with a custom connected dropdown
+- Event callback wiring for connect/disconnect/error and quick log output
+- `FiberPayQuickCard` one-line integration and payment callbacks
 
 ## Notes
 

--- a/apps/react-quick-card/README.md
+++ b/apps/react-quick-card/README.md
@@ -12,10 +12,19 @@ Then open `http://localhost:5174`.
 
 ## What it demonstrates
 
-- `ConnectButton` integration in external-hook mode via `useFiberNode`
-- Password-based connect/disconnect flow with a custom connected dropdown
-- Event callback wiring for connect/disconnect/error and quick log output
-- `FiberPayQuickCard` one-line integration and payment callbacks
+- Step-by-step connection lifecycle with `useFiberNode` + `ConnectButton`
+- Direct source-code links for core SDK/demo files from inside the page
+- Explicit strategy selection (`password` or `passkey`) and live hook status visibility
+- UI customization showcase for `ConnectButton` (`style`, `dropdownStyle`, `renderConnectedDropdown`)
+- Runtime verification actions (`node_info`, `list_peers`, `list_channels`) after connect
+- `FiberPayQuickCard` as a standalone fast-MVP payment UI with callback wiring
+
+## Suggested walkthrough
+
+1. Choose a connection strategy in section 1.
+2. Connect the node and verify status changes to `running`.
+3. Click "Read runtime snapshot" to confirm RPC calls are working.
+4. Try section 2 to validate quick payment UI integration.
 
 ## Notes
 

--- a/apps/react-quick-card/src/App.tsx
+++ b/apps/react-quick-card/src/App.tsx
@@ -11,6 +11,11 @@ interface RuntimeSnapshot {
   channels: number;
 }
 
+interface EventLogEntry {
+  id: string;
+  text: string;
+}
+
 function shorten(value: string, head = 10, tail = 8): string {
   if (!value || value.length <= head + tail + 3) {
     return value;
@@ -21,15 +26,15 @@ function shorten(value: string, head = 10, tail = 8): string {
 const sourceLinks = [
   {
     label: 'ConnectButton source',
-    href: 'https://github.com/RetricSu/fiber-pay/blob/feat/react-quick-card-connect-demo/packages/react/src/connect-button.tsx',
+    href: 'https://github.com/RetricSu/fiber-pay/blob/main/packages/react/src/connect-button.tsx',
   },
   {
     label: 'useFiberNode source',
-    href: 'https://github.com/RetricSu/fiber-pay/blob/feat/react-quick-card-connect-demo/packages/react/src/use-fiber-node.ts',
+    href: 'https://github.com/RetricSu/fiber-pay/blob/main/packages/react/src/use-fiber-node.ts',
   },
   {
     label: 'This demo page source',
-    href: 'https://github.com/RetricSu/fiber-pay/blob/feat/react-quick-card-connect-demo/apps/react-quick-card/src/App.tsx',
+    href: 'https://github.com/RetricSu/fiber-pay/blob/main/apps/react-quick-card/src/App.tsx',
   },
 ];
 
@@ -51,7 +56,7 @@ const themedDropdownStyle: CSSProperties = {
 export function App() {
   const [strategy, setStrategy] = useState<ConnectStrategy>('password');
   const [password, setPassword] = useState('demo-secret');
-  const [eventLogs, setEventLogs] = useState<string[]>([]);
+  const [eventLogs, setEventLogs] = useState<EventLogEntry[]>([]);
   const [snapshot, setSnapshot] = useState<RuntimeSnapshot | null>(null);
   const [snapshotError, setSnapshotError] = useState<string | null>(null);
   const [isSnapshotLoading, setIsSnapshotLoading] = useState(false);
@@ -62,8 +67,13 @@ export function App() {
   });
 
   const addLog = (message: string) => {
-    const ts = new Date().toISOString().slice(11, 19);
-    setEventLogs((prev) => [`[${ts}] ${message}`, ...prev].slice(0, 20));
+    const now = new Date();
+    const ts = now.toISOString().slice(11, 19);
+    const entry = {
+      id: `${now.getTime()}-${crypto.randomUUID()}`,
+      text: `[${ts}] ${message}`,
+    };
+    setEventLogs((prev) => [entry, ...prev].slice(0, 20));
   };
 
   const clearLogs = () => {
@@ -407,7 +417,7 @@ export function App() {
         >
           {eventLogs.length === 0
             ? 'No events yet.'
-            : eventLogs.map((line, index) => <div key={`${index}-${line}`}>{line}</div>)}
+            : eventLogs.map((entry) => <div key={entry.id}>{entry.text}</div>)}
         </div>
       </section>
 

--- a/apps/react-quick-card/src/App.tsx
+++ b/apps/react-quick-card/src/App.tsx
@@ -1,10 +1,60 @@
 import type { GetPaymentResult } from '@fiber-pay/sdk/browser';
 import { ConnectButton, FiberPayQuickCard, useFiberNode } from '@fiber-pay/react';
-import { useMemo, useState } from 'react';
+import { type CSSProperties, useMemo, useState } from 'react';
+
+type ConnectStrategy = 'password' | 'passkey';
+
+interface RuntimeSnapshot {
+  nodeId: string;
+  version: string;
+  peers: number;
+  channels: number;
+}
+
+function shorten(value: string, head = 10, tail = 8): string {
+  if (!value || value.length <= head + tail + 3) {
+    return value;
+  }
+  return `${value.slice(0, head)}...${value.slice(-tail)}`;
+}
+
+const sourceLinks = [
+  {
+    label: 'ConnectButton source',
+    href: 'https://github.com/RetricSu/fiber-pay/blob/feat/react-quick-card-connect-demo/packages/react/src/connect-button.tsx',
+  },
+  {
+    label: 'useFiberNode source',
+    href: 'https://github.com/RetricSu/fiber-pay/blob/feat/react-quick-card-connect-demo/packages/react/src/use-fiber-node.ts',
+  },
+  {
+    label: 'This demo page source',
+    href: 'https://github.com/RetricSu/fiber-pay/blob/feat/react-quick-card-connect-demo/apps/react-quick-card/src/App.tsx',
+  },
+];
+
+const themedConnectRootStyle = {
+  '--fpay-accent': '#0f766e',
+  '--fpay-accent-fg': '#ecfeff',
+  '--fpay-accent-subtle': 'rgba(15,118,110,0.14)',
+  '--fpay-accent-border': 'rgba(15,118,110,0.35)',
+  '--fpay-border': '#99f6e4',
+  '--fpay-bg-elevated': '#f0fdfa',
+} as CSSProperties;
+
+const themedDropdownStyle: CSSProperties = {
+  width: 340,
+  borderRadius: 12,
+  border: '1px solid #5eead4',
+};
 
 export function App() {
+  const [strategy, setStrategy] = useState<ConnectStrategy>('password');
   const [password, setPassword] = useState('demo-secret');
   const [eventLogs, setEventLogs] = useState<string[]>([]);
+  const [snapshot, setSnapshot] = useState<RuntimeSnapshot | null>(null);
+  const [snapshotError, setSnapshotError] = useState<string | null>(null);
+  const [isSnapshotLoading, setIsSnapshotLoading] = useState(false);
 
   const fiber = useFiberNode({
     network: 'testnet',
@@ -13,7 +63,41 @@ export function App() {
 
   const addLog = (message: string) => {
     const ts = new Date().toISOString().slice(11, 19);
-    setEventLogs((prev) => [`[${ts}] ${message}`, ...prev].slice(0, 10));
+    setEventLogs((prev) => [`[${ts}] ${message}`, ...prev].slice(0, 20));
+  };
+
+  const clearLogs = () => {
+    setEventLogs([]);
+  };
+
+  const readRuntimeSnapshot = async () => {
+    if (!fiber.node) {
+      setSnapshotError('Node is not connected yet.');
+      return;
+    }
+
+    setIsSnapshotLoading(true);
+    setSnapshotError(null);
+    try {
+      const [info, peers, channels] = await Promise.all([
+        fiber.node.nodeInfo(),
+        fiber.node.listPeers(),
+        fiber.node.listChannels(),
+      ]);
+      setSnapshot({
+        nodeId: info.pubkey,
+        version: info.version,
+        peers: peers.peers?.length ?? 0,
+        channels: channels.channels?.length ?? 0,
+      });
+      addLog('Runtime snapshot loaded (node_info/list_peers/list_channels).');
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      setSnapshotError(message);
+      addLog(`Snapshot error: ${message}`);
+    } finally {
+      setIsSnapshotLoading(false);
+    }
   };
 
   const handleInvoiceCreated = (invoice: string) => {
@@ -31,21 +115,52 @@ export function App() {
     addLog(`QuickCard error (${error.scope}): ${error.message}`);
   };
 
-  const nodeSummary = useMemo(() => {
-    if (!fiber.nodeInfo?.pubkey) {
-      return 'Not connected';
-    }
-    const pubkey = fiber.nodeInfo.pubkey;
-    return `${pubkey.slice(0, 10)}...${pubkey.slice(-8)}`;
-  }, [fiber.nodeInfo?.pubkey]);
+  const statusSummary = useMemo(
+    () => [
+      { label: 'State', value: fiber.state },
+      { label: 'Connected', value: fiber.isRunning ? 'Yes' : 'No' },
+      { label: 'Node', value: fiber.nodeInfo?.pubkey ? shorten(fiber.nodeInfo.pubkey) : 'Not connected' },
+      {
+        label: 'Passkey Support',
+        value: fiber.isPasskeySupported ? 'Available' : fiber.passkeyUnavailableReason ?? 'Unavailable',
+      },
+    ],
+    [fiber.isPasskeySupported, fiber.isRunning, fiber.nodeInfo?.pubkey, fiber.passkeyUnavailableReason, fiber.state],
+  );
 
   return (
-    <div style={{ padding: 24, fontFamily: 'system-ui, sans-serif', maxWidth: 860, margin: '0 auto' }}>
-      <h1>Fiber Pay React SDK Demo</h1>
+    <div style={{ padding: 24, fontFamily: 'system-ui, sans-serif', maxWidth: 900, margin: '0 auto' }}>
+      <h1>Fiber Pay React SDK Capability Demo</h1>
       <p>
-        This page simulates a downstream integration. It demonstrates both{' '}
-        <code>ConnectButton</code> and <code>FiberPayQuickCard</code> usage.
+        This page is designed as a downstream developer walkthrough. It shows what the React SDK gives
+        you and how to verify each capability quickly.
       </p>
+      <ol style={{ marginTop: 8, paddingLeft: 22 }}>
+        <li>Connection lifecycle using <code>useFiberNode</code> + <code>ConnectButton</code>.</li>
+        <li>Basic runtime RPC checks after connection.</li>
+        <li>Fast payment UI integration using <code>FiberPayQuickCard</code>.</li>
+      </ol>
+
+      <div
+        style={{
+          marginTop: 12,
+          border: '1px solid #d1d5db',
+          borderRadius: 10,
+          padding: 12,
+          background: '#f8fafc',
+        }}
+      >
+        <strong style={{ fontSize: 14 }}>Source code links</strong>
+        <ul style={{ marginBottom: 0, marginTop: 8, paddingLeft: 18 }}>
+          {sourceLinks.map((item) => (
+            <li key={item.href}>
+              <a href={item.href} target="_blank" rel="noreferrer" style={{ color: '#1d4ed8' }}>
+                {item.label}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </div>
 
       <section
         style={{
@@ -56,27 +171,66 @@ export function App() {
           background: '#fafafa',
         }}
       >
-        <h2 style={{ marginTop: 0 }}>1) ConnectButton integration</h2>
+        <h2 style={{ marginTop: 0 }}>1) Connection + Lifecycle (Custom App Style)</h2>
         <p style={{ marginTop: 0 }}>
-          Shared hook mode with custom connected dropdown, using password strategy.
+          Use one shared <code>useFiberNode</code> instance and drive connection with explicit strategy.
         </p>
 
-        <label style={{ display: 'block', fontSize: 13, marginBottom: 8 }}>
-          Password
-          <input
-            type="password"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            style={{ marginLeft: 8, padding: '6px 8px', borderRadius: 8, border: '1px solid #d1d5db' }}
-          />
-        </label>
+        <div style={{ display: 'flex', gap: 8, marginBottom: 10, flexWrap: 'wrap' }}>
+          <button
+            type="button"
+            onClick={() => setStrategy('password')}
+            style={{
+              border: '1px solid #d1d5db',
+              borderRadius: 8,
+              padding: '6px 10px',
+              background: strategy === 'password' ? '#111827' : '#fff',
+              color: strategy === 'password' ? '#fff' : '#111827',
+              cursor: 'pointer',
+            }}
+          >
+            Password Strategy
+          </button>
+          <button
+            type="button"
+            onClick={() => setStrategy('passkey')}
+            style={{
+              border: '1px solid #d1d5db',
+              borderRadius: 8,
+              padding: '6px 10px',
+              background: strategy === 'passkey' ? '#111827' : '#fff',
+              color: strategy === 'passkey' ? '#fff' : '#111827',
+              cursor: 'pointer',
+            }}
+          >
+            Passkey Strategy
+          </button>
+        </div>
+
+        {strategy === 'password' && (
+          <label style={{ display: 'block', fontSize: 13, marginBottom: 12 }}>
+            Password
+            <input
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              style={{ marginLeft: 8, padding: '6px 8px', borderRadius: 8, border: '1px solid #d1d5db' }}
+            />
+          </label>
+        )}
+
+        {strategy === 'passkey' && !fiber.isPasskeySupported && (
+          <p style={{ marginTop: 0, color: '#b45309', fontSize: 13 }}>
+            Passkey is currently unavailable: {fiber.passkeyUnavailableReason}
+          </p>
+        )}
 
         <ConnectButton
           fiber={fiber}
-          strategy="password"
-          password={password}
+          strategy={strategy}
+          password={strategy === 'password' ? password : undefined}
           onConnect={(_node, info) => {
-            addLog(`ConnectButton connected: ${info.pubkey.slice(0, 12)}...`);
+            addLog(`ConnectButton connected: ${shorten(info.pubkey, 12, 10)}`);
           }}
           onDisconnect={() => {
             addLog('ConnectButton disconnected');
@@ -84,44 +238,160 @@ export function App() {
           onError={(msg) => {
             addLog(`ConnectButton error: ${msg}`);
           }}
-          renderConnectedDropdown={({ fiber: dropdownFiber, disconnect }) => (
-            <div>
-              <div style={{ fontSize: 12, color: '#6b7280' }}>Connected via custom dropdown</div>
-              <div style={{ marginTop: 8, fontSize: 12 }}>
-                State: <strong>{dropdownFiber.state}</strong>
-              </div>
-              <div style={{ marginTop: 4, fontSize: 12 }}>
-                Node: {dropdownFiber.nodeInfo?.pubkey?.slice(0, 20) ?? 'n/a'}
-              </div>
-              <button
-                type="button"
-                onClick={() => {
-                  void disconnect();
-                }}
-                style={{
-                  marginTop: 10,
-                  width: '100%',
-                  padding: '8px 10px',
-                  borderRadius: 8,
-                  border: '1px solid #d1d5db',
-                  background: '#fff',
-                  cursor: 'pointer',
-                }}
-              >
-                Disconnect
-              </button>
-            </div>
-          )}
         />
 
-        <div style={{ marginTop: 12, fontSize: 13 }}>
-          <div>
-            Hook state: <strong>{fiber.state}</strong>
-          </div>
-          <div>
-            Node: <strong>{nodeSummary}</strong>
+        <div
+          style={{
+            marginTop: 14,
+            border: '1px dashed #cbd5e1',
+            borderRadius: 10,
+            padding: 12,
+            background: '#fff',
+          }}
+        >
+          <h3 style={{ marginTop: 0, marginBottom: 8, fontSize: 16 }}>UI Customization Showcase</h3>
+          <p style={{ marginTop: 0, fontSize: 13, color: '#475569' }}>
+            Same connection state, different UI surface. This mimics component-library style examples.
+          </p>
+          <div style={{ display: 'grid', gap: 12, gridTemplateColumns: 'repeat(auto-fit, minmax(260px, 1fr))' }}>
+            <div style={{ border: '1px solid #e2e8f0', borderRadius: 10, padding: 10 }}>
+              <div style={{ fontSize: 12, color: '#64748b', marginBottom: 8 }}>Default appearance</div>
+              <ConnectButton
+                fiber={fiber}
+                strategy={strategy}
+                password={strategy === 'password' ? password : undefined}
+              />
+            </div>
+
+            <div style={{ border: '1px solid #99f6e4', borderRadius: 10, padding: 10, background: '#f0fdfa' }}>
+              <div style={{ fontSize: 12, color: '#0f766e', marginBottom: 8 }}>Themed + custom dropdown</div>
+              <ConnectButton
+                fiber={fiber}
+                strategy={strategy}
+                password={strategy === 'password' ? password : undefined}
+                style={themedConnectRootStyle}
+                dropdownStyle={themedDropdownStyle}
+                renderConnectedDropdown={({ fiber: dropdownFiber, disconnect }) => (
+                  <div>
+                    <div style={{ fontSize: 12, color: '#0f766e', marginBottom: 6 }}>Custom connected panel</div>
+                    <div style={{ fontSize: 12, marginBottom: 4 }}>
+                      State: <strong>{dropdownFiber.state}</strong>
+                    </div>
+                    <div style={{ fontSize: 12, marginBottom: 8 }}>
+                      Pubkey: <strong>{shorten(dropdownFiber.nodeInfo?.pubkey ?? 'n/a', 8, 6)}</strong>
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        void disconnect();
+                      }}
+                      style={{
+                        width: '100%',
+                        borderRadius: 8,
+                        border: '1px solid #0f766e',
+                        background: '#14b8a6',
+                        color: '#fff',
+                        padding: '7px 10px',
+                        cursor: 'pointer',
+                      }}
+                    >
+                      Disconnect (custom action)
+                    </button>
+                  </div>
+                )}
+              />
+            </div>
           </div>
         </div>
+
+        <div style={{ marginTop: 12, fontSize: 13, display: 'grid', gap: 6 }}>
+          {statusSummary.map((item) => (
+            <div key={item.label}>
+              {item.label}: <strong>{item.value}</strong>
+            </div>
+          ))}
+        </div>
+
+        {fiber.error && (
+          <div
+            style={{
+              marginTop: 10,
+              border: '1px solid #fecaca',
+              background: '#fef2f2',
+              color: '#991b1b',
+              borderRadius: 8,
+              padding: '8px 10px',
+              fontSize: 13,
+            }}
+          >
+            Hook error: {fiber.error}
+          </div>
+        )}
+
+        <div style={{ marginTop: 12, display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+          <button
+            type="button"
+            onClick={() => {
+              void readRuntimeSnapshot();
+            }}
+            disabled={!fiber.isRunning || isSnapshotLoading}
+            style={{
+              border: '1px solid #d1d5db',
+              borderRadius: 8,
+              padding: '7px 10px',
+              background: '#fff',
+              cursor: fiber.isRunning ? 'pointer' : 'not-allowed',
+              opacity: fiber.isRunning ? 1 : 0.6,
+            }}
+          >
+            {isSnapshotLoading ? 'Reading snapshot...' : 'Read runtime snapshot'}
+          </button>
+          <button
+            type="button"
+            onClick={clearLogs}
+            style={{
+              border: '1px solid #d1d5db',
+              borderRadius: 8,
+              padding: '7px 10px',
+              background: '#fff',
+              cursor: 'pointer',
+            }}
+          >
+            Clear logs
+          </button>
+        </div>
+
+        {snapshotError && (
+          <p style={{ marginTop: 10, color: '#b91c1c', fontSize: 13 }}>Snapshot error: {snapshotError}</p>
+        )}
+
+        {snapshot && (
+          <div
+            style={{
+              marginTop: 10,
+              border: '1px solid #d1d5db',
+              background: '#fff',
+              borderRadius: 8,
+              padding: 10,
+              fontSize: 13,
+              display: 'grid',
+              gap: 4,
+            }}
+          >
+            <div>
+              Snapshot Node: <strong>{shorten(snapshot.nodeId)}</strong>
+            </div>
+            <div>
+              Version: <strong>{snapshot.version}</strong>
+            </div>
+            <div>
+              Peers: <strong>{snapshot.peers}</strong>
+            </div>
+            <div>
+              Channels: <strong>{snapshot.channels}</strong>
+            </div>
+          </div>
+        )}
 
         <div
           style={{
@@ -135,7 +405,9 @@ export function App() {
             minHeight: 110,
           }}
         >
-          {eventLogs.length === 0 ? 'No events yet.' : eventLogs.map((line) => <div key={line}>{line}</div>)}
+          {eventLogs.length === 0
+            ? 'No events yet.'
+            : eventLogs.map((line, index) => <div key={`${index}-${line}`}>{line}</div>)}
         </div>
       </section>
 
@@ -147,18 +419,19 @@ export function App() {
           padding: 16,
         }}
       >
-        <h2 style={{ marginTop: 0 }}>2) FiberPayQuickCard integration</h2>
-      <p>
-        This is the existing minimal demo of the <code>FiberPayQuickCard</code> component from{' '}
-        <code>@fiber-pay/react</code>.
-      </p>
-      <FiberPayQuickCard
-        network="testnet"
-        title="Quick Card"
-        onInvoiceCreated={handleInvoiceCreated}
-        onPaymentResult={handlePaymentResult}
-        onError={handleError}
-      />
+        <h2 style={{ marginTop: 0 }}>2) Quick Payment UI (MVP Style)</h2>
+        <p>
+          <code>FiberPayQuickCard</code> is the fastest way to embed invoice creation + payment actions.
+          This block is intentionally standalone and uses a separate <code>walletId</code>.
+        </p>
+        <FiberPayQuickCard
+          network="testnet"
+          walletId="quick-card-mvp-demo"
+          title="Quick Card"
+          onInvoiceCreated={handleInvoiceCreated}
+          onPaymentResult={handlePaymentResult}
+          onError={handleError}
+        />
       </section>
     </div>
   );

--- a/apps/react-quick-card/src/App.tsx
+++ b/apps/react-quick-card/src/App.tsx
@@ -1,24 +1,155 @@
 import type { GetPaymentResult } from '@fiber-pay/sdk/browser';
-import { FiberPayQuickCard } from '@fiber-pay/react';
+import { ConnectButton, FiberPayQuickCard, useFiberNode } from '@fiber-pay/react';
+import { useMemo, useState } from 'react';
 
 export function App() {
+  const [password, setPassword] = useState('demo-secret');
+  const [eventLogs, setEventLogs] = useState<string[]>([]);
+
+  const fiber = useFiberNode({
+    network: 'testnet',
+    walletId: 'quick-card-connect-demo',
+  });
+
+  const addLog = (message: string) => {
+    const ts = new Date().toISOString().slice(11, 19);
+    setEventLogs((prev) => [`[${ts}] ${message}`, ...prev].slice(0, 10));
+  };
+
   const handleInvoiceCreated = (invoice: string) => {
     console.log('Invoice created:', invoice);
+    addLog(`QuickCard invoice created: ${invoice.slice(0, 32)}...`);
   };
 
   const handlePaymentResult = (result: GetPaymentResult) => {
     console.log('Payment result:', result);
+    addLog(`QuickCard payment status: ${result.status}`);
   };
 
   const handleError = (error: { scope: 'node' | 'payment' | 'invoice'; message: string }) => {
     console.error('FiberPay error:', error);
+    addLog(`QuickCard error (${error.scope}): ${error.message}`);
   };
 
+  const nodeSummary = useMemo(() => {
+    if (!fiber.nodeInfo?.pubkey) {
+      return 'Not connected';
+    }
+    const pubkey = fiber.nodeInfo.pubkey;
+    return `${pubkey.slice(0, 10)}...${pubkey.slice(-8)}`;
+  }, [fiber.nodeInfo?.pubkey]);
+
   return (
-    <div style={{ padding: 24, fontFamily: 'system-ui, sans-serif' }}>
-      <h1>Fiber Pay Quick Card Demo</h1>
+    <div style={{ padding: 24, fontFamily: 'system-ui, sans-serif', maxWidth: 860, margin: '0 auto' }}>
+      <h1>Fiber Pay React SDK Demo</h1>
       <p>
-        This is a minimal demo of the <code>FiberPayQuickCard</code> component from{' '}
+        This page simulates a downstream integration. It demonstrates both{' '}
+        <code>ConnectButton</code> and <code>FiberPayQuickCard</code> usage.
+      </p>
+
+      <section
+        style={{
+          marginTop: 20,
+          border: '1px solid #e5e7eb',
+          borderRadius: 12,
+          padding: 16,
+          background: '#fafafa',
+        }}
+      >
+        <h2 style={{ marginTop: 0 }}>1) ConnectButton integration</h2>
+        <p style={{ marginTop: 0 }}>
+          Shared hook mode with custom connected dropdown, using password strategy.
+        </p>
+
+        <label style={{ display: 'block', fontSize: 13, marginBottom: 8 }}>
+          Password
+          <input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            style={{ marginLeft: 8, padding: '6px 8px', borderRadius: 8, border: '1px solid #d1d5db' }}
+          />
+        </label>
+
+        <ConnectButton
+          fiber={fiber}
+          strategy="password"
+          password={password}
+          onConnect={(_node, info) => {
+            addLog(`ConnectButton connected: ${info.pubkey.slice(0, 12)}...`);
+          }}
+          onDisconnect={() => {
+            addLog('ConnectButton disconnected');
+          }}
+          onError={(msg) => {
+            addLog(`ConnectButton error: ${msg}`);
+          }}
+          renderConnectedDropdown={({ fiber: dropdownFiber, disconnect }) => (
+            <div>
+              <div style={{ fontSize: 12, color: '#6b7280' }}>Connected via custom dropdown</div>
+              <div style={{ marginTop: 8, fontSize: 12 }}>
+                State: <strong>{dropdownFiber.state}</strong>
+              </div>
+              <div style={{ marginTop: 4, fontSize: 12 }}>
+                Node: {dropdownFiber.nodeInfo?.pubkey?.slice(0, 20) ?? 'n/a'}
+              </div>
+              <button
+                type="button"
+                onClick={() => {
+                  void disconnect();
+                }}
+                style={{
+                  marginTop: 10,
+                  width: '100%',
+                  padding: '8px 10px',
+                  borderRadius: 8,
+                  border: '1px solid #d1d5db',
+                  background: '#fff',
+                  cursor: 'pointer',
+                }}
+              >
+                Disconnect
+              </button>
+            </div>
+          )}
+        />
+
+        <div style={{ marginTop: 12, fontSize: 13 }}>
+          <div>
+            Hook state: <strong>{fiber.state}</strong>
+          </div>
+          <div>
+            Node: <strong>{nodeSummary}</strong>
+          </div>
+        </div>
+
+        <div
+          style={{
+            marginTop: 12,
+            background: '#111827',
+            color: '#e5e7eb',
+            borderRadius: 8,
+            padding: 10,
+            fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+            fontSize: 12,
+            minHeight: 110,
+          }}
+        >
+          {eventLogs.length === 0 ? 'No events yet.' : eventLogs.map((line) => <div key={line}>{line}</div>)}
+        </div>
+      </section>
+
+      <section
+        style={{
+          marginTop: 20,
+          border: '1px solid #e5e7eb',
+          borderRadius: 12,
+          padding: 16,
+        }}
+      >
+        <h2 style={{ marginTop: 0 }}>2) FiberPayQuickCard integration</h2>
+      <p>
+        This is the existing minimal demo of the <code>FiberPayQuickCard</code> component from{' '}
         <code>@fiber-pay/react</code>.
       </p>
       <FiberPayQuickCard
@@ -28,6 +159,7 @@ export function App() {
         onPaymentResult={handlePaymentResult}
         onError={handleError}
       />
+      </section>
     </div>
   );
 }

--- a/docs/wasm-passkey-payment-component-quickstart.md
+++ b/docs/wasm-passkey-payment-component-quickstart.md
@@ -180,7 +180,9 @@ await node.newInvoice({ amount: '0x5f5e100', description: 'hello' });
 
 - React package: official hooks and starter component are available in `@fiber-pay/react`.
 - SDK browser API: still available for advanced integrations and custom abstractions.
-- Demo app: `apps/browser-wallet` is dogfooding `@fiber-pay/react`.
+- Demo apps:
+  - `apps/browser-wallet`: full-featured browser wallet console (hook-first, operational flows).
+  - `apps/react-quick-card`: downstream integration demo focused on `ConnectButton` + `FiberPayQuickCard`.
 
 Recommended approach:
 
@@ -190,7 +192,10 @@ Recommended approach:
 
 ## React SDK Tutorial (Dogfood Pattern)
 
-This is the exact integration style currently used by `apps/browser-wallet`:
+These integration patterns are used across the demo apps:
+
+- `apps/browser-wallet`: hook-first integration with custom business UI and richer operational controls.
+- `apps/react-quick-card`: downstream-friendly component integration with quick event wiring.
 
 - Use `useFiberNode` for node lifecycle and passkey diagnostics.
 - Keep business UI in your own component tree.
@@ -300,4 +305,6 @@ Use this path when you want to ship a functional payment panel quickly, then pro
 - SDK browser entry: `packages/sdk/src/browser/index.ts`
 - Browser node API: `packages/sdk/src/browser/fiber-browser-node.ts`
 - Passkey provider: `packages/sdk/src/browser/passkey-credential-provider.ts`
-- Demo app: `apps/browser-wallet/src/App.tsx`
+- Demo apps:
+  - `apps/browser-wallet/src/App.tsx`
+  - `apps/react-quick-card/src/App.tsx`

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -43,15 +43,18 @@ import { Fiber } from '@nervosnetwork/fiber-js';
 
 export function HeaderWallet() {
   const fiber = useFiberNode({ network: 'testnet', wasmFactory: () => new Fiber() });
-  return <ConnectButton fiber={fiber} />;
+  return <ConnectButton fiber={fiber} strategy="passkey" />;
 }
 ```
+
+`ConnectButton` uses explicit strategy selection and supports only `"passkey"` or `"password"`.
 
 For custom connected-state panels (for example peer/channel controls), use `renderConnectedDropdown`:
 
 ```tsx
 <ConnectButton
   fiber={fiber}
+  strategy="passkey"
   dropdownStyle={{ width: 320 }}
   renderConnectedDropdown={({ fiber, disconnect }) => (
     <div>

--- a/packages/react/src/connect-button.tsx
+++ b/packages/react/src/connect-button.tsx
@@ -36,7 +36,7 @@ import { useFiberNode } from './use-fiber-node.js';
 // =============================================================================
 
 /** Credential strategy the ConnectButton should use */
-export type ConnectStrategy = 'passkey' | 'password' | 'rawKey' | 'auto';
+export type ConnectStrategy = 'passkey' | 'password';
 
 export interface ConnectButtonProps {
   /** Network to connect to. Required in standalone mode; ignored when `fiber` is provided. */
@@ -48,17 +48,11 @@ export interface ConnectButtonProps {
    */
   fiber?: UseFiberNodeResult;
 
-  /** Credential strategy. Defaults to `"auto"`. */
-  strategy?: ConnectStrategy;
+  /** Credential strategy. Explicitly choose either `"passkey"` or `"password"`. */
+  strategy: ConnectStrategy;
 
   /** Password for the "password" strategy. */
   password?: string;
-
-  /** Raw Fiber key (32 bytes) for the "rawKey" strategy. */
-  rawKey?: Uint8Array;
-
-  /** Raw CKB secret key (32 bytes) for the "rawKey" strategy (optional). */
-  rawCkbKey?: Uint8Array;
 
   /** Wallet identifier for IndexedDB isolation. */
   walletId?: string;
@@ -298,10 +292,8 @@ export function ConnectButton(props: ConnectButtonProps) {
   const {
     network = 'testnet',
     fiber: externalFiber,
-    strategy = 'auto',
+    strategy,
     password,
-    rawKey,
-    rawCkbKey,
     walletId,
     passkeyUsername = 'User',
     wasmFactory,
@@ -339,7 +331,6 @@ export function ConnectButton(props: ConnectButtonProps) {
     createPasskeyAndStart,
     startWithPasskey,
     startWithPassword,
-    startWithRawKey,
     stop,
   } = fiber;
 
@@ -385,29 +376,14 @@ export function ConnectButton(props: ConnectButtonProps) {
 
   // --- Actions --------------------------------------------------------------
 
-  const resolvedStrategy =
-    strategy === 'auto'
-      ? hasPasskeyConfigured && isPasskeySupported
-        ? 'passkey'
-        : password
-          ? 'password'
-          : rawKey
-            ? 'rawKey'
-            : 'passkey'
-      : strategy;
-
   const handleConnect = useCallback(async () => {
     setIsConnecting(true);
     setLocalError(null);
     try {
-      switch (resolvedStrategy) {
+      switch (strategy) {
         case 'password':
           if (!password) throw new Error('Password is required for "password" strategy');
           await startWithPassword(password);
-          break;
-        case 'rawKey':
-          if (!rawKey) throw new Error('rawKey is required for "rawKey" strategy');
-          await startWithRawKey(rawKey, rawCkbKey);
           break;
         case 'passkey':
           if (hasPasskeyConfigured) {
@@ -425,15 +401,12 @@ export function ConnectButton(props: ConnectButtonProps) {
       setIsConnecting(false);
     }
   }, [
-    resolvedStrategy,
+    strategy,
     password,
-    rawKey,
-    rawCkbKey,
     passkeyUsername,
     hasPasskeyConfigured,
     startWithPassword,
     startWithPasskey,
-    startWithRawKey,
     createPasskeyAndStart,
     onError,
   ]);
@@ -487,7 +460,7 @@ export function ConnectButton(props: ConnectButtonProps) {
     buttonStyle = { ...styles.button, ...styles.connectButton, ...styles.disabledButton };
   } else {
     // Idle — label depends on strategy
-    switch (resolvedStrategy) {
+    switch (strategy) {
       case 'passkey':
         buttonLabel = hasPasskeyConfigured ? 'Connect with Passkey' : 'Connect via Passkey';
         if (!isPasskeySupported) {
@@ -496,9 +469,6 @@ export function ConnectButton(props: ConnectButtonProps) {
         }
         break;
       case 'password':
-        buttonLabel = 'Connect';
-        break;
-      case 'rawKey':
         buttonLabel = 'Connect';
         break;
     }
@@ -514,7 +484,7 @@ export function ConnectButton(props: ConnectButtonProps) {
     <div className={className} style={{ ...styles.root, ...style }} data-fpay-connect-button="">
       {/* Error / passkey unavailability message */}
       {(hasError ||
-        (!isPasskeySupported && passkeyUnavailableReason && resolvedStrategy === 'passkey')) && (
+        (!isPasskeySupported && passkeyUnavailableReason && strategy === 'passkey')) && (
         <span style={styles.errorText}>{error || localError || passkeyUnavailableReason}</span>
       )}
 

--- a/packages/react/src/use-fiber-node.ts
+++ b/packages/react/src/use-fiber-node.ts
@@ -101,8 +101,12 @@ export function useFiberNode(options: UseFiberNodeOptions): UseFiberNodeResult {
     nodeListenersRef.current = null;
   }, []);
 
-  useEffect(
-    () => () => {
+  useEffect(() => {
+    // React StrictMode remounts components in development.
+    // Reset the mounted flag on each mount so async state updates are not dropped.
+    isMountedRef.current = true;
+
+    return () => {
       isMountedRef.current = false;
 
       const node = nodeRef.current;
@@ -112,9 +116,8 @@ export function useFiberNode(options: UseFiberNodeOptions): UseFiberNodeResult {
         detachNodeListeners(node);
         void node.stop().catch(() => {});
       }
-    },
-    [detachNodeListeners],
-  );
+    };
+  }, [detachNodeListeners]);
 
   useEffect(() => {
     if (options.enabled === false) return;


### PR DESCRIPTION
## Summary\n- improve react-quick-card capability demo with source links and customization showcase\n- fix useFiberNode StrictMode mounted-flag reliability\n- switch browser-wallet auth entry to ConnectButton-first flow with handwritten strategy/password helpers\n\n## Validation\n- apps/react-quick-card: pnpm build\n- packages/react: pnpm build && pnpm test\n- apps/browser-wallet: pnpm build\n