### PR TITLE
feat: redesign FiberNodeButton panel and dev-focused React demo

### DIFF
--- a/.changeset/warm-drinks-travel.md
+++ b/.changeset/warm-drinks-travel.md
@@ -1,0 +1,10 @@
+---
+"@fiber-pay/react": patch
+---
+
+Redesign `FiberNodeButton` connected dropdown into a task-oriented tabbed panel:
+- Add a compact global status/header area with clearer selected-tab semantics
+- Split actions into `Workbench`, `Channels`, and `Diagnostics`
+- Add force-close confirmation flow and streamlined channel management UX
+
+Improve developer dogfood/demo experience in `react-quick-card` by refocusing the page on `FiberNodeButton` integration and runtime callback visibility.

--- a/apps/react-quick-card/README.md
+++ b/apps/react-quick-card/README.md
@@ -1,6 +1,6 @@
-# React SDK Demo (ConnectButton + QuickCard)
+# React SDK Demo (FiberNodeButton + QuickCard)
 
-A Vite + React app demonstrating both `ConnectButton` and `FiberPayQuickCard` from `@fiber-pay/react`.
+A Vite + React app demonstrating `FiberNodeButton` and `FiberPayQuickCard` from `@fiber-pay/react`.
 
 ## Run
 
@@ -12,7 +12,8 @@ Then open `http://localhost:5174`.
 
 ## What it demonstrates
 
-- Step-by-step connection lifecycle with `useFiberNode` + `ConnectButton`
+- Step-by-step connection lifecycle with `useFiberNode` + `FiberNodeButton`
+- `FiberNodeButton` default wallet-style dropdown sections: connection state/actions, channel management, payment management, optional connector block
 - Explicit strategy selection (`password` or `passkey`) and live hook status visibility
 - External wallet funding mode toggle with CCC signer integration
 - Peer management + channel open flow (`list_peers`, `connect_peer`, `open_channel`)
@@ -22,9 +23,9 @@ Then open `http://localhost:5174`.
 
 1. Choose a connection strategy in section 1.
 2. Connect the node and verify status changes to `running`.
-3. (Optional) enable external wallet mode and connect CCC signer.
-4. Connect/select a peer and open a channel in section 2.
-5. Create and pay invoices in section 3 using the same node session.
+3. Open `FiberNodeButton` dropdown and try channel / payment actions.
+4. (Optional) enable external wallet mode and connect CCC signer.
+5. Compare with the legacy `FiberPayQuickCard` block.
 
 ## Notes
 

--- a/apps/react-quick-card/README.md
+++ b/apps/react-quick-card/README.md
@@ -13,18 +13,18 @@ Then open `http://localhost:5174`.
 ## What it demonstrates
 
 - Step-by-step connection lifecycle with `useFiberNode` + `ConnectButton`
-- Direct source-code links for core SDK/demo files from inside the page
 - Explicit strategy selection (`password` or `passkey`) and live hook status visibility
-- UI customization showcase for `ConnectButton` (`style`, `dropdownStyle`, `renderConnectedDropdown`)
-- Runtime verification actions (`node_info`, `list_peers`, `list_channels`) after connect
-- `FiberPayQuickCard` as a standalone fast-MVP payment UI with callback wiring
+- External wallet funding mode toggle with CCC signer integration
+- Peer management + channel open flow (`list_peers`, `connect_peer`, `open_channel`)
+- `FiberPayQuickCard` reusing the same connected node session via the `fiber` prop
 
 ## Suggested walkthrough
 
 1. Choose a connection strategy in section 1.
 2. Connect the node and verify status changes to `running`.
-3. Click "Read runtime snapshot" to confirm RPC calls are working.
-4. Try section 2 to validate quick payment UI integration.
+3. (Optional) enable external wallet mode and connect CCC signer.
+4. Connect/select a peer and open a channel in section 2.
+5. Create and pay invoices in section 3 using the same node session.
 
 ## Notes
 

--- a/apps/react-quick-card/README.md
+++ b/apps/react-quick-card/README.md
@@ -1,6 +1,6 @@
-# React SDK Demo (FiberNodeButton + QuickCard)
+# React SDK Demo (FiberNodeButton)
 
-A Vite + React app demonstrating `FiberNodeButton` and `FiberPayQuickCard` from `@fiber-pay/react`.
+A Vite + React app focused on onboarding developers to `FiberNodeButton` from `@fiber-pay/react`.
 
 ## Run
 
@@ -13,19 +13,19 @@ Then open `http://localhost:5174`.
 ## What it demonstrates
 
 - Step-by-step connection lifecycle with `useFiberNode` + `FiberNodeButton`
-- `FiberNodeButton` default wallet-style dropdown sections: connection state/actions, channel management, payment management, optional connector block
+- `FiberNodeButton` tabbed dropdown panel with global status + task-oriented tabs (`Workbench`, `Channels`, `Diagnostics`)
 - Explicit strategy selection (`password` or `passkey`) and live hook status visibility
 - External wallet funding mode toggle with CCC signer integration
-- Peer management + channel open flow (`list_peers`, `connect_peer`, `open_channel`)
-- `FiberPayQuickCard` reusing the same connected node session via the `fiber` prop
+- Peer management + channel open flow + diagnostics (`list_peers`, `connect_peer`, `open_channel`, graph snapshot)
+- Integration guide section with copyable wiring snippet and runtime callback logs
 
 ## Suggested walkthrough
 
-1. Choose a connection strategy in section 1.
-2. Connect the node and verify status changes to `running`.
-3. Open `FiberNodeButton` dropdown and try channel / payment actions.
+1. Choose a connection strategy (`password` or `passkey`) in the Live Playground.
+2. Connect the node and verify hook state plus event logs update.
+3. Open the `FiberNodeButton` dropdown and run Workbench -> Channels -> Diagnostics flow.
 4. (Optional) enable external wallet mode and connect CCC signer.
-5. Compare with the legacy `FiberPayQuickCard` block.
+5. Copy the Integration Guide code block into your app and replace session/wallet details.
 
 ## Notes
 

--- a/apps/react-quick-card/src/App.tsx
+++ b/apps/react-quick-card/src/App.tsx
@@ -8,7 +8,7 @@ import {
   type HexString,
   type Script,
 } from '@fiber-pay/sdk/browser';
-import { type CSSProperties, useEffect, useMemo, useState } from 'react';
+import { type CSSProperties, useCallback, useEffect, useMemo, useState } from 'react';
 
 type ConnectStrategy = 'password' | 'passkey';
 
@@ -78,7 +78,7 @@ export function App() {
     externalWallet,
   });
 
-  const addLog = (message: string) => {
+  const addLog = useCallback((message: string) => {
     const now = new Date();
     const ts = now.toISOString().slice(11, 19);
     const entry = {
@@ -86,18 +86,18 @@ export function App() {
       text: `[${ts}] ${message}`,
     };
     setEventLogs((prev) => [entry, ...prev].slice(0, 16));
-  };
+  }, []);
 
-  const clearLogs = () => {
+  const clearLogs = useCallback(() => {
     setEventLogs([]);
-  };
+  }, []);
 
   const channelOpenFlow = useChannelOpenFlow({
     node: fiber.node,
     onLog: addLog,
   });
 
-  const refreshConnectedPeers = async () => {
+  const refreshConnectedPeers = useCallback(async () => {
     if (!fiber.node) {
       setConnectedPeerPubkeys([]);
       return;
@@ -119,7 +119,7 @@ export function App() {
     } finally {
       setIsRefreshingPeers(false);
     }
-  };
+  }, [addLog, fiber.node]);
 
   const connectPeerByAddress = async () => {
     if (!fiber.node) {
@@ -277,7 +277,7 @@ export function App() {
     }
 
     void refreshConnectedPeers();
-  }, [externalWallet, fiber.isRunning, fiber.node]);
+  }, [externalWallet, fiber.isRunning, fiber.node, refreshConnectedPeers]);
 
   useEffect(() => {
     setExternalFundingPeerPubkey((prev) => (prev.trim() ? prev : connectedPeerPubkeys[0] ?? prev));
@@ -314,6 +314,7 @@ export function App() {
     : isOpeningChannel
       ? 'Open Channel (External Wallet Flow...)'
       : 'Open Channel (External Wallet One Click)';
+  const externalWalletToggleLocked = fiber.isRunning || fiber.isStarting || isOpeningChannel;
 
   return (
     <div style={{ padding: 24, fontFamily: 'system-ui, sans-serif', maxWidth: 880, margin: '0 auto' }}>
@@ -371,7 +372,6 @@ export function App() {
         <ConnectButton
           fiber={fiber}
           strategy={strategy}
-          externalWallet={externalWallet}
           password={strategy === 'password' ? password : undefined}
           onConnect={(_node, info) => {
             addLog(`ConnectButton connected: ${shorten(info.pubkey, 12, 10)}`);
@@ -406,6 +406,7 @@ export function App() {
             <input
               type="checkbox"
               checked={externalWallet}
+              disabled={externalWalletToggleLocked}
               onChange={(e) => setExternalWallet(e.target.checked)}
               style={{ width: 16, height: 16 }}
             />
@@ -417,6 +418,11 @@ export function App() {
               ? 'External mode is on. Channel opening will use CCC wallet signing.'
               : 'External mode is off. Channel opening uses internal node-managed funding.'}
           </p>
+          {externalWalletToggleLocked && (
+            <p style={{ marginTop: 6, marginBottom: 0, fontSize: 12, color: '#b45309' }}>
+              Disconnect the node before switching funding mode.
+            </p>
+          )}
 
           {externalWallet && (
             <>
@@ -599,12 +605,12 @@ export function App() {
       <section style={cardStyle}>
         <h2 style={{ marginTop: 0 }}>3) Quick Payment UI</h2>
         <p style={{ marginTop: 0, color: '#475569', fontSize: 13 }}>
-          Drop-in component for invoice creation and payment actions.
+          Reuses the same connected node from section 1 for invoice creation and payment actions.
         </p>
 
         <FiberPayQuickCard
+          fiber={fiber}
           network="testnet"
-          walletId="quick-card-mvp-demo"
           title="Quick Card"
           onInvoiceCreated={handleInvoiceCreated}
           onPaymentResult={handlePaymentResult}

--- a/apps/react-quick-card/src/App.tsx
+++ b/apps/react-quick-card/src/App.tsx
@@ -1,14 +1,13 @@
 import { ccc } from '@ckb-ccc/connector-react';
-import { ConnectButton, FiberPayQuickCard, useChannelOpenFlow, useFiberNode } from '@fiber-pay/react';
+import { FiberNodeButton, FiberPayQuickCard, useFiberNode } from '@fiber-pay/react';
 import {
   cccScriptToFiberScript,
   createCccSignFundingTx,
   resolveFundingLockCellDepsByKnownScript,
   type GetPaymentResult,
-  type HexString,
   type Script,
 } from '@fiber-pay/sdk/browser';
-import { type CSSProperties, useCallback, useEffect, useMemo, useState } from 'react';
+import { type CSSProperties, useCallback, useEffect, useState } from 'react';
 
 type ConnectStrategy = 'password' | 'passkey';
 
@@ -24,19 +23,6 @@ function shorten(value: string, head = 10, tail = 8): string {
     return value;
   }
   return `${value.slice(0, head)}...${value.slice(-tail)}`;
-}
-
-function toHexPrefixed(value: string): HexString {
-  const trimmed = value.trim();
-  if (!trimmed) {
-    throw new Error('Hex value is empty.');
-  }
-
-  return (trimmed.startsWith('0x') ? trimmed : `0x${trimmed}`) as HexString;
-}
-
-function normalizePubkey(value: string): string {
-  return value.trim().toLowerCase().replace(/^0x/, '');
 }
 
 const cardStyle: CSSProperties = {
@@ -59,16 +45,7 @@ export function App() {
   const [externalWallet, setExternalWallet] = useState(false);
   const [password, setPassword] = useState('demo-secret');
 
-  const [externalFundingPeerPubkey, setExternalFundingPeerPubkey] = useState('');
-  const [connectedPeerPubkeys, setConnectedPeerPubkeys] = useState<string[]>([]);
-  const [peerAddressInput, setPeerAddressInput] = useState('');
-  const [fundingAmountCkb, setFundingAmountCkb] = useState('1000');
-
-  const [actionError, setActionError] = useState<string | null>(null);
   const [externalWalletAddress, setExternalWalletAddress] = useState<string | null>(null);
-  const [isRefreshingPeers, setIsRefreshingPeers] = useState(false);
-  const [isConnectingPeer, setIsConnectingPeer] = useState(false);
-  const [isOpeningChannel, setIsOpeningChannel] = useState(false);
 
   const [eventLogs, setEventLogs] = useState<EventLogEntry[]>([]);
 
@@ -92,137 +69,6 @@ export function App() {
     setEventLogs([]);
   }, []);
 
-  const channelOpenFlow = useChannelOpenFlow({
-    node: fiber.node,
-    onLog: addLog,
-  });
-
-  const refreshConnectedPeers = useCallback(async () => {
-    if (!fiber.node) {
-      setConnectedPeerPubkeys([]);
-      return;
-    }
-
-    setIsRefreshingPeers(true);
-    setActionError(null);
-
-    try {
-      const peers = await fiber.node.listPeers();
-      const pubkeys = peers.peers.map((peer) => peer.pubkey);
-      setConnectedPeerPubkeys(pubkeys);
-      setExternalFundingPeerPubkey((prev) => (prev.trim() ? prev : pubkeys[0] ?? prev));
-      addLog(`Loaded connected peers: ${pubkeys.length}.`);
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      setActionError(message);
-      addLog(`Refresh peers failed: ${message}`);
-    } finally {
-      setIsRefreshingPeers(false);
-    }
-  }, [addLog, fiber.node]);
-
-  const connectPeerByAddress = async () => {
-    if (!fiber.node) {
-      setActionError('Node is not connected.');
-      return;
-    }
-
-    if (!peerAddressInput.trim()) {
-      setActionError('Peer address is empty.');
-      return;
-    }
-
-    setIsConnectingPeer(true);
-    setActionError(null);
-
-    try {
-      await fiber.node.connectPeer({
-        address: peerAddressInput.trim(),
-        save: true,
-      });
-      addLog('Peer connected from address input.');
-      await refreshConnectedPeers();
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      setActionError(message);
-      addLog(`Connect peer failed: ${message}`);
-    } finally {
-      setIsConnectingPeer(false);
-    }
-  };
-
-  const openChannel = async () => {
-    if (!fiber.node) {
-      setActionError('Node is not connected.');
-      return;
-    }
-
-    if (!externalFundingPeerPubkey.trim()) {
-      setActionError('Target peer pubkey is empty.');
-      return;
-    }
-
-    setActionError(null);
-    setIsOpeningChannel(true);
-    channelOpenFlow.reset();
-
-    try {
-      const targetPubkey = toHexPrefixed(externalFundingPeerPubkey);
-      const normalizedTarget = normalizePubkey(targetPubkey);
-      const isConnected = connectedPeerPubkeys.some(
-        (peerPubkey) => normalizePubkey(peerPubkey) === normalizedTarget,
-      );
-
-      if (!isConnected) {
-        throw new Error('Target peer is not connected. Connect or select a peer first.');
-      }
-
-      if (!externalWallet) {
-        await channelOpenFlow.openChannel({
-          pubkey: targetPubkey,
-          fundingAmountCkb,
-          externalWallet: false,
-        });
-        return;
-      }
-
-      if (!cccSigner) {
-        throw new Error('External wallet mode requires a connected CCC wallet signer.');
-      }
-
-      const addressObj = await cccSigner.getRecommendedAddressObj();
-      const walletScript: Script = cccScriptToFiberScript(addressObj.script);
-      const resolvedDeps = await resolveFundingLockCellDepsByKnownScript(
-        cccSigner,
-        walletScript,
-        Object.values(ccc.KnownScript),
-      );
-      const signFundingTx = createCccSignFundingTx(cccSigner);
-
-      await channelOpenFlow.openChannel({
-        pubkey: targetPubkey,
-        fundingAmountCkb,
-        externalWallet: true,
-        shutdownScript: walletScript,
-        fundingLockScript: walletScript,
-        fundingLockScriptCellDeps: resolvedDeps?.cellDeps,
-        signFundingTx,
-        ckbRpcUrl: TESTNET_CKB_RPC_URL,
-      });
-
-      setExternalWalletAddress(addressObj.toString());
-      if (resolvedDeps?.knownScript) {
-        addLog(`Using CCC known script deps: ${resolvedDeps.knownScript}.`);
-      }
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      setActionError(message);
-      addLog(`Open channel failed: ${message}`);
-    } finally {
-      setIsOpeningChannel(false);
-    }
-  };
-
   const handleInvoiceCreated = (invoice: string) => {
     console.log('Invoice created:', invoice);
     addLog(`QuickCard invoice created: ${invoice.slice(0, 32)}...`);
@@ -240,9 +86,6 @@ export function App() {
 
   useEffect(() => {
     if (!externalWallet || !cccSigner) {
-      if (!externalWallet) {
-        setExternalWalletAddress(null);
-      }
       return;
     }
 
@@ -259,7 +102,7 @@ export function App() {
           return;
         }
         const message = error instanceof Error ? error.message : String(error);
-        setActionError(message);
+        addLog(`External wallet address load failed: ${message}`);
       }
     };
 
@@ -268,53 +111,54 @@ export function App() {
     return () => {
       cancelled = true;
     };
-  }, [cccSigner, externalWallet]);
+  }, [addLog, cccSigner, externalWallet]);
 
-  useEffect(() => {
-    if (!externalWallet || !fiber.isRunning || !fiber.node) {
-      setConnectedPeerPubkeys([]);
-      return;
-    }
+  const statusSummary = [
+    { label: 'State', value: fiber.state },
+    { label: 'Connected', value: fiber.isRunning ? 'Yes' : 'No' },
+    { label: 'Node', value: fiber.nodeInfo?.pubkey ? shorten(fiber.nodeInfo.pubkey) : 'Not connected' },
+    {
+      label: 'Funding Mode',
+      value: externalWallet ? 'External wallet (CCC signer)' : 'Internal wallet (node managed)',
+    },
+    {
+      label: 'Passkey',
+      value: fiber.isPasskeySupported ? 'Available' : fiber.passkeyUnavailableReason ?? 'Unavailable',
+    },
+  ];
 
-    void refreshConnectedPeers();
-  }, [externalWallet, fiber.isRunning, fiber.node, refreshConnectedPeers]);
+  const externalWalletToggleLocked = fiber.isRunning || fiber.isStarting;
 
-  useEffect(() => {
-    setExternalFundingPeerPubkey((prev) => (prev.trim() ? prev : connectedPeerPubkeys[0] ?? prev));
-  }, [connectedPeerPubkeys]);
+  const resolveExternalFunding = useCallback(
+    async () => {
+      if (!cccSigner) {
+        throw new Error('External wallet mode requires a connected CCC wallet signer.');
+      }
 
-  const primaryError = actionError ?? channelOpenFlow.error;
+      const addressObj = await cccSigner.getRecommendedAddressObj();
+      const walletScript: Script = cccScriptToFiberScript(addressObj.script);
+      const resolvedDeps = await resolveFundingLockCellDepsByKnownScript(
+        cccSigner,
+        walletScript,
+        Object.values(ccc.KnownScript),
+      );
 
-  const statusSummary = useMemo(
-    () => [
-      { label: 'State', value: fiber.state },
-      { label: 'Connected', value: fiber.isRunning ? 'Yes' : 'No' },
-      { label: 'Node', value: fiber.nodeInfo?.pubkey ? shorten(fiber.nodeInfo.pubkey) : 'Not connected' },
-      {
-        label: 'Funding Mode',
-        value: externalWallet ? 'External wallet (CCC signer)' : 'Internal wallet (node managed)',
-      },
-      {
-        label: 'Passkey',
-        value: fiber.isPasskeySupported ? 'Available' : fiber.passkeyUnavailableReason ?? 'Unavailable',
-      },
-    ],
-    [
-      externalWallet,
-      fiber.isPasskeySupported,
-      fiber.isRunning,
-      fiber.nodeInfo?.pubkey,
-      fiber.passkeyUnavailableReason,
-      fiber.state,
-    ],
+      setExternalWalletAddress(addressObj.toString());
+
+      if (resolvedDeps?.knownScript) {
+        addLog(`Using CCC known script deps: ${resolvedDeps.knownScript}.`);
+      }
+
+      return {
+        signFundingTx: createCccSignFundingTx(cccSigner),
+        shutdownScript: walletScript,
+        fundingLockScript: walletScript,
+        fundingLockScriptCellDeps: resolvedDeps?.cellDeps,
+        ckbRpcUrl: TESTNET_CKB_RPC_URL,
+      };
+    },
+    [addLog, cccSigner],
   );
-
-  const openChannelButtonText = !externalWallet
-    ? 'Open Channel (Internal Funding)'
-    : isOpeningChannel
-      ? 'Open Channel (External Wallet Flow...)'
-      : 'Open Channel (External Wallet One Click)';
-  const externalWalletToggleLocked = fiber.isRunning || fiber.isStarting || isOpeningChannel;
 
   return (
     <div style={{ padding: 24, fontFamily: 'system-ui, sans-serif', maxWidth: 880, margin: '0 auto' }}>
@@ -324,7 +168,7 @@ export function App() {
       </p>
 
       <section style={cardStyle}>
-        <h2 style={{ marginTop: 0 }}>1) Connect</h2>
+        <h2 style={{ marginTop: 0 }}>1) Fiber Node Button</h2>
 
         <div style={{ display: 'flex', gap: 8, marginBottom: 10, flexWrap: 'wrap' }}>
           <button
@@ -369,64 +213,31 @@ export function App() {
           </label>
         )}
 
-        <ConnectButton
+        <FiberNodeButton
           fiber={fiber}
           strategy={strategy}
           password={strategy === 'password' ? password : undefined}
+          onLog={addLog}
           onConnect={(_node, info) => {
-            addLog(`ConnectButton connected: ${shorten(info.pubkey, 12, 10)}`);
+            addLog(`FiberNodeButton connected: ${shorten(info.pubkey, 12, 10)}`);
           }}
           onDisconnect={() => {
-            addLog('ConnectButton disconnected.');
+            addLog('FiberNodeButton disconnected.');
           }}
           onError={(msg) => {
-            addLog(`ConnectButton error: ${msg}`);
+            addLog(`FiberNodeButton error: ${msg}`);
           }}
-        />
-
-        <div
-          style={{
-            marginTop: 12,
-            border: '1px solid #cbd5e1',
-            borderRadius: 8,
-            padding: 10,
-            background: '#fff',
+          externalFunding={{
+            enabled: externalWallet,
+            resolve: resolveExternalFunding,
           }}
-        >
-          <label
-            style={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: 8,
-              fontWeight: 600,
-              color: '#0f172a',
-              cursor: 'pointer',
-            }}
-          >
-            <input
-              type="checkbox"
-              checked={externalWallet}
-              disabled={externalWalletToggleLocked}
-              onChange={(e) => setExternalWallet(e.target.checked)}
-              style={{ width: 16, height: 16 }}
-            />
-            Use External Wallet (CCC Signer)
-          </label>
-
-          <p style={{ marginTop: 6, marginBottom: 0, fontSize: 12, color: '#64748b' }}>
-            {externalWallet
-              ? 'External mode is on. Channel opening will use CCC wallet signing.'
-              : 'External mode is off. Channel opening uses internal node-managed funding.'}
-          </p>
-          {externalWalletToggleLocked && (
-            <p style={{ marginTop: 6, marginBottom: 0, fontSize: 12, color: '#b45309' }}>
-              Disconnect the node before switching funding mode.
-            </p>
-          )}
-
-          {externalWallet && (
-            <>
-              <div style={{ marginTop: 10, display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+          renderConnectorSection={() => (
+            <div style={{ display: 'grid', gap: 6 }}>
+              <div style={{ fontSize: 12, color: '#475569' }}>
+                CCC wallet: <strong>{connectedExternalWallet?.name ?? 'Not connected'}</strong>
+                {externalWalletAddress ? ` | address: ${shorten(externalWalletAddress, 20, 10)}` : ''}
+              </div>
+              <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
                 <button
                   type="button"
                   onClick={() => {
@@ -462,11 +273,61 @@ export function App() {
                   Disconnect External Wallet
                 </button>
               </div>
-              <div style={{ marginTop: 8, fontSize: 12, color: '#475569' }}>
-                CCC wallet: <strong>{connectedExternalWallet?.name ?? 'Not connected'}</strong>
-                {externalWalletAddress ? ` | address: ${shorten(externalWalletAddress, 20, 10)}` : ''}
-              </div>
-            </>
+            </div>
+          )}
+        />
+
+        <div
+          style={{
+            marginTop: 12,
+            border: '1px solid #cbd5e1',
+            borderRadius: 8,
+            padding: 10,
+            background: '#fff',
+          }}
+        >
+          <label
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 8,
+              fontWeight: 600,
+              color: '#0f172a',
+              cursor: 'pointer',
+            }}
+          >
+            <input
+              type="checkbox"
+              checked={externalWallet}
+              disabled={externalWalletToggleLocked}
+              onChange={(e) => {
+                const checked = e.target.checked;
+                setExternalWallet(checked);
+                if (!checked) {
+                  setExternalWalletAddress(null);
+                }
+              }}
+              style={{ width: 16, height: 16 }}
+            />
+            Use External Wallet (CCC Signer)
+          </label>
+
+          <p style={{ marginTop: 6, marginBottom: 0, fontSize: 12, color: '#64748b' }}>
+            {externalWallet
+              ? 'External mode is on. Channel opening will use CCC wallet signing.'
+              : 'External mode is off. Channel opening uses internal node-managed funding.'}
+          </p>
+          {externalWalletToggleLocked && (
+            <p style={{ marginTop: 6, marginBottom: 0, fontSize: 12, color: '#b45309' }}>
+              Disconnect the node before switching funding mode.
+            </p>
+          )}
+
+          {externalWallet && (
+            <div style={{ marginTop: 8, fontSize: 12, color: '#475569' }}>
+              CCC wallet: <strong>{connectedExternalWallet?.name ?? 'Not connected'}</strong>
+              {externalWalletAddress ? ` | address: ${shorten(externalWalletAddress, 20, 10)}` : ''}
+            </div>
           )}
         </div>
 
@@ -480,132 +341,10 @@ export function App() {
       </section>
 
       <section style={cardStyle}>
-        <h2 style={{ marginTop: 0 }}>2) Open Channel (One Click)</h2>
-        <p style={{ marginTop: 0, fontSize: 13, color: '#475569' }}>
-          Keep it simple: target peer + funding amount. External mode signs and submits automatically.
-        </p>
-
-        <div style={{ display: 'grid', gap: 8 }}>
-          <label style={{ fontSize: 13 }}>
-            Target Peer Pubkey
-            <input
-              type="text"
-              list="connected-peer-pubkeys"
-              value={externalFundingPeerPubkey}
-              onChange={(e) => setExternalFundingPeerPubkey(e.target.value)}
-              placeholder={connectedPeerPubkeys[0] ?? '0x...'}
-              style={{ width: '100%', marginTop: 4, padding: '6px 8px', borderRadius: 8, border: '1px solid #cbd5e1' }}
-            />
-            <datalist id="connected-peer-pubkeys">
-              {connectedPeerPubkeys.map((peerPubkey) => (
-                <option key={peerPubkey} value={peerPubkey} />
-              ))}
-            </datalist>
-            <div style={{ marginTop: 4, fontSize: 12, color: '#64748b' }}>
-              Connected peers: {connectedPeerPubkeys.length}
-            </div>
-          </label>
-
-          <label style={{ fontSize: 13 }}>
-            Connect Peer by Address (optional)
-            <input
-              type="text"
-              value={peerAddressInput}
-              onChange={(e) => setPeerAddressInput(e.target.value)}
-              placeholder="/dns4/.../tcp/.../wss/p2p/..."
-              style={{ width: '100%', marginTop: 4, padding: '6px 8px', borderRadius: 8, border: '1px solid #cbd5e1' }}
-            />
-          </label>
-
-          <label style={{ fontSize: 13 }}>
-            Funding Amount (CKB)
-            <input
-              type="text"
-              value={fundingAmountCkb}
-              onChange={(e) => setFundingAmountCkb(e.target.value)}
-              placeholder="1000"
-              style={{ width: '100%', marginTop: 4, padding: '6px 8px', borderRadius: 8, border: '1px solid #cbd5e1' }}
-            />
-          </label>
-
-          {channelOpenFlow.suggestedFundingAmountCkb && (
-            <div style={{ fontSize: 12, color: '#0f766e', display: 'flex', alignItems: 'center', gap: 8 }}>
-              <span>Suggested amount: {channelOpenFlow.suggestedFundingAmountCkb} CKB</span>
-              <button
-                type="button"
-                onClick={() => setFundingAmountCkb(channelOpenFlow.suggestedFundingAmountCkb ?? fundingAmountCkb)}
-                style={{
-                  border: '1px solid #0f766e',
-                  borderRadius: 6,
-                  padding: '3px 8px',
-                  background: '#ecfdf5',
-                  color: '#0f766e',
-                  cursor: 'pointer',
-                }}
-              >
-                Use Suggested Amount
-              </button>
-            </div>
-          )}
-        </div>
-
-        <div style={{ marginTop: 10, display: 'flex', gap: 8, flexWrap: 'wrap' }}>
-          <button
-            type="button"
-            onClick={() => {
-              void refreshConnectedPeers();
-            }}
-            disabled={!fiber.isRunning || isRefreshingPeers}
-            style={{ border: '1px solid #cbd5e1', borderRadius: 8, padding: '7px 10px', background: '#fff', cursor: fiber.isRunning ? 'pointer' : 'not-allowed', opacity: fiber.isRunning ? 1 : 0.65 }}
-          >
-            {isRefreshingPeers ? 'Refreshing Peers...' : 'Refresh Connected Peers'}
-          </button>
-          <button
-            type="button"
-            onClick={() => {
-              void connectPeerByAddress();
-            }}
-            disabled={!fiber.isRunning || isConnectingPeer}
-            style={{ border: '1px solid #334155', borderRadius: 8, padding: '7px 10px', background: '#334155', color: '#fff', cursor: fiber.isRunning ? 'pointer' : 'not-allowed', opacity: fiber.isRunning ? 1 : 0.65 }}
-          >
-            {isConnectingPeer ? 'Connecting Peer...' : 'Connect Peer by Address'}
-          </button>
-          <button
-            type="button"
-            onClick={() => {
-              void openChannel();
-            }}
-            disabled={!fiber.isRunning || isOpeningChannel || (externalWallet && !cccSigner)}
-            style={{ border: '1px solid #0f766e', borderRadius: 8, padding: '7px 10px', background: '#14b8a6', color: '#fff', cursor: fiber.isRunning ? 'pointer' : 'not-allowed', opacity: fiber.isRunning ? 1 : 0.65 }}
-          >
-            {isOpeningChannel ? 'Opening Channel...' : openChannelButtonText}
-          </button>
-        </div>
-
-        {channelOpenFlow.lastResult && (
-          <div style={{ marginTop: 10, fontSize: 13, display: 'grid', gap: 4 }}>
-            <div>
-              Channel ID: <strong>{channelOpenFlow.lastResult.channelId}</strong>
-            </div>
-            {channelOpenFlow.lastResult.fundingTxHash && (
-              <div>
-                Funding Tx Hash: <strong>{channelOpenFlow.lastResult.fundingTxHash}</strong>
-              </div>
-            )}
-          </div>
-        )}
-
-        {primaryError && <p style={{ marginTop: 10, color: '#b91c1c', fontSize: 13 }}>{primaryError}</p>}
-
-        {channelOpenFlow.diagnostic && (
-          <p style={{ marginTop: 10, color: '#0f172a', fontSize: 13 }}>{channelOpenFlow.diagnostic}</p>
-        )}
-      </section>
-
-      <section style={cardStyle}>
-        <h2 style={{ marginTop: 0 }}>3) Quick Payment UI</h2>
+        <h2 style={{ marginTop: 0 }}>2) Quick Payment UI (Legacy Comparison)</h2>
         <p style={{ marginTop: 0, color: '#475569', fontSize: 13 }}>
-          Reuses the same connected node from section 1 for invoice creation and payment actions.
+          `FiberNodeButton` already includes payment actions in its dropdown panel. This block remains
+          only for side-by-side comparison.
         </p>
 
         <FiberPayQuickCard

--- a/apps/react-quick-card/src/App.tsx
+++ b/apps/react-quick-card/src/App.tsx
@@ -1,10 +1,9 @@
 import { ccc } from '@ckb-ccc/connector-react';
-import { FiberNodeButton, FiberPayQuickCard, useFiberNode } from '@fiber-pay/react';
+import { FiberNodeButton, useFiberNode } from '@fiber-pay/react';
 import {
   cccScriptToFiberScript,
   createCccSignFundingTx,
   resolveFundingLockCellDepsByKnownScript,
-  type GetPaymentResult,
   type Script,
 } from '@fiber-pay/sdk/browser';
 import { type CSSProperties, useCallback, useEffect, useState } from 'react';
@@ -18,6 +17,23 @@ interface EventLogEntry {
 
 const TESTNET_CKB_RPC_URL = 'https://testnet.ckbapp.dev/';
 
+const integrationSnippet = `const fiber = useFiberNode({
+  network: 'testnet',
+  walletId: 'my-app-fiber-session',
+  externalWallet,
+});
+
+<FiberNodeButton
+  fiber={fiber}
+  strategy={strategy}
+  password={strategy === 'password' ? password : undefined}
+  externalFunding={{ enabled: externalWallet, resolve: resolveExternalFunding }}
+  onConnect={(_, info) => log('connected', info.pubkey)}
+  onDisconnect={() => log('disconnected')}
+  onError={(msg) => log('error', msg)}
+  onLog={(msg) => log('fiber', msg)}
+/>`;
+
 function shorten(value: string, head = 10, tail = 8): string {
   if (!value || value.length <= head + tail + 3) {
     return value;
@@ -25,12 +41,255 @@ function shorten(value: string, head = 10, tail = 8): string {
   return `${value.slice(0, head)}...${value.slice(-tail)}`;
 }
 
-const cardStyle: CSSProperties = {
-  marginTop: 20,
-  border: '1px solid #e5e7eb',
-  borderRadius: 12,
-  padding: 16,
-  background: '#fafafa',
+const styles = {
+  page: {
+    minHeight: '100vh',
+    padding: '28px 18px 36px',
+    background:
+      'radial-gradient(circle at 4% -12%, rgba(29,78,216,0.2), transparent 42%), radial-gradient(circle at 92% -8%, rgba(14,116,144,0.16), transparent 38%), #f3f6fb',
+    color: '#0f172a',
+    fontFamily: 'IBM Plex Sans, Avenir Next, Segoe UI, sans-serif',
+  } satisfies CSSProperties,
+
+  shell: {
+    maxWidth: '1120px',
+    margin: '0 auto',
+    display: 'grid',
+    gap: '16px',
+  } satisfies CSSProperties,
+
+  hero: {
+    border: '1px solid #d6e0f0',
+    borderRadius: '18px',
+    padding: '18px 18px 16px',
+    background: 'linear-gradient(180deg, rgba(255,255,255,0.96) 0%, rgba(249,251,255,0.95) 100%)',
+    boxShadow: '0 14px 30px -28px rgba(15, 23, 42, 0.45)',
+  } satisfies CSSProperties,
+
+  title: {
+    margin: 0,
+    fontSize: '1.55rem',
+    letterSpacing: '-0.02em',
+  } satisfies CSSProperties,
+
+  subtitle: {
+    margin: '8px 0 0',
+    fontSize: '0.9rem',
+    color: '#475569',
+    maxWidth: '68ch',
+    lineHeight: 1.4,
+  } satisfies CSSProperties,
+
+  layout: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    gap: '14px',
+    alignItems: 'flex-start',
+  } satisfies CSSProperties,
+
+  panel: {
+    flex: '1 1 520px',
+    border: '1px solid #d6e0f0',
+    borderRadius: '16px',
+    padding: '14px',
+    background: 'rgba(255,255,255,0.95)',
+    boxShadow: '0 12px 28px -26px rgba(15, 23, 42, 0.5)',
+    display: 'grid',
+    gap: '12px',
+  } satisfies CSSProperties,
+
+  panelTitle: {
+    margin: 0,
+    fontSize: '1rem',
+    letterSpacing: '-0.01em',
+  } satisfies CSSProperties,
+
+  panelLead: {
+    margin: 0,
+    fontSize: '0.8rem',
+    color: '#64748b',
+  } satisfies CSSProperties,
+
+  row: {
+    display: 'flex',
+    alignItems: 'center',
+    flexWrap: 'wrap',
+    gap: '8px',
+  } satisfies CSSProperties,
+
+  modeButton: {
+    border: '1px solid #cfd8ea',
+    borderRadius: '999px',
+    padding: '6px 12px',
+    fontSize: '0.82rem',
+    fontWeight: 700,
+    background: '#fff',
+    color: '#334155',
+    cursor: 'pointer',
+  } satisfies CSSProperties,
+
+  modeButtonActive: {
+    borderColor: '#1d4ed8',
+    background: '#1d4ed8',
+    color: '#fff',
+  } satisfies CSSProperties,
+
+  passwordInput: {
+    border: '1px solid #cfd8ea',
+    borderRadius: '10px',
+    padding: '7px 9px',
+    fontSize: '0.84rem',
+    minWidth: '230px',
+  } satisfies CSSProperties,
+
+  fundingCard: {
+    border: '1px solid #d7e0ee',
+    borderRadius: '12px',
+    padding: '10px',
+    display: 'grid',
+    gap: '7px',
+    background: '#f8fbff',
+  } satisfies CSSProperties,
+
+  checkboxLabel: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '8px',
+    fontWeight: 700,
+    color: '#1e293b',
+    cursor: 'pointer',
+    fontSize: '0.84rem',
+  } satisfies CSSProperties,
+
+  helperText: {
+    margin: 0,
+    fontSize: '0.78rem',
+    color: '#64748b',
+    lineHeight: 1.35,
+  } satisfies CSSProperties,
+
+  warningText: {
+    margin: 0,
+    fontSize: '0.78rem',
+    color: '#b45309',
+    lineHeight: 1.35,
+  } satisfies CSSProperties,
+
+  compactMeta: {
+    margin: 0,
+    fontSize: '0.78rem',
+    color: '#475569',
+    lineHeight: 1.35,
+  } satisfies CSSProperties,
+
+  statusGrid: {
+    display: 'grid',
+    gridTemplateColumns: 'repeat(auto-fit, minmax(170px, 1fr))',
+    gap: '7px',
+  } satisfies CSSProperties,
+
+  statusItem: {
+    border: '1px solid #dbe4f3',
+    borderRadius: '10px',
+    padding: '7px 9px',
+    fontSize: '0.78rem',
+    color: '#334155',
+    background: '#fff',
+  } satisfies CSSProperties,
+
+  statusLabel: {
+    display: 'block',
+    fontSize: '0.67rem',
+    color: '#64748b',
+    textTransform: 'uppercase',
+    letterSpacing: '0.02em',
+  } satisfies CSSProperties,
+
+  statusValue: {
+    display: 'block',
+    marginTop: '2px',
+    fontWeight: 700,
+    color: '#0f172a',
+    wordBreak: 'break-all',
+  } satisfies CSSProperties,
+
+  stepList: {
+    margin: 0,
+    padding: 0,
+    listStyle: 'none',
+    display: 'grid',
+    gap: '8px',
+  } satisfies CSSProperties,
+
+  stepItem: {
+    border: '1px solid #dbe4f3',
+    borderRadius: '10px',
+    padding: '8px 10px',
+    background: '#fff',
+    display: 'grid',
+    gap: '3px',
+  } satisfies CSSProperties,
+
+  stepTitle: {
+    margin: 0,
+    fontSize: '0.82rem',
+    fontWeight: 700,
+    color: '#0f172a',
+  } satisfies CSSProperties,
+
+  stepDesc: {
+    margin: 0,
+    fontSize: '0.76rem',
+    color: '#64748b',
+    lineHeight: 1.35,
+  } satisfies CSSProperties,
+
+  codeBlock: {
+    margin: 0,
+    border: '1px solid #cdd8ea',
+    borderRadius: '10px',
+    padding: '10px',
+    background: '#0f172a',
+    color: '#cbd5e1',
+    fontFamily: 'IBM Plex Mono, Menlo, monospace',
+    fontSize: '0.74rem',
+    lineHeight: 1.45,
+    whiteSpace: 'pre-wrap',
+    wordBreak: 'break-word',
+  } satisfies CSSProperties,
+
+  eventBox: {
+    border: '1px solid #cdd8ea',
+    borderRadius: '10px',
+    padding: '10px',
+    background: '#0f172a',
+    color: '#e2e8f0',
+    fontFamily: 'IBM Plex Mono, Menlo, monospace',
+    fontSize: '0.72rem',
+    minHeight: '126px',
+    maxHeight: '220px',
+    overflowY: 'auto',
+  } satisfies CSSProperties,
+
+  actionButton: {
+    border: '1px solid #cfd8ea',
+    borderRadius: '8px',
+    padding: '6px 10px',
+    background: '#fff',
+    color: '#0f172a',
+    fontSize: '0.78rem',
+    fontWeight: 700,
+    cursor: 'pointer',
+  } satisfies CSSProperties,
+
+  errorBox: {
+    border: '1px solid #fecaca',
+    borderRadius: '10px',
+    padding: '8px 10px',
+    color: '#991b1b',
+    background: '#fef2f2',
+    fontSize: '0.78rem',
+  } satisfies CSSProperties,
 };
 
 export function App() {
@@ -44,9 +303,7 @@ export function App() {
   const [strategy, setStrategy] = useState<ConnectStrategy>('password');
   const [externalWallet, setExternalWallet] = useState(false);
   const [password, setPassword] = useState('demo-secret');
-
   const [externalWalletAddress, setExternalWalletAddress] = useState<string | null>(null);
-
   const [eventLogs, setEventLogs] = useState<EventLogEntry[]>([]);
 
   const fiber = useFiberNode({
@@ -62,27 +319,12 @@ export function App() {
       id: `${now.getTime()}-${crypto.randomUUID()}`,
       text: `[${ts}] ${message}`,
     };
-    setEventLogs((prev) => [entry, ...prev].slice(0, 16));
+    setEventLogs((prev) => [entry, ...prev].slice(0, 18));
   }, []);
 
   const clearLogs = useCallback(() => {
     setEventLogs([]);
   }, []);
-
-  const handleInvoiceCreated = (invoice: string) => {
-    console.log('Invoice created:', invoice);
-    addLog(`QuickCard invoice created: ${invoice.slice(0, 32)}...`);
-  };
-
-  const handlePaymentResult = (result: GetPaymentResult) => {
-    console.log('Payment result:', result);
-    addLog(`QuickCard payment status: ${result.status}`);
-  };
-
-  const handleError = (error: { scope: 'node' | 'payment' | 'invoice'; message: string }) => {
-    console.error('FiberPay error:', error);
-    addLog(`QuickCard error (${error.scope}): ${error.message}`);
-  };
 
   useEffect(() => {
     if (!externalWallet || !cccSigner) {
@@ -112,22 +354,6 @@ export function App() {
       cancelled = true;
     };
   }, [addLog, cccSigner, externalWallet]);
-
-  const statusSummary = [
-    { label: 'State', value: fiber.state },
-    { label: 'Connected', value: fiber.isRunning ? 'Yes' : 'No' },
-    { label: 'Node', value: fiber.nodeInfo?.pubkey ? shorten(fiber.nodeInfo.pubkey) : 'Not connected' },
-    {
-      label: 'Funding Mode',
-      value: externalWallet ? 'External wallet (CCC signer)' : 'Internal wallet (node managed)',
-    },
-    {
-      label: 'Passkey',
-      value: fiber.isPasskeySupported ? 'Available' : fiber.passkeyUnavailableReason ?? 'Unavailable',
-    },
-  ];
-
-  const externalWalletToggleLocked = fiber.isRunning || fiber.isStarting;
 
   const resolveExternalFunding = useCallback(
     async () => {
@@ -160,252 +386,213 @@ export function App() {
     [addLog, cccSigner],
   );
 
+  const externalWalletToggleLocked = fiber.isRunning || fiber.isStarting;
+
+  const hookStateItems = [
+    { label: 'Node state', value: fiber.state },
+    { label: 'Connected', value: fiber.isRunning ? 'Yes' : 'No' },
+    {
+      label: 'Funding mode',
+      value: externalWallet ? 'External wallet (CCC signer)' : 'Internal wallet (node managed)',
+    },
+  ];
+
   return (
-    <div style={{ padding: 24, fontFamily: 'system-ui, sans-serif', maxWidth: 880, margin: '0 auto' }}>
-      <h1>Fiber Pay React SDK: Clear Demo</h1>
-      <p style={{ marginTop: 0, color: '#475569' }}>
-        Minimal path only: connect, select peer, open channel, then use QuickCard.
-      </p>
-
-      <section style={cardStyle}>
-        <h2 style={{ marginTop: 0 }}>1) Fiber Node Button</h2>
-
-        <div style={{ display: 'flex', gap: 8, marginBottom: 10, flexWrap: 'wrap' }}>
-          <button
-            type="button"
-            onClick={() => setStrategy('password')}
-            style={{
-              border: '1px solid #d1d5db',
-              borderRadius: 8,
-              padding: '6px 10px',
-              background: strategy === 'password' ? '#111827' : '#fff',
-              color: strategy === 'password' ? '#fff' : '#111827',
-              cursor: 'pointer',
-            }}
-          >
-            Password
-          </button>
-          <button
-            type="button"
-            onClick={() => setStrategy('passkey')}
-            style={{
-              border: '1px solid #d1d5db',
-              borderRadius: 8,
-              padding: '6px 10px',
-              background: strategy === 'passkey' ? '#111827' : '#fff',
-              color: strategy === 'passkey' ? '#fff' : '#111827',
-              cursor: 'pointer',
-            }}
-          >
-            Passkey
-          </button>
-        </div>
-
-        {strategy === 'password' && (
-          <label style={{ display: 'block', fontSize: 13, marginBottom: 12 }}>
-            Password
-            <input
-              type="password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              style={{ marginLeft: 8, padding: '6px 8px', borderRadius: 8, border: '1px solid #d1d5db' }}
-            />
-          </label>
-        )}
-
-        <FiberNodeButton
-          fiber={fiber}
-          strategy={strategy}
-          password={strategy === 'password' ? password : undefined}
-          onLog={addLog}
-          onConnect={(_node, info) => {
-            addLog(`FiberNodeButton connected: ${shorten(info.pubkey, 12, 10)}`);
-          }}
-          onDisconnect={() => {
-            addLog('FiberNodeButton disconnected.');
-          }}
-          onError={(msg) => {
-            addLog(`FiberNodeButton error: ${msg}`);
-          }}
-          externalFunding={{
-            enabled: externalWallet,
-            resolve: resolveExternalFunding,
-          }}
-          renderConnectorSection={() => (
-            <div style={{ display: 'grid', gap: 6 }}>
-              <div style={{ fontSize: 12, color: '#475569' }}>
-                CCC wallet: <strong>{connectedExternalWallet?.name ?? 'Not connected'}</strong>
-                {externalWalletAddress ? ` | address: ${shorten(externalWalletAddress, 20, 10)}` : ''}
-              </div>
-              <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
-                <button
-                  type="button"
-                  onClick={() => {
-                    void openExternalWalletConnectModal();
-                  }}
-                  style={{
-                    border: '1px solid #1d4ed8',
-                    borderRadius: 8,
-                    padding: '6px 10px',
-                    background: '#2563eb',
-                    color: '#fff',
-                    cursor: 'pointer',
-                  }}
-                >
-                  {connectedExternalWallet ? 'Switch External Wallet' : 'Connect External Wallet'}
-                </button>
-                <button
-                  type="button"
-                  onClick={() => {
-                    void disconnectExternalWallet();
-                  }}
-                  disabled={!connectedExternalWallet}
-                  style={{
-                    border: '1px solid #cbd5e1',
-                    borderRadius: 8,
-                    padding: '6px 10px',
-                    background: '#fff',
-                    color: '#111827',
-                    cursor: connectedExternalWallet ? 'pointer' : 'not-allowed',
-                    opacity: connectedExternalWallet ? 1 : 0.65,
-                  }}
-                >
-                  Disconnect External Wallet
-                </button>
-              </div>
-            </div>
-          )}
-        />
-
-        <div
-          style={{
-            marginTop: 12,
-            border: '1px solid #cbd5e1',
-            borderRadius: 8,
-            padding: 10,
-            background: '#fff',
-          }}
-        >
-          <label
-            style={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: 8,
-              fontWeight: 600,
-              color: '#0f172a',
-              cursor: 'pointer',
-            }}
-          >
-            <input
-              type="checkbox"
-              checked={externalWallet}
-              disabled={externalWalletToggleLocked}
-              onChange={(e) => {
-                const checked = e.target.checked;
-                setExternalWallet(checked);
-                if (!checked) {
-                  setExternalWalletAddress(null);
-                }
-              }}
-              style={{ width: 16, height: 16 }}
-            />
-            Use External Wallet (CCC Signer)
-          </label>
-
-          <p style={{ marginTop: 6, marginBottom: 0, fontSize: 12, color: '#64748b' }}>
-            {externalWallet
-              ? 'External mode is on. Channel opening will use CCC wallet signing.'
-              : 'External mode is off. Channel opening uses internal node-managed funding.'}
+    <div style={styles.page}>
+      <div style={styles.shell}>
+        <header style={styles.hero}>
+          <h1 style={styles.title}>FiberNodeButton Developer Demo</h1>
+          <p style={styles.subtitle}>
+            One component, one page: learn FiberNodeButton integration fast, then verify behavior in the
+            live panel and runtime logs.
           </p>
-          {externalWalletToggleLocked && (
-            <p style={{ marginTop: 6, marginBottom: 0, fontSize: 12, color: '#b45309' }}>
-              Disconnect the node before switching funding mode.
+        </header>
+
+        <div style={styles.layout}>
+          <aside style={styles.panel}>
+            <h2 style={styles.panelTitle}>Integration Guide</h2>
+            <p style={styles.panelLead}>Copy this wiring model and replace wallet/session config with your app values.</p>
+
+            <ol style={styles.stepList}>
+              <li style={styles.stepItem}>
+                <p style={styles.stepTitle}>Step 1. Create one shared fiber hook</p>
+                <p style={styles.stepDesc}>Keep useFiberNode in your page or provider and pass the same fiber object into FiberNodeButton.</p>
+              </li>
+              <li style={styles.stepItem}>
+                <p style={styles.stepTitle}>Step 2. Choose auth strategy at runtime</p>
+                <p style={styles.stepDesc}>Password and passkey can share one component, switch via strategy prop.</p>
+              </li>
+              <li style={styles.stepItem}>
+                <p style={styles.stepTitle}>Step 3. Plug external funding only when needed</p>
+                <p style={styles.stepDesc}>Use externalFunding.enabled plus resolve callback for CCC signer handoff.</p>
+              </li>
+              <li style={styles.stepItem}>
+                <p style={styles.stepTitle}>Step 4. Subscribe to callback events</p>
+                <p style={styles.stepDesc}>onConnect, onDisconnect, onError, onLog cover most app-level telemetry needs.</p>
+              </li>
+            </ol>
+
+            <pre style={styles.codeBlock}>{integrationSnippet}</pre>
+
+            <div>
+              <div style={styles.row}>
+                <h3 style={{ ...styles.panelTitle, fontSize: '0.92rem' }}>Runtime Events</h3>
+                <button type="button" onClick={clearLogs} style={styles.actionButton}>
+                  Clear Logs
+                </button>
+              </div>
+              <div style={styles.eventBox}>
+                {eventLogs.length === 0
+                  ? 'No events yet. Connect the node and interact with the tabbed panel.'
+                  : eventLogs.map((entry) => <div key={entry.id}>{entry.text}</div>)}
+              </div>
+            </div>
+          </aside>
+
+          <section style={styles.panel}>
+            <h2 style={styles.panelTitle}>Live Playground</h2>
+            <p style={styles.panelLead}>Choose strategy, toggle funding mode, then open FiberNodeButton.</p>
+
+            <div style={styles.row}>
+              <button
+                type="button"
+                onClick={() => setStrategy('password')}
+                style={{
+                  ...styles.modeButton,
+                  ...(strategy === 'password' ? styles.modeButtonActive : {}),
+                }}
+              >
+                Password
+              </button>
+              <button
+                type="button"
+                onClick={() => setStrategy('passkey')}
+                style={{
+                  ...styles.modeButton,
+                  ...(strategy === 'passkey' ? styles.modeButtonActive : {}),
+                }}
+              >
+                Passkey
+              </button>
+              {strategy === 'password' ? (
+                <input
+                  type="password"
+                  value={password}
+                  onChange={(event) => setPassword(event.target.value)}
+                  style={styles.passwordInput}
+                  placeholder="Password for node unlock"
+                />
+              ) : null}
+            </div>
+
+            <FiberNodeButton
+              fiber={fiber}
+              strategy={strategy}
+              password={strategy === 'password' ? password : undefined}
+              onLog={addLog}
+              onConnect={(_node, info) => {
+                addLog(`FiberNodeButton connected: ${shorten(info.pubkey, 12, 10)}`);
+              }}
+              onDisconnect={() => {
+                addLog('FiberNodeButton disconnected.');
+              }}
+              onError={(msg) => {
+                addLog(`FiberNodeButton error: ${msg}`);
+              }}
+              externalFunding={{
+                enabled: externalWallet,
+                resolve: resolveExternalFunding,
+              }}
+              renderConnectorSection={() => (
+                <div style={{ display: 'grid', gap: 6 }}>
+                  <div style={{ fontSize: 12, color: '#475569' }}>
+                    CCC wallet: <strong>{connectedExternalWallet?.name ?? 'Not connected'}</strong>
+                    {externalWalletAddress ? ` | address: ${shorten(externalWalletAddress, 20, 10)}` : ''}
+                  </div>
+                  <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        void openExternalWalletConnectModal();
+                      }}
+                      style={{
+                        border: '1px solid #1d4ed8',
+                        borderRadius: 8,
+                        padding: '6px 10px',
+                        background: '#2563eb',
+                        color: '#fff',
+                        cursor: 'pointer',
+                        fontWeight: 700,
+                      }}
+                    >
+                      {connectedExternalWallet ? 'Switch External Wallet' : 'Connect External Wallet'}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        void disconnectExternalWallet();
+                      }}
+                      disabled={!connectedExternalWallet}
+                      style={{
+                        border: '1px solid #cbd5e1',
+                        borderRadius: 8,
+                        padding: '6px 10px',
+                        background: '#fff',
+                        color: '#111827',
+                        cursor: connectedExternalWallet ? 'pointer' : 'not-allowed',
+                        opacity: connectedExternalWallet ? 1 : 0.65,
+                        fontWeight: 700,
+                      }}
+                    >
+                      Disconnect External Wallet
+                    </button>
+                  </div>
+                </div>
+              )}
+            />
+
+            <div style={styles.fundingCard}>
+              <label style={styles.checkboxLabel}>
+                <input
+                  type="checkbox"
+                  checked={externalWallet}
+                  disabled={externalWalletToggleLocked}
+                  onChange={(event) => {
+                    const checked = event.target.checked;
+                    setExternalWallet(checked);
+                    if (!checked) {
+                      setExternalWalletAddress(null);
+                    }
+                  }}
+                  style={{ width: 16, height: 16 }}
+                />
+                Use External Wallet (CCC Signer)
+              </label>
+
+              <p style={styles.helperText}>{externalWallet ? 'External mode enabled.' : 'Internal mode enabled.'}</p>
+
+              {externalWalletToggleLocked ? (
+                <p style={styles.warningText}>Disconnect the node before switching funding mode.</p>
+              ) : null}
+            </div>
+
+            <p style={styles.compactMeta}>
+              Node: {fiber.nodeInfo?.pubkey ? shorten(fiber.nodeInfo.pubkey, 18, 12) : 'Not connected'}
             </p>
-          )}
 
-          {externalWallet && (
-            <div style={{ marginTop: 8, fontSize: 12, color: '#475569' }}>
-              CCC wallet: <strong>{connectedExternalWallet?.name ?? 'Not connected'}</strong>
-              {externalWalletAddress ? ` | address: ${shorten(externalWalletAddress, 20, 10)}` : ''}
+            <div style={styles.statusGrid}>
+              {hookStateItems.map((item) => (
+                <div key={item.label} style={styles.statusItem}>
+                  <span style={styles.statusLabel}>{item.label}</span>
+                  <span style={styles.statusValue}>{item.value}</span>
+                </div>
+              ))}
             </div>
-          )}
+
+            {fiber.error ? <div style={styles.errorBox}>Hook error: {fiber.error}</div> : null}
+          </section>
         </div>
-
-        <div style={{ marginTop: 12, fontSize: 13, display: 'grid', gap: 6 }}>
-          {statusSummary.map((item) => (
-            <div key={item.label}>
-              {item.label}: <strong>{item.value}</strong>
-            </div>
-          ))}
-        </div>
-      </section>
-
-      <section style={cardStyle}>
-        <h2 style={{ marginTop: 0 }}>2) Quick Payment UI (Legacy Comparison)</h2>
-        <p style={{ marginTop: 0, color: '#475569', fontSize: 13 }}>
-          `FiberNodeButton` already includes payment actions in its dropdown panel. This block remains
-          only for side-by-side comparison.
-        </p>
-
-        <FiberPayQuickCard
-          fiber={fiber}
-          network="testnet"
-          title="Quick Card"
-          onInvoiceCreated={handleInvoiceCreated}
-          onPaymentResult={handlePaymentResult}
-          onError={handleError}
-        />
-      </section>
-
-      <details style={{ marginTop: 14 }}>
-        <summary style={{ cursor: 'pointer', color: '#475569', fontSize: 13 }}>Event Logs</summary>
-        <div
-          style={{
-            marginTop: 8,
-            background: '#111827',
-            color: '#e5e7eb',
-            borderRadius: 8,
-            padding: 10,
-            fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
-            fontSize: 12,
-            minHeight: 110,
-          }}
-        >
-          {eventLogs.length === 0
-            ? 'No events yet.'
-            : eventLogs.map((entry) => <div key={entry.id}>{entry.text}</div>)}
-        </div>
-        <button
-          type="button"
-          onClick={clearLogs}
-          style={{
-            marginTop: 8,
-            border: '1px solid #d1d5db',
-            borderRadius: 8,
-            padding: '7px 10px',
-            background: '#fff',
-            cursor: 'pointer',
-          }}
-        >
-          Clear logs
-        </button>
-      </details>
-
-      {fiber.error && (
-        <div
-          style={{
-            marginTop: 12,
-            border: '1px solid #fecaca',
-            background: '#fef2f2',
-            color: '#991b1b',
-            borderRadius: 8,
-            padding: '8px 10px',
-            fontSize: 13,
-          }}
-        >
-          Hook error: {fiber.error}
-        </div>
-      )}
+      </div>
     </div>
   );
 }

--- a/apps/react-quick-card/vite.config.ts
+++ b/apps/react-quick-card/vite.config.ts
@@ -24,4 +24,8 @@ export default defineConfig({
   server: {
     port: 5174,
   },
+  build: {
+    // Browser Fiber WASM artifacts are intentionally large in this demo app.
+    chunkSizeWarningLimit: 20000,
+  },
 });

--- a/docs/plan/fiber-node-button-tabbed-panel-design-spec.md
+++ b/docs/plan/fiber-node-button-tabbed-panel-design-spec.md
@@ -1,7 +1,7 @@
 # FiberNodeButton 分 Tab 重构设计规格（交付开发）
 
 - 日期：2026-05-21
-- 状态：待实现
+- 状态：已实现（v0.2.5）
 - 目标页面：react-quick-card 中的 FiberNodeButton 已连接下拉面板
 - 设计范围：仅重构面板的信息架构与交互，不改底层 SDK RPC 语义
 

--- a/docs/plan/fiber-node-button-tabbed-panel-design-spec.md
+++ b/docs/plan/fiber-node-button-tabbed-panel-design-spec.md
@@ -1,0 +1,263 @@
+# FiberNodeButton 分 Tab 重构设计规格（交付开发）
+
+- 日期：2026-05-21
+- 状态：待实现
+- 目标页面：react-quick-card 中的 FiberNodeButton 已连接下拉面板
+- 设计范围：仅重构面板的信息架构与交互，不改底层 SDK RPC 语义
+
+## 1. 背景与问题定义
+
+当前面板采用纵向堆叠的 Connection / Peers&Graph / Channels / Payments 结构，已出现以下问题：
+
+1. 面板过长，单屏无法覆盖核心操作。
+2. 任务路径不清晰，用户需要先阅读大量状态信息。
+3. 技术诊断信息与高频任务信息混排，认知负担过高。
+4. 通道列表卡片密度高，纵向滚动成本大。
+5. 危险操作虽有样式区分，但仍暴露在高频区域，决策成本高。
+
+## 2. 重构目标
+
+1. 将“单页长滚动”改为“任务分层 + Tab 切换”。
+2. 首屏聚焦高频任务，确保大部分操作在单屏完成。
+3. 技术诊断信息下沉到独立 Tab，默认不打扰。
+4. 保持现有 props 与 RPC 行为兼容，优先做 UI/UX 重构。
+
+## 3. 信息架构（IA）
+
+新面板采用 2 层结构：
+
+1. 全局状态条（跨 Tab 固定可见）
+2. Tab 内容区（按任务分域）
+
+### 3.1 全局状态条（固定）
+
+展示最小决策信息：
+
+1. Node 状态（running / idle / error）
+2. Funding 模式（Internal / External）
+3. 活跃通道数（Active）
+4. 最近错误状态（有错显示红点 + 文案）
+
+全局动作：
+
+1. Disconnect
+2. Close Panel
+
+### 3.2 Tab 定义
+
+使用 3 个主 Tab（任务导向）：
+
+1. 操作台（默认）
+2. 通道管理
+3. 网络诊断
+
+说明：
+
+1. 不再使用“Connection / Peers / Graph / Channels / Payments”作为主导航。
+2. Peers 与 Graph 从主流程中移除，统一进入“网络诊断”。
+
+## 4. 布局与内容规范
+
+### 4.1 Tab: 操作台（默认 Tab）
+
+目标：新用户进入后无需理解底层概念即可完成关键动作。
+
+包含模块：
+
+1. 连接准备卡
+2. 开通道卡
+3. 支付卡
+
+模块顺序：连接准备 -> 开通道 -> 支付
+
+字段与动作：
+
+1. 连接准备卡
+- 展示：当前连接状态、外部钱包状态（若开启）
+- 动作：Connect External Wallet / Switch / Disconnect
+
+2. 开通道卡
+- 输入：Target Peer Pubkey
+- 输入：Funding Amount（CKB，强制显示单位）
+- 主按钮：Open Channel
+- 辅助信息：最近一次开通道结果、建议金额
+
+3. 支付卡
+- 动作：Create Invoice (1 CKB)
+- 输入：Invoice
+- 主按钮：Pay Invoice
+- 结果：支付状态标签（Succeeded / Failed / Pending）
+
+交互约束：
+
+1. 未连接时，开通道与支付主按钮 disabled。
+2. 按钮 loading 与 disabled 状态明确且互斥。
+3. 错误提示优先显示最近操作错误，不堆叠多个错误块。
+
+### 4.2 Tab: 通道管理
+
+目标：对已有通道进行查看、筛选、管理，避免干扰主任务。
+
+包含模块：
+
+1. 通道状态摘要（Active / Pending / Closed）
+2. 筛选器（active / pending / closed / all）
+3. 通道列表（紧凑行，不再默认大卡）
+4. 通道详情面板（点选行后展开）
+
+通道列表行最小信息：
+
+1. Channel ID（短）
+2. Peer（短）
+3. State Badge
+4. Local / Remote Balance（简写）
+
+详情面板信息：
+
+1. 完整 Channel ID
+2. 余额与 TLC 细节
+3. failure_detail
+4. shutdown tx hash
+
+动作策略：
+
+1. Close Channel 作为常规按钮。
+2. Force Close 作为危险按钮，仅在详情面板出现。
+3. Pending 状态展示 Abandon Pending。
+
+确认策略：
+
+1. Force Close 触发二次确认。
+2. 确认文案必须包含后果说明，不使用仅“是否确认”的弱文案。
+
+### 4.3 Tab: 网络诊断
+
+目标：将专家向信息集中，避免污染主操作路径。
+
+包含模块：
+
+1. 已连接 Peers
+2. Connect Peer（address 输入 + connect）
+3. Graph Snapshot
+4. 最近日志（可选，后续迭代）
+
+展示策略：
+
+1. Graph 明确标注采样范围，例如 showing X of N nodes。
+2. 默认折叠原始长文本，按需展开。
+
+## 5. 关键交互规则
+
+1. Tab 切换不丢状态。
+2. 输入内容与筛选条件跨 Tab 保留，直到面板关闭。
+3. 面板关闭后重开，恢复默认 Tab 为“操作台”。
+4. 错误提示采用单一错误槽位（latest error slot）。
+5. 成功反馈使用短时 status 文案，避免长期占位。
+
+## 6. 响应式规范
+
+### 6.1 Desktop
+
+1. 面板宽度：420 到 480。
+2. 内容区最大高度：视口高度的 70% 到 75%。
+3. Tab 内容区内部滚动，状态条与 Tab 栏固定。
+
+### 6.2 Mobile
+
+1. Tab 栏采用等宽 segmented control。
+2. 内容单列布局。
+3. 操作按钮宽度占满容器，减少误触。
+
+## 7. 可访问性（A11y）
+
+1. Tab 使用 aria-role="tablist/tab" 与可见焦点样式。
+2. 所有 icon-only 动作提供 aria-label。
+3. 颜色不是唯一状态信号，需配合文本与图标。
+4. 危险动作确认弹层支持键盘 Esc 关闭。
+
+## 8. 文案与术语规范
+
+1. 面向普通用户的主路径避免裸露术语。
+2. TLC 在首次出现处增加释义 tooltip。
+3. Funding Amount 永远附带单位 CKB。
+4. Graph sample 文案统一为：showing X of N nodes, Y of M channels。
+
+## 9. 技术实现建议（React）
+
+建议拆分组件，降低单文件复杂度：
+
+1. FiberNodePanelShell
+2. FiberNodeGlobalStatusBar
+3. FiberNodeTabs
+4. FiberNodeWorkbenchTab
+5. FiberNodeChannelsTab
+6. FiberNodeDiagnosticsTab
+
+状态管理建议：
+
+1. 保留现有 hooks：useFiberNode / useFiberPayment / useChannelOpenFlow
+2. 新增本地 UI 状态：activeTab、selectedChannelId、forceCloseConfirmOpen
+3. 将列表刷新逻辑集中到统一 actions，减少重复 loading 状态
+
+兼容性要求：
+
+1. FiberNodeButton 对外 props 不破坏。
+2. renderConnectorSection 仍在“操作台-连接准备卡”可用。
+
+## 10. 事件埋点建议
+
+1. fiber_panel_tab_switched
+2. fiber_channel_force_close_confirm_opened
+3. fiber_channel_force_close_confirmed
+4. fiber_panel_primary_action_clicked
+5. fiber_panel_error_shown
+
+埋点字段建议：
+
+1. tab_name
+2. channel_state
+3. external_wallet_enabled
+4. node_state
+
+## 11. 实施分期
+
+### Phase 1（快速落地，1 到 2 天）
+
+1. 引入 Tab 架构与全局状态条。
+2. 将 Peers + Graph 迁移到“网络诊断”。
+3. 完成“操作台”主流程整合。
+4. 保持现有数据获取与 action 逻辑。
+
+### Phase 2（体验强化，2 到 3 天）
+
+1. 通道列表改为紧凑行 + 详情面板。
+2. Force Close 二次确认弹层。
+3. 统一错误槽位与短时成功反馈。
+
+### Phase 3（优化，按需）
+
+1. 日志分组与搜索。
+2. 通道列表虚拟滚动。
+3. 新手引导文案与空状态优化。
+
+## 12. 验收标准（交付 QA）
+
+1. 默认打开面板时进入“操作台”Tab。
+2. 用户可在单屏内完成 connect -> open channel -> pay 主路径。
+3. Peers / Graph 信息不出现在默认首屏。
+4. Force Close 具备二次确认与后果文案。
+5. 切换 Tab 不丢输入状态。
+6. 所有按钮在 loading/disabled 上行为一致。
+7. format、lint、typecheck、test 全部通过。
+
+## 13. 非目标
+
+1. 本轮不调整底层 RPC 接口。
+2. 本轮不引入全新设计系统。
+3. 本轮不重写 node 运行时状态机。
+
+## 14. 设计评审待确认项
+
+1. Tab 文案使用“操作台/通道管理/网络诊断”还是英文版本。
+2. 通道详情面板采用 inline 展开还是右侧抽屉。
+3. Force Close 确认层采用 Popover 还是 Dialog。

--- a/docs/react-fiber-node-button-handoff.md
+++ b/docs/react-fiber-node-button-handoff.md
@@ -1,0 +1,98 @@
+# React FiberNodeButton Handoff
+
+## Context
+
+This handoff covers the FiberNodeButton panel redesign delivered on branch:
+- feat/react-connect-button-dogfood-fixes
+
+Primary implementation commit:
+- 0b374db feat(react): redesign FiberNodeButton management panel UX
+
+## Scope Delivered
+
+Updated files:
+- packages/react/src/fiber-node-button.tsx
+- packages/react/tests/fiber-node-button.test.tsx
+
+Key panel IA updates:
+1. Connection section now includes connector content (no separate connector section).
+2. Added a Peers and Graph composite section.
+3. Reworked Channels into a management-first section:
+- state summary (active, pending, closed)
+- filter chips (active, pending, closed, all)
+- clearer open-channel form hierarchy
+- row-level actions (close, force close, abandon pending)
+
+Behavior updates:
+- pending channels use abandonChannel
+- ready/active channels use shutdownChannel
+- closed/shutting-down channels are guarded from duplicate close attempts
+- graph and peer snapshots can be refreshed independently
+
+## Validation Completed
+
+React package:
+- pnpm --filter @fiber-pay/react test
+- pnpm --filter @fiber-pay/react typecheck
+- pnpm --filter @fiber-pay/react build
+
+Dogfood app:
+- cd apps/react-quick-card
+- pnpm lint
+- pnpm build
+
+Repository checks (pre-commit and manual):
+- pnpm format:check
+- pnpm lint
+
+## Handoff Notes For Reviewers
+
+Primary dogfood surface:
+- apps/react-quick-card/src/App.tsx
+
+SDK source of truth:
+- packages/react/src/fiber-node-button.tsx
+
+Test coverage touchpoints:
+- connection + dropdown sections render
+- peers and graph fetch behavior
+- channel close action path for ready channels
+
+## Acceptance Review Criteria
+
+Use this checklist for sign-off.
+
+### A. Functional Correctness
+- Connection controls behave correctly while node is connected/disconnected.
+- Connector actions embedded in Connection section remain usable.
+- Peers refresh, connect by address, and graph refresh all behave correctly.
+- Channel list reflects states and row actions call expected backend methods.
+- Payments panel still works (create invoice, pay invoice, status updates).
+
+### B. Information Architecture Clarity
+- Panel order is understandable: Connection -> Peers and Graph -> Channels -> Payments.
+- Each section has clear intent and avoids mixed responsibilities.
+- Channel data hierarchy is clear at a glance (state, balances, actions).
+
+### C. Interaction Quality
+- Important actions are obvious and discoverable.
+- Dangerous actions (force close) are visually distinct.
+- Loading states and disabled states prevent accidental repeated actions.
+
+### D. User-Perspective Experience (New)
+- Review from an end-user perspective specifically in react-quick-card:
+  - Can a user understand what this button panel can do without reading code?
+  - Can a user complete common tasks (connect, inspect peers/graph, open/manage channels, pay) with low confusion?
+  - Are the UX and UI signals (labels, grouping, state summaries, action affordances) clear enough for first-time usage?
+- This user-perspective check is required for acceptance, not optional.
+
+## Known Constraints
+
+- Graph section currently shows a sampled snapshot (limited nodes/channels) for panel readability.
+- The panel is dense by design; further progressive disclosure may still be useful after user testing.
+
+## Suggested Next Iteration
+
+1. Add lightweight inline confirm for close/force close actions.
+2. Add quick peer search/filter for larger peer sets.
+3. Add collapsible advanced details per channel row.

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -28,10 +28,28 @@ export function App() {
 
 `FiberPayQuickCard` supports lightweight integration hooks:
 
+- `fiber` (reuse existing `useFiberNode()` session)
 - `className`, `style`, `title`
 - `onInvoiceCreated(invoice)`
 - `onPaymentResult(result)`
 - `onError({ scope, message })`
+
+When you already manage connection state (for example with `ConnectButton`), pass the same hook result into `FiberPayQuickCard` so invoices and payments run on the same node session:
+
+```tsx
+import { ConnectButton, FiberPayQuickCard, useFiberNode } from '@fiber-pay/react';
+
+export function UnifiedFlow() {
+  const fiber = useFiberNode({ network: 'testnet', walletId: 'demo-wallet' });
+
+  return (
+    <>
+      <ConnectButton fiber={fiber} strategy="passkey" />
+      <FiberPayQuickCard fiber={fiber} network="testnet" title="Quick Card" />
+    </>
+  );
+}
+```
 
 ## ConnectButton
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -65,6 +65,35 @@ export function HeaderWallet() {
 }
 ```
 
+## FiberNodeButton
+
+`FiberNodeButton` is a higher-level button + dropdown panel for day-to-day node operations.
+It wraps `ConnectButton` and provides default sections for:
+
+- Connection state and disconnect
+- Channel management (peer connect / open channel)
+- Payment management (create invoice / pay invoice)
+- Optional connector section (custom renderer)
+
+```tsx
+import { FiberNodeButton, useFiberNode } from '@fiber-pay/react';
+
+export function WalletEntry() {
+  const fiber = useFiberNode({ network: 'testnet', walletId: 'demo-wallet' });
+
+  return (
+    <FiberNodeButton
+      fiber={fiber}
+      strategy="passkey"
+      onLog={(message) => console.log(message)}
+    />
+  );
+}
+```
+
+For external funding, pass `externalFunding` with an async `resolve` callback that returns
+`signFundingTx` and optional script / dep overrides.
+
 `ConnectButton` uses explicit strategy selection and supports only `"passkey"` or `"password"`.
 
 For custom connected-state panels (for example peer/channel controls), use `renderConnectedDropdown`:

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -51,6 +51,8 @@
     }
   },
   "devDependencies": {
-    "@types/react": "^18.0.0 || ^19.0.0"
+    "@testing-library/react": "^16.3.0",
+    "@types/react": "^18.0.0 || ^19.0.0",
+    "jsdom": "^26.1.0"
   }
 }

--- a/packages/react/src/connect-button.tsx
+++ b/packages/react/src/connect-button.tsx
@@ -25,6 +25,7 @@ import {
   type ReactNode,
   useCallback,
   useEffect,
+  useId,
   useRef,
   useState,
 } from 'react';
@@ -347,6 +348,8 @@ export function ConnectButton(props: ConnectButtonProps) {
   const [showDropdown, setShowDropdown] = useState(false);
   const [localError, setLocalError] = useState<string | null>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
+  const dropdownId = useId();
+  const lastReportedErrorRef = useRef<string | null>(null);
 
   const effectiveIsStarting = isConnecting || isStarting;
 
@@ -377,10 +380,21 @@ export function ConnectButton(props: ConnectButtonProps) {
     prevRunningRef.current = isRunning;
   }, [isRunning, node, nodeInfo, onConnect, onDisconnect]);
 
-  // Notify parent on error
+  // Notify parent on error once per distinct message.
+  const effectiveError = error ?? localError;
   useEffect(() => {
-    if (error) onError?.(error);
-  }, [error, onError]);
+    if (!effectiveError) {
+      lastReportedErrorRef.current = null;
+      return;
+    }
+
+    if (lastReportedErrorRef.current === effectiveError) {
+      return;
+    }
+
+    lastReportedErrorRef.current = effectiveError;
+    onError?.(effectiveError);
+  }, [effectiveError, onError]);
 
   // --- Actions --------------------------------------------------------------
 
@@ -404,7 +418,6 @@ export function ConnectButton(props: ConnectButtonProps) {
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       setLocalError(msg);
-      onError?.(msg);
     } finally {
       setIsConnecting(false);
     }
@@ -416,7 +429,6 @@ export function ConnectButton(props: ConnectButtonProps) {
     startWithPassword,
     startWithPasskey,
     createPasskeyAndStart,
-    onError,
   ]);
 
   const handleDisconnect = useCallback(async () => {
@@ -425,11 +437,10 @@ export function ConnectButton(props: ConnectButtonProps) {
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       setLocalError(msg);
-      onError?.(msg);
     } finally {
       setShowDropdown(false);
     }
-  }, [stop, onError]);
+  }, [stop]);
 
   const closeDropdown = useCallback(() => {
     setShowDropdown(false);
@@ -437,7 +448,7 @@ export function ConnectButton(props: ConnectButtonProps) {
 
   // --- Render ---------------------------------------------------------------
 
-  const hasError = !!(error || localError);
+  const hasError = !!effectiveError;
 
   // Determine button content and behaviour
   let buttonLabel: ReactNode;
@@ -498,12 +509,19 @@ export function ConnectButton(props: ConnectButtonProps) {
 
       {isRunning ? (
         <div style={{ position: 'relative' }} ref={dropdownRef}>
-          <button type="button" onClick={buttonOnClick} style={buttonStyle}>
+          <button
+            type="button"
+            onClick={buttonOnClick}
+            style={buttonStyle}
+            aria-haspopup="menu"
+            aria-expanded={showDropdown}
+            aria-controls={showDropdown ? dropdownId : undefined}
+          >
             {buttonLabel}
           </button>
 
           {showDropdown && (
-            <div style={{ ...styles.dropdown, ...dropdownStyle }}>
+            <div id={dropdownId} role="menu" style={{ ...styles.dropdown, ...dropdownStyle }}>
               {renderConnectedDropdown ? (
                 renderConnectedDropdown({
                   fiber,

--- a/packages/react/src/connect-button.tsx
+++ b/packages/react/src/connect-button.tsx
@@ -513,7 +513,7 @@ export function ConnectButton(props: ConnectButtonProps) {
             type="button"
             onClick={buttonOnClick}
             style={buttonStyle}
-            aria-haspopup="menu"
+            aria-haspopup="dialog"
             aria-expanded={showDropdown}
             aria-controls={showDropdown ? dropdownId : undefined}
           >
@@ -521,7 +521,12 @@ export function ConnectButton(props: ConnectButtonProps) {
           </button>
 
           {showDropdown && (
-            <div id={dropdownId} role="menu" style={{ ...styles.dropdown, ...dropdownStyle }}>
+            <div
+              id={dropdownId}
+              role="dialog"
+              aria-label="Connection panel"
+              style={{ ...styles.dropdown, ...dropdownStyle }}
+            >
               {renderConnectedDropdown ? (
                 renderConnectedDropdown({
                   fiber,

--- a/packages/react/src/fiber-node-button.tsx
+++ b/packages/react/src/fiber-node-button.tsx
@@ -1,0 +1,645 @@
+import type {
+  CellDep,
+  FiberBrowserNode,
+  FiberWasmFactory,
+  HexString,
+  NodeInfoResult,
+  Script,
+} from '@fiber-pay/sdk/browser';
+import {
+  type CSSProperties,
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useState,
+} from 'react';
+import {
+  ConnectButton,
+  type ConnectButtonConnectedDropdownContext,
+  type ConnectStrategy,
+} from './connect-button.js';
+import { useChannelOpenFlow } from './use-channel-open-flow.js';
+import type { UseFiberNodeOptions, UseFiberNodeResult } from './use-fiber-node.js';
+import { useFiberNode } from './use-fiber-node.js';
+import { useFiberPayment } from './use-fiber-payment.js';
+
+const ONE_CKB_SHANNONS = '0x5f5e100';
+
+function shorten(value: string, head = 10, tail = 8): string {
+  if (!value || value.length <= head + tail + 3) {
+    return value;
+  }
+  return `${value.slice(0, head)}...${value.slice(-tail)}`;
+}
+
+function toHexPrefixed(value: string): HexString {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    throw new Error('Hex value is empty.');
+  }
+  return (trimmed.startsWith('0x') ? trimmed : `0x${trimmed}`) as HexString;
+}
+
+export interface FiberNodeButtonExternalFundingResolved {
+  signFundingTx: (txForSigner: unknown) => Promise<unknown>;
+  shutdownScript?: Script;
+  fundingLockScript?: Script;
+  fundingLockScriptCellDeps?: CellDep[];
+  ckbRpcUrl?: string;
+}
+
+export interface FiberNodeButtonExternalFundingResolverContext {
+  node: FiberBrowserNode;
+  pubkey: HexString;
+  fundingAmountCkb: string;
+}
+
+export interface FiberNodeButtonExternalFundingConfig {
+  enabled: boolean;
+  resolve: (
+    context: FiberNodeButtonExternalFundingResolverContext,
+  ) => Promise<FiberNodeButtonExternalFundingResolved>;
+}
+
+export interface FiberNodeButtonConnectorSectionContext {
+  fiber: UseFiberNodeResult;
+  externalFundingEnabled: boolean;
+  isOpeningChannel: boolean;
+}
+
+export interface FiberNodeButtonProps {
+  network?: 'testnet' | 'mainnet';
+  fiber?: UseFiberNodeResult;
+  strategy?: ConnectStrategy;
+  externalWallet?: boolean;
+  password?: string;
+  walletId?: string;
+  passkeyUsername?: string;
+  wasmFactory?: FiberWasmFactory;
+  nodeConfig?: UseFiberNodeOptions['nodeConfig'];
+  className?: string;
+  style?: CSSProperties;
+  dropdownStyle?: CSSProperties;
+  onConnect?: (node: FiberBrowserNode, nodeInfo: NodeInfoResult) => void;
+  onDisconnect?: () => void;
+  onError?: (error: string) => void;
+  onLog?: (message: string) => void;
+  initialPeerPubkey?: string;
+  initialPeerAddress?: string;
+  initialFundingAmountCkb?: string;
+  externalFunding?: FiberNodeButtonExternalFundingConfig;
+  renderConnectorSection?: (context: FiberNodeButtonConnectorSectionContext) => ReactNode;
+}
+
+const styles = {
+  panel: {
+    display: 'grid',
+    gap: '0.75rem',
+    minWidth: '360px',
+  } satisfies CSSProperties,
+
+  section: {
+    border: '1px solid var(--fpay-border, #e5e7eb)',
+    borderRadius: '0.6rem',
+    padding: '0.6rem',
+    background: 'var(--fpay-bg-secondary, #f8fafc)',
+  } satisfies CSSProperties,
+
+  sectionTitle: {
+    margin: '0 0 0.5rem',
+    fontSize: '0.78rem',
+    fontWeight: 700,
+    color: 'var(--fpay-text-primary, #111827)',
+    letterSpacing: '0.02em',
+  } satisfies CSSProperties,
+
+  row: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '0.5rem',
+    marginBottom: '0.5rem',
+  } satisfies CSSProperties,
+
+  compactText: {
+    fontSize: '0.75rem',
+    color: 'var(--fpay-text-secondary, #6b7280)',
+    margin: 0,
+  } satisfies CSSProperties,
+
+  input: {
+    width: '100%',
+    border: '1px solid var(--fpay-border, #cbd5e1)',
+    borderRadius: '0.4rem',
+    padding: '0.35rem 0.45rem',
+    fontSize: '0.78rem',
+    background: '#fff',
+  } satisfies CSSProperties,
+
+  actionButton: {
+    border: '1px solid var(--fpay-border, #cbd5e1)',
+    borderRadius: '0.45rem',
+    padding: '0.35rem 0.55rem',
+    fontSize: '0.76rem',
+    fontWeight: 600,
+    background: '#fff',
+    color: 'var(--fpay-text-primary, #111827)',
+    cursor: 'pointer',
+  } satisfies CSSProperties,
+
+  primaryButton: {
+    border: '1px solid var(--fpay-accent, #2563eb)',
+    borderRadius: '0.45rem',
+    padding: '0.35rem 0.55rem',
+    fontSize: '0.76rem',
+    fontWeight: 700,
+    background: 'var(--fpay-accent, #2563eb)',
+    color: '#fff',
+    cursor: 'pointer',
+  } satisfies CSSProperties,
+
+  errorBox: {
+    border: '1px solid #fecaca',
+    background: '#fff1f2',
+    color: '#9f1239',
+    borderRadius: '0.5rem',
+    padding: '0.45rem 0.55rem',
+    fontSize: '0.74rem',
+    marginTop: '0.2rem',
+  } satisfies CSSProperties,
+};
+
+export function FiberNodeButton(props: FiberNodeButtonProps) {
+  const {
+    network = 'testnet',
+    fiber: externalFiber,
+    strategy = 'passkey',
+    externalWallet = false,
+    password,
+    walletId,
+    passkeyUsername = 'User',
+    wasmFactory,
+    nodeConfig,
+    className,
+    style,
+    dropdownStyle,
+    onConnect,
+    onDisconnect,
+    onError,
+    onLog,
+    initialPeerPubkey = '',
+    initialPeerAddress = '',
+    initialFundingAmountCkb = '1000',
+    externalFunding,
+    renderConnectorSection,
+  } = props;
+
+  const managedFiber = useFiberNode({
+    network,
+    walletId,
+    wasmFactory,
+    nodeConfig,
+    externalWallet,
+    enabled: !externalFiber,
+  });
+  const fiber = externalFiber ?? managedFiber;
+
+  const [peerPubkey, setPeerPubkey] = useState(initialPeerPubkey);
+  const [peerAddress, setPeerAddress] = useState(initialPeerAddress);
+  const [fundingAmountCkb, setFundingAmountCkb] = useState(initialFundingAmountCkb);
+  const [connectedPeers, setConnectedPeers] = useState<string[]>([]);
+  const [isRefreshingPeers, setIsRefreshingPeers] = useState(false);
+  const [isConnectingPeer, setIsConnectingPeer] = useState(false);
+
+  const [invoiceInput, setInvoiceInput] = useState('');
+  const [createdInvoice, setCreatedInvoice] = useState('');
+  const [isCreatingInvoice, setIsCreatingInvoice] = useState(false);
+  const [localError, setLocalError] = useState<string | null>(null);
+
+  const peerListId = useId();
+
+  const channelOpenFlow = useChannelOpenFlow({
+    node: fiber.node,
+    onLog,
+  });
+
+  const { payInvoice, isPaying, paymentResult, error: paymentError } = useFiberPayment(fiber.node);
+
+  const reportError = useCallback(
+    (message: string) => {
+      setLocalError(message);
+      onError?.(message);
+    },
+    [onError],
+  );
+
+  const refreshConnectedPeers = useCallback(async () => {
+    if (!fiber.node) {
+      setConnectedPeers([]);
+      return;
+    }
+
+    setIsRefreshingPeers(true);
+    setLocalError(null);
+
+    try {
+      const peers = await fiber.node.listPeers();
+      const pubkeys = peers.peers.map((peer) => peer.pubkey);
+      setConnectedPeers(pubkeys);
+      setPeerPubkey((prev) => (prev.trim() ? prev : (pubkeys[0] ?? prev)));
+      onLog?.(`Loaded connected peers: ${pubkeys.length}.`);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      reportError(message);
+      onLog?.(`Refresh peers failed: ${message}`);
+    } finally {
+      setIsRefreshingPeers(false);
+    }
+  }, [fiber.node, onLog, reportError]);
+
+  const connectPeerByAddress = useCallback(async () => {
+    if (!fiber.node) {
+      reportError('Node is not connected.');
+      return;
+    }
+
+    if (!peerAddress.trim()) {
+      reportError('Peer address is empty.');
+      return;
+    }
+
+    setIsConnectingPeer(true);
+    setLocalError(null);
+
+    try {
+      await fiber.node.connectPeer({
+        address: peerAddress.trim(),
+        save: true,
+      });
+      onLog?.('Peer connected from address input.');
+      await refreshConnectedPeers();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      reportError(message);
+      onLog?.(`Connect peer failed: ${message}`);
+    } finally {
+      setIsConnectingPeer(false);
+    }
+  }, [fiber.node, onLog, peerAddress, refreshConnectedPeers, reportError]);
+
+  const openChannel = useCallback(async () => {
+    if (!fiber.node) {
+      reportError('Node is not connected.');
+      return;
+    }
+
+    if (!peerPubkey.trim()) {
+      reportError('Target peer pubkey is empty.');
+      return;
+    }
+
+    setLocalError(null);
+    channelOpenFlow.reset();
+
+    try {
+      const pubkey = toHexPrefixed(peerPubkey);
+
+      if (!externalFunding?.enabled) {
+        await channelOpenFlow.openChannel({
+          pubkey,
+          fundingAmountCkb,
+          externalWallet: false,
+        });
+        return;
+      }
+
+      const resolved = await externalFunding.resolve({
+        node: fiber.node,
+        pubkey,
+        fundingAmountCkb,
+      });
+
+      await channelOpenFlow.openChannel({
+        pubkey,
+        fundingAmountCkb,
+        externalWallet: true,
+        shutdownScript: resolved.shutdownScript,
+        fundingLockScript: resolved.fundingLockScript,
+        fundingLockScriptCellDeps: resolved.fundingLockScriptCellDeps,
+        signFundingTx: resolved.signFundingTx,
+        ckbRpcUrl: resolved.ckbRpcUrl,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      reportError(message);
+      onLog?.(`Open channel failed: ${message}`);
+    }
+  }, [
+    channelOpenFlow,
+    externalFunding,
+    fiber.node,
+    fundingAmountCkb,
+    onLog,
+    peerPubkey,
+    reportError,
+  ]);
+
+  const createInvoice = useCallback(async () => {
+    if (!fiber.node) {
+      reportError('Node is not connected.');
+      return;
+    }
+
+    setIsCreatingInvoice(true);
+    setLocalError(null);
+
+    try {
+      const created = await fiber.node.newInvoice({
+        amount: ONE_CKB_SHANNONS,
+        currency: network === 'mainnet' ? 'Fibb' : 'Fibt',
+        description: 'FiberNodeButton invoice',
+      });
+      setCreatedInvoice(created.invoice_address);
+      onLog?.(`Invoice created: ${shorten(created.invoice_address, 20, 8)}`);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      reportError(message);
+    } finally {
+      setIsCreatingInvoice(false);
+    }
+  }, [fiber.node, network, onLog, reportError]);
+
+  const submitPayment = useCallback(async () => {
+    if (!invoiceInput.trim()) {
+      reportError('Invoice is empty.');
+      return;
+    }
+
+    setLocalError(null);
+    await payInvoice(invoiceInput);
+  }, [invoiceInput, payInvoice, reportError]);
+
+  useEffect(() => {
+    if (paymentError) {
+      reportError(paymentError);
+    }
+  }, [paymentError, reportError]);
+
+  useEffect(() => {
+    if (paymentResult) {
+      onLog?.(`Payment status: ${paymentResult.status}`);
+    }
+  }, [onLog, paymentResult]);
+
+  useEffect(() => {
+    if (!fiber.isRunning || !fiber.node) {
+      setConnectedPeers([]);
+      return;
+    }
+
+    void refreshConnectedPeers();
+  }, [fiber.isRunning, fiber.node, refreshConnectedPeers]);
+
+  const mergedError = useMemo(
+    () => localError ?? channelOpenFlow.error ?? paymentError,
+    [channelOpenFlow.error, localError, paymentError],
+  );
+
+  const handleConnectButtonError = useCallback(
+    (error: string) => {
+      reportError(error);
+    },
+    [reportError],
+  );
+
+  const connectorContext: FiberNodeButtonConnectorSectionContext = useMemo(
+    () => ({
+      fiber,
+      externalFundingEnabled: !!externalFunding?.enabled,
+      isOpeningChannel: channelOpenFlow.isOpening,
+    }),
+    [channelOpenFlow.isOpening, externalFunding?.enabled, fiber],
+  );
+
+  const renderDropdown = useCallback(
+    (dropdownContext: ConnectButtonConnectedDropdownContext) => (
+      <div style={styles.panel}>
+        <section style={styles.section}>
+          <h4 style={styles.sectionTitle}>Connection</h4>
+          <p style={styles.compactText}>State: {fiber.state}</p>
+          <p style={styles.compactText}>
+            Node: {fiber.nodeInfo?.pubkey ? shorten(fiber.nodeInfo.pubkey) : 'N/A'}
+          </p>
+          <p style={styles.compactText}>
+            Funding mode: {externalFunding?.enabled ? 'External signer' : 'Internal node'}
+          </p>
+          <div style={{ ...styles.row, marginBottom: 0 }}>
+            <button
+              type="button"
+              style={styles.actionButton}
+              onClick={() => {
+                void dropdownContext.disconnect();
+              }}
+            >
+              Disconnect
+            </button>
+            <button
+              type="button"
+              style={styles.actionButton}
+              onClick={() => {
+                dropdownContext.closeDropdown();
+              }}
+            >
+              Close
+            </button>
+          </div>
+        </section>
+
+        <section style={styles.section}>
+          <h4 style={styles.sectionTitle}>Channels</h4>
+          <div style={styles.row}>
+            <input
+              style={styles.input}
+              list={peerListId}
+              value={peerPubkey}
+              onChange={(event) => setPeerPubkey(event.target.value)}
+              placeholder={connectedPeers[0] ?? 'Target peer pubkey (0x...)'}
+            />
+            <datalist id={peerListId}>
+              {connectedPeers.map((peer) => (
+                <option key={peer} value={peer} />
+              ))}
+            </datalist>
+          </div>
+          <div style={styles.row}>
+            <input
+              style={styles.input}
+              value={peerAddress}
+              onChange={(event) => setPeerAddress(event.target.value)}
+              placeholder="Peer address (/dns4/.../wss/p2p/...)"
+            />
+          </div>
+          <div style={styles.row}>
+            <input
+              style={styles.input}
+              value={fundingAmountCkb}
+              onChange={(event) => setFundingAmountCkb(event.target.value)}
+              placeholder="Funding amount in CKB"
+            />
+          </div>
+          <div style={{ ...styles.row, marginBottom: 0 }}>
+            <button
+              type="button"
+              style={styles.actionButton}
+              disabled={isRefreshingPeers}
+              onClick={() => {
+                void refreshConnectedPeers();
+              }}
+            >
+              {isRefreshingPeers ? 'Refreshing...' : 'Refresh Peers'}
+            </button>
+            <button
+              type="button"
+              style={styles.actionButton}
+              disabled={isConnectingPeer}
+              onClick={() => {
+                void connectPeerByAddress();
+              }}
+            >
+              {isConnectingPeer ? 'Connecting...' : 'Connect Peer'}
+            </button>
+            <button
+              type="button"
+              style={styles.primaryButton}
+              disabled={channelOpenFlow.isOpening}
+              onClick={() => {
+                void openChannel();
+              }}
+            >
+              {channelOpenFlow.isOpening ? 'Opening...' : 'Open Channel'}
+            </button>
+          </div>
+          {channelOpenFlow.lastResult && (
+            <p style={{ ...styles.compactText, marginTop: '0.45rem' }}>
+              Channel: {shorten(channelOpenFlow.lastResult.channelId, 12, 8)}
+            </p>
+          )}
+          {channelOpenFlow.suggestedFundingAmountCkb && (
+            <p style={{ ...styles.compactText, marginTop: '0.35rem' }}>
+              Suggested amount: {channelOpenFlow.suggestedFundingAmountCkb} CKB
+            </p>
+          )}
+        </section>
+
+        <section style={styles.section}>
+          <h4 style={styles.sectionTitle}>Payments</h4>
+          <div style={styles.row}>
+            <button
+              type="button"
+              style={styles.actionButton}
+              disabled={isCreatingInvoice}
+              onClick={() => {
+                void createInvoice();
+              }}
+            >
+              {isCreatingInvoice ? 'Creating...' : 'Create Invoice (1 CKB)'}
+            </button>
+            {createdInvoice && (
+              <span style={styles.compactText}>{shorten(createdInvoice, 18, 10)}</span>
+            )}
+          </div>
+          <div style={styles.row}>
+            <input
+              style={styles.input}
+              value={invoiceInput}
+              onChange={(event) => setInvoiceInput(event.target.value)}
+              placeholder="Paste invoice to pay"
+            />
+          </div>
+          <div style={{ ...styles.row, marginBottom: 0 }}>
+            <button
+              type="button"
+              style={styles.primaryButton}
+              disabled={isPaying}
+              onClick={() => {
+                void submitPayment();
+              }}
+            >
+              {isPaying ? 'Paying...' : 'Pay Invoice'}
+            </button>
+            {paymentResult && (
+              <span style={styles.compactText}>Status: {paymentResult.status}</span>
+            )}
+          </div>
+        </section>
+
+        {renderConnectorSection ? (
+          <section style={styles.section}>
+            <h4 style={styles.sectionTitle}>Connector</h4>
+            {renderConnectorSection(connectorContext)}
+          </section>
+        ) : null}
+
+        {mergedError && <div style={styles.errorBox}>{mergedError}</div>}
+        {channelOpenFlow.diagnostic && (
+          <div
+            style={{
+              ...styles.errorBox,
+              borderColor: '#bfdbfe',
+              color: '#1d4ed8',
+              background: '#eff6ff',
+            }}
+          >
+            {channelOpenFlow.diagnostic}
+          </div>
+        )}
+      </div>
+    ),
+    [
+      channelOpenFlow.diagnostic,
+      channelOpenFlow.isOpening,
+      channelOpenFlow.lastResult,
+      channelOpenFlow.suggestedFundingAmountCkb,
+      connectPeerByAddress,
+      connectorContext,
+      createdInvoice,
+      externalFunding?.enabled,
+      fiber.nodeInfo?.pubkey,
+      fiber.state,
+      fundingAmountCkb,
+      invoiceInput,
+      isConnectingPeer,
+      isCreatingInvoice,
+      isPaying,
+      isRefreshingPeers,
+      mergedError,
+      openChannel,
+      paymentResult,
+      peerAddress,
+      peerListId,
+      peerPubkey,
+      refreshConnectedPeers,
+      renderConnectorSection,
+      submitPayment,
+      createInvoice,
+      connectedPeers,
+    ],
+  );
+
+  return (
+    <ConnectButton
+      fiber={fiber}
+      strategy={strategy}
+      password={password}
+      passkeyUsername={passkeyUsername}
+      onConnect={onConnect}
+      onDisconnect={onDisconnect}
+      onError={handleConnectButtonError}
+      className={className}
+      style={style}
+      dropdownStyle={{ width: 420, ...dropdownStyle }}
+      renderConnectedDropdown={renderDropdown}
+    />
+  );
+}

--- a/packages/react/src/fiber-node-button.tsx
+++ b/packages/react/src/fiber-node-button.tsx
@@ -1,11 +1,18 @@
 import type {
+  AbandonChannelParams,
   CellDep,
+  Channel,
   FiberBrowserNode,
   FiberWasmFactory,
+  GraphChannelsResult,
+  GraphNodesResult,
   HexString,
+  ListPeersResult,
   NodeInfoResult,
   Script,
+  ShutdownChannelParams,
 } from '@fiber-pay/sdk/browser';
+import { ChannelState, shannonsToCkb } from '@fiber-pay/sdk/browser';
 import {
   type CSSProperties,
   type ReactNode,
@@ -27,6 +34,11 @@ import { useFiberPayment } from './use-fiber-payment.js';
 
 const ONE_CKB_SHANNONS = '0x5f5e100';
 
+type ChannelFilter = 'active' | 'pending' | 'closed' | 'all';
+type GraphChannelInfo = GraphChannelsResult['channels'][number];
+type GraphNodeInfo = GraphNodesResult['nodes'][number];
+type PeerInfo = ListPeersResult['peers'][number];
+
 function shorten(value: string, head = 10, tail = 8): string {
   if (!value || value.length <= head + tail + 3) {
     return value;
@@ -40,6 +52,32 @@ function toHexPrefixed(value: string): HexString {
     throw new Error('Hex value is empty.');
   }
   return (trimmed.startsWith('0x') ? trimmed : `0x${trimmed}`) as HexString;
+}
+
+function isPendingChannelState(state: ChannelState): boolean {
+  return (
+    state === ChannelState.NegotiatingFunding ||
+    state === ChannelState.CollaboratingFundingTx ||
+    state === ChannelState.SigningCommitment ||
+    state === ChannelState.AwaitingTxSignatures ||
+    state === ChannelState.AwaitingChannelReady
+  );
+}
+
+function formatChannelBalance(shannonsHex: HexString): string {
+  const ckb = shannonsToCkb(shannonsHex);
+  return Number.isFinite(ckb) ? ckb.toFixed(4) : '0.0000';
+}
+
+function isClosedChannelState(state: ChannelState): boolean {
+  return state === ChannelState.Closed || state === ChannelState.ShuttingDown;
+}
+
+function getChannelFilterState(channel: Channel): ChannelFilter {
+  const state = channel.state.state_name;
+  if (isPendingChannelState(state)) return 'pending';
+  if (isClosedChannelState(state)) return 'closed';
+  return 'active';
 }
 
 export interface FiberNodeButtonExternalFundingResolved {
@@ -122,6 +160,28 @@ const styles = {
     marginBottom: '0.5rem',
   } satisfies CSSProperties,
 
+  rowBetween: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: '0.5rem',
+    marginBottom: '0.5rem',
+  } satisfies CSSProperties,
+
+  stack: {
+    display: 'grid',
+    gap: '0.5rem',
+  } satisfies CSSProperties,
+
+  fieldLabel: {
+    display: 'grid',
+    gap: '0.25rem',
+    fontSize: '0.68rem',
+    fontWeight: 700,
+    color: 'var(--fpay-text-secondary, #64748b)',
+    textTransform: 'uppercase',
+  } satisfies CSSProperties,
+
   compactText: {
     fontSize: '0.75rem',
     color: 'var(--fpay-text-secondary, #6b7280)',
@@ -148,6 +208,28 @@ const styles = {
     cursor: 'pointer',
   } satisfies CSSProperties,
 
+  ghostButton: {
+    border: '1px solid transparent',
+    borderRadius: '0.45rem',
+    padding: '0.32rem 0.5rem',
+    fontSize: '0.74rem',
+    fontWeight: 600,
+    background: 'transparent',
+    color: 'var(--fpay-text-secondary, #475569)',
+    cursor: 'pointer',
+  } satisfies CSSProperties,
+
+  dangerButton: {
+    border: '1px solid #fecaca',
+    borderRadius: '0.45rem',
+    padding: '0.35rem 0.55rem',
+    fontSize: '0.76rem',
+    fontWeight: 700,
+    background: '#fff1f2',
+    color: '#9f1239',
+    cursor: 'pointer',
+  } satisfies CSSProperties,
+
   primaryButton: {
     border: '1px solid var(--fpay-accent, #2563eb)',
     borderRadius: '0.45rem',
@@ -167,6 +249,78 @@ const styles = {
     padding: '0.45rem 0.55rem',
     fontSize: '0.74rem',
     marginTop: '0.2rem',
+  } satisfies CSSProperties,
+
+  channelList: {
+    marginTop: '0.55rem',
+    display: 'grid',
+    gap: '0.45rem',
+    maxHeight: '220px',
+    overflowY: 'auto',
+    paddingRight: '0.15rem',
+  } satisfies CSSProperties,
+
+  channelItem: {
+    border: '1px solid var(--fpay-border, #dbe1ea)',
+    borderRadius: '0.45rem',
+    background: '#fff',
+    padding: '0.55rem',
+    display: 'grid',
+    gap: '0.45rem',
+  } satisfies CSSProperties,
+
+  statGrid: {
+    display: 'grid',
+    gridTemplateColumns: 'repeat(3, minmax(0, 1fr))',
+    gap: '0.4rem',
+  } satisfies CSSProperties,
+
+  statTile: {
+    border: '1px solid var(--fpay-border, #dbe1ea)',
+    borderRadius: '0.45rem',
+    background: '#fff',
+    padding: '0.45rem',
+  } satisfies CSSProperties,
+
+  statValue: {
+    display: 'block',
+    fontSize: '0.95rem',
+    fontWeight: 750,
+    color: 'var(--fpay-text-primary, #0f172a)',
+    lineHeight: 1.1,
+  } satisfies CSSProperties,
+
+  statLabel: {
+    display: 'block',
+    marginTop: '0.12rem',
+    fontSize: '0.65rem',
+    color: 'var(--fpay-text-secondary, #64748b)',
+  } satisfies CSSProperties,
+
+  badge: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    width: 'fit-content',
+    borderRadius: '999px',
+    border: '1px solid var(--fpay-border, #cbd5e1)',
+    background: '#f8fafc',
+    color: 'var(--fpay-text-secondary, #475569)',
+    padding: '0.12rem 0.42rem',
+    fontSize: '0.66rem',
+    fontWeight: 700,
+  } satisfies CSSProperties,
+
+  filterBar: {
+    display: 'flex',
+    gap: '0.25rem',
+    flexWrap: 'wrap',
+  } satisfies CSSProperties,
+
+  inlineCode: {
+    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+    fontSize: '0.72rem',
+    color: 'var(--fpay-text-primary, #111827)',
+    margin: 0,
   } satisfies CSSProperties,
 };
 
@@ -208,9 +362,16 @@ export function FiberNodeButton(props: FiberNodeButtonProps) {
   const [peerPubkey, setPeerPubkey] = useState(initialPeerPubkey);
   const [peerAddress, setPeerAddress] = useState(initialPeerAddress);
   const [fundingAmountCkb, setFundingAmountCkb] = useState(initialFundingAmountCkb);
-  const [connectedPeers, setConnectedPeers] = useState<string[]>([]);
+  const [connectedPeers, setConnectedPeers] = useState<PeerInfo[]>([]);
   const [isRefreshingPeers, setIsRefreshingPeers] = useState(false);
   const [isConnectingPeer, setIsConnectingPeer] = useState(false);
+  const [graphNodes, setGraphNodes] = useState<GraphNodeInfo[]>([]);
+  const [graphChannels, setGraphChannels] = useState<GraphChannelInfo[]>([]);
+  const [isRefreshingGraph, setIsRefreshingGraph] = useState(false);
+  const [channels, setChannels] = useState<Channel[]>([]);
+  const [channelFilter, setChannelFilter] = useState<ChannelFilter>('active');
+  const [isRefreshingChannels, setIsRefreshingChannels] = useState(false);
+  const [closingChannelId, setClosingChannelId] = useState<string | null>(null);
 
   const [invoiceInput, setInvoiceInput] = useState('');
   const [createdInvoice, setCreatedInvoice] = useState('');
@@ -245,16 +406,43 @@ export function FiberNodeButton(props: FiberNodeButtonProps) {
 
     try {
       const peers = await fiber.node.listPeers();
-      const pubkeys = peers.peers.map((peer) => peer.pubkey);
-      setConnectedPeers(pubkeys);
-      setPeerPubkey((prev) => (prev.trim() ? prev : (pubkeys[0] ?? prev)));
-      onLog?.(`Loaded connected peers: ${pubkeys.length}.`);
+      setConnectedPeers(peers.peers);
+      setPeerPubkey((prev) => (prev.trim() ? prev : (peers.peers[0]?.pubkey ?? prev)));
+      onLog?.(`Loaded connected peers: ${peers.peers.length}.`);
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       reportError(message);
       onLog?.(`Refresh peers failed: ${message}`);
     } finally {
       setIsRefreshingPeers(false);
+    }
+  }, [fiber.node, onLog, reportError]);
+
+  const refreshGraph = useCallback(async () => {
+    if (!fiber.node) {
+      setGraphNodes([]);
+      setGraphChannels([]);
+      return;
+    }
+
+    setIsRefreshingGraph(true);
+
+    try {
+      const [nodesResult, channelsResult] = await Promise.all([
+        fiber.node.graphNodes({ limit: '0x8' }),
+        fiber.node.graphChannels({ limit: '0x8' }),
+      ]);
+      setGraphNodes(nodesResult.nodes);
+      setGraphChannels(channelsResult.channels);
+      onLog?.(
+        `Loaded graph: ${nodesResult.nodes.length} nodes, ${channelsResult.channels.length} channels.`,
+      );
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      reportError(message);
+      onLog?.(`Refresh graph failed: ${message}`);
+    } finally {
+      setIsRefreshingGraph(false);
     }
   }, [fiber.node, onLog, reportError]);
 
@@ -288,6 +476,83 @@ export function FiberNodeButton(props: FiberNodeButtonProps) {
     }
   }, [fiber.node, onLog, peerAddress, refreshConnectedPeers, reportError]);
 
+  const refreshChannels = useCallback(async () => {
+    if (!fiber.node) {
+      setChannels([]);
+      return;
+    }
+
+    setIsRefreshingChannels(true);
+
+    try {
+      const result = await fiber.node.listChannels({ include_closed: true });
+      setChannels(result.channels);
+      onLog?.(`Loaded channels: ${result.channels.length}.`);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      reportError(message);
+      onLog?.(`Refresh channels failed: ${message}`);
+    } finally {
+      setIsRefreshingChannels(false);
+    }
+  }, [fiber.node, onLog, reportError]);
+
+  const closeChannel = useCallback(
+    async (channelId: string, force = false) => {
+      if (!fiber.node) {
+        reportError('Node is not connected.');
+        return;
+      }
+
+      setClosingChannelId(channelId);
+      setLocalError(null);
+
+      try {
+        const latest = await fiber.node.listChannels({ include_closed: true });
+        const target = latest.channels.find((item) => item.channel_id === channelId);
+
+        if (!target) {
+          throw new Error(`Channel not found in latest snapshot: ${channelId}.`);
+        }
+
+        if (target.state.state_name === ChannelState.Closed) {
+          setChannels(latest.channels);
+          onLog?.(`Channel already closed: ${channelId}`);
+          return;
+        }
+
+        if (target.state.state_name === ChannelState.ShuttingDown) {
+          setChannels(latest.channels);
+          onLog?.(`Channel is already shutting down: ${channelId}`);
+          return;
+        }
+
+        if (isPendingChannelState(target.state.state_name)) {
+          const params: AbandonChannelParams = {
+            channel_id: channelId as HexString,
+          };
+          await fiber.node.abandonChannel(params);
+          onLog?.(`Pending channel abandoned: ${channelId}`);
+        } else {
+          const params: ShutdownChannelParams = {
+            channel_id: channelId as HexString,
+            force,
+          };
+          await fiber.node.shutdownChannel(params);
+          onLog?.(`${force ? 'Force close' : 'Close'} channel requested: ${channelId}`);
+        }
+
+        await refreshChannels();
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        reportError(message);
+      } finally {
+        setClosingChannelId(null);
+      }
+    },
+    [fiber.node, onLog, refreshChannels, reportError],
+  );
+
   const openChannel = useCallback(async () => {
     if (!fiber.node) {
       reportError('Node is not connected.');
@@ -311,6 +576,7 @@ export function FiberNodeButton(props: FiberNodeButtonProps) {
           fundingAmountCkb,
           externalWallet: false,
         });
+        await refreshChannels();
         return;
       }
 
@@ -330,6 +596,7 @@ export function FiberNodeButton(props: FiberNodeButtonProps) {
         signFundingTx: resolved.signFundingTx,
         ckbRpcUrl: resolved.ckbRpcUrl,
       });
+      await refreshChannels();
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       reportError(message);
@@ -342,6 +609,7 @@ export function FiberNodeButton(props: FiberNodeButtonProps) {
     fundingAmountCkb,
     onLog,
     peerPubkey,
+    refreshChannels,
     reportError,
   ]);
 
@@ -395,11 +663,34 @@ export function FiberNodeButton(props: FiberNodeButtonProps) {
   useEffect(() => {
     if (!fiber.isRunning || !fiber.node) {
       setConnectedPeers([]);
+      setGraphNodes([]);
+      setGraphChannels([]);
+      setChannels([]);
       return;
     }
 
     void refreshConnectedPeers();
-  }, [fiber.isRunning, fiber.node, refreshConnectedPeers]);
+    void refreshGraph();
+    void refreshChannels();
+  }, [fiber.isRunning, fiber.node, refreshChannels, refreshConnectedPeers, refreshGraph]);
+
+  const channelCounts = useMemo(() => {
+    const counts = { active: 0, pending: 0, closed: 0, all: channels.length };
+
+    for (const channel of channels) {
+      counts[getChannelFilterState(channel)] += 1;
+    }
+
+    return counts;
+  }, [channels]);
+
+  const visibleChannels = useMemo(
+    () =>
+      channelFilter === 'all'
+        ? channels
+        : channels.filter((channel) => getChannelFilterState(channel) === channelFilter),
+    [channelFilter, channels],
+  );
 
   const mergedError = useMemo(
     () => localError ?? channelOpenFlow.error ?? paymentError,
@@ -427,12 +718,24 @@ export function FiberNodeButton(props: FiberNodeButtonProps) {
       <div style={styles.panel}>
         <section style={styles.section}>
           <h4 style={styles.sectionTitle}>Connection</h4>
-          <p style={styles.compactText}>State: {fiber.state}</p>
-          <p style={styles.compactText}>
-            Node: {fiber.nodeInfo?.pubkey ? shorten(fiber.nodeInfo.pubkey) : 'N/A'}
-          </p>
-          <p style={styles.compactText}>
-            Funding mode: {externalFunding?.enabled ? 'External signer' : 'Internal node'}
+          <div style={styles.statGrid}>
+            <div style={styles.statTile}>
+              <span style={styles.statValue}>{fiber.state}</span>
+              <span style={styles.statLabel}>State</span>
+            </div>
+            <div style={styles.statTile}>
+              <span style={styles.statValue}>
+                {externalFunding?.enabled ? 'External' : 'Internal'}
+              </span>
+              <span style={styles.statLabel}>Funding</span>
+            </div>
+            <div style={styles.statTile}>
+              <span style={styles.statValue}>{connectedPeers.length}</span>
+              <span style={styles.statLabel}>Peers</span>
+            </div>
+          </div>
+          <p style={{ ...styles.inlineCode, marginTop: '0.5rem' }}>
+            Node: {fiber.nodeInfo?.pubkey ? shorten(fiber.nodeInfo.pubkey, 18, 12) : 'N/A'}
           </p>
           <div style={{ ...styles.row, marginBottom: 0 }}>
             <button
@@ -454,65 +757,181 @@ export function FiberNodeButton(props: FiberNodeButtonProps) {
               Close
             </button>
           </div>
+          {renderConnectorSection ? (
+            <div
+              style={{ marginTop: '0.6rem', paddingTop: '0.55rem', borderTop: '1px solid #e2e8f0' }}
+            >
+              {renderConnectorSection(connectorContext)}
+            </div>
+          ) : null}
         </section>
 
         <section style={styles.section}>
-          <h4 style={styles.sectionTitle}>Channels</h4>
-          <div style={styles.row}>
-            <input
-              style={styles.input}
-              list={peerListId}
-              value={peerPubkey}
-              onChange={(event) => setPeerPubkey(event.target.value)}
-              placeholder={connectedPeers[0] ?? 'Target peer pubkey (0x...)'}
-            />
-            <datalist id={peerListId}>
-              {connectedPeers.map((peer) => (
-                <option key={peer} value={peer} />
-              ))}
-            </datalist>
+          <div style={styles.rowBetween}>
+            <h4 style={{ ...styles.sectionTitle, margin: 0 }}>Peers & Graph</h4>
+            <div style={styles.filterBar}>
+              <button
+                type="button"
+                style={styles.actionButton}
+                disabled={isRefreshingPeers}
+                onClick={() => {
+                  void refreshConnectedPeers();
+                }}
+              >
+                {isRefreshingPeers ? 'Refreshing...' : 'Refresh Peers'}
+              </button>
+              <button
+                type="button"
+                style={styles.actionButton}
+                disabled={isRefreshingGraph}
+                onClick={() => {
+                  void refreshGraph();
+                }}
+              >
+                {isRefreshingGraph ? 'Loading...' : 'Refresh Graph'}
+              </button>
+            </div>
           </div>
-          <div style={styles.row}>
-            <input
-              style={styles.input}
-              value={peerAddress}
-              onChange={(event) => setPeerAddress(event.target.value)}
-              placeholder="Peer address (/dns4/.../wss/p2p/...)"
-            />
+
+          <div style={styles.statGrid}>
+            <div style={styles.statTile}>
+              <span style={styles.statValue}>{connectedPeers.length}</span>
+              <span style={styles.statLabel}>Connected</span>
+            </div>
+            <div style={styles.statTile}>
+              <span style={styles.statValue}>{graphNodes.length}</span>
+              <span style={styles.statLabel}>Graph Nodes</span>
+            </div>
+            <div style={styles.statTile}>
+              <span style={styles.statValue}>{graphChannels.length}</span>
+              <span style={styles.statLabel}>Graph Channels</span>
+            </div>
           </div>
-          <div style={styles.row}>
-            <input
-              style={styles.input}
-              value={fundingAmountCkb}
-              onChange={(event) => setFundingAmountCkb(event.target.value)}
-              placeholder="Funding amount in CKB"
-            />
-          </div>
-          <div style={{ ...styles.row, marginBottom: 0 }}>
+
+          <div style={{ ...styles.stack, marginTop: '0.55rem' }}>
+            <label style={styles.fieldLabel}>
+              Connect peer
+              <input
+                style={styles.input}
+                value={peerAddress}
+                onChange={(event) => setPeerAddress(event.target.value)}
+                placeholder="Peer address (/dns4/.../wss/p2p/...)"
+              />
+            </label>
             <button
               type="button"
-              style={styles.actionButton}
-              disabled={isRefreshingPeers}
-              onClick={() => {
-                void refreshConnectedPeers();
-              }}
-            >
-              {isRefreshingPeers ? 'Refreshing...' : 'Refresh Peers'}
-            </button>
-            <button
-              type="button"
-              style={styles.actionButton}
-              disabled={isConnectingPeer}
+              style={styles.primaryButton}
+              disabled={isConnectingPeer || !peerAddress.trim()}
               onClick={() => {
                 void connectPeerByAddress();
               }}
             >
               {isConnectingPeer ? 'Connecting...' : 'Connect Peer'}
             </button>
+          </div>
+
+          <div style={styles.channelList}>
+            {connectedPeers.length === 0 ? (
+              <p style={styles.compactText}>No connected peers.</p>
+            ) : (
+              connectedPeers.map((peer) => (
+                <article key={peer.pubkey} style={styles.channelItem}>
+                  <p style={styles.inlineCode}>Peer: {shorten(peer.pubkey, 18, 12)}</p>
+                  <p style={styles.compactText}>{peer.address}</p>
+                  <button
+                    type="button"
+                    style={styles.ghostButton}
+                    onClick={() => setPeerPubkey(peer.pubkey)}
+                  >
+                    Use for Channel
+                  </button>
+                </article>
+              ))
+            )}
+          </div>
+
+          {graphNodes.length > 0 || graphChannels.length > 0 ? (
+            <div style={{ ...styles.stack, marginTop: '0.55rem' }}>
+              <p style={styles.compactText}>Graph sample</p>
+              {graphNodes.slice(0, 3).map((node) => (
+                <p key={node.pubkey} style={styles.inlineCode}>
+                  Node: {node.node_name || shorten(node.pubkey, 18, 10)}
+                </p>
+              ))}
+              {graphChannels.slice(0, 2).map((channel) => (
+                <p
+                  key={`${channel.node1}-${channel.node2}-${channel.channel_outpoint.tx_hash}`}
+                  style={styles.inlineCode}
+                >
+                  Route: {shorten(channel.node1, 10, 6)} {'to'} {shorten(channel.node2, 10, 6)};{' '}
+                  {formatChannelBalance(channel.capacity)} CKB
+                </p>
+              ))}
+            </div>
+          ) : null}
+        </section>
+
+        <section style={styles.section}>
+          <div style={styles.rowBetween}>
+            <h4 style={{ ...styles.sectionTitle, margin: 0 }}>Channels</h4>
+            <button
+              type="button"
+              style={styles.actionButton}
+              disabled={isRefreshingChannels}
+              onClick={() => {
+                void refreshChannels();
+              }}
+            >
+              {isRefreshingChannels ? 'Refreshing...' : 'Refresh Channels'}
+            </button>
+          </div>
+
+          <div style={styles.statGrid}>
+            <div style={styles.statTile}>
+              <span style={styles.statValue}>{channelCounts.active}</span>
+              <span style={styles.statLabel}>Active</span>
+            </div>
+            <div style={styles.statTile}>
+              <span style={styles.statValue}>{channelCounts.pending}</span>
+              <span style={styles.statLabel}>Pending</span>
+            </div>
+            <div style={styles.statTile}>
+              <span style={styles.statValue}>{channelCounts.closed}</span>
+              <span style={styles.statLabel}>Closed</span>
+            </div>
+          </div>
+
+          <div style={{ ...styles.stack, marginTop: '0.65rem' }}>
+            <label style={styles.fieldLabel}>
+              Target peer pubkey
+              <input
+                style={styles.input}
+                list={peerListId}
+                value={peerPubkey}
+                onChange={(event) => setPeerPubkey(event.target.value)}
+                placeholder={connectedPeers[0]?.pubkey ?? '0x...'}
+              />
+              <datalist id={peerListId}>
+                {connectedPeers.map((peer) => (
+                  <option key={peer.pubkey} value={peer.pubkey} />
+                ))}
+              </datalist>
+            </label>
+            <label style={styles.fieldLabel}>
+              Funding amount
+              <input
+                style={styles.input}
+                value={fundingAmountCkb}
+                onChange={(event) => setFundingAmountCkb(event.target.value)}
+                placeholder="1000"
+              />
+            </label>
+          </div>
+          <div style={{ ...styles.row, marginTop: '0.55rem', marginBottom: 0 }}>
             <button
               type="button"
               style={styles.primaryButton}
-              disabled={channelOpenFlow.isOpening}
+              disabled={channelOpenFlow.isOpening || !peerPubkey.trim()}
               onClick={() => {
                 void openChannel();
               }}
@@ -530,6 +949,93 @@ export function FiberNodeButton(props: FiberNodeButtonProps) {
               Suggested amount: {channelOpenFlow.suggestedFundingAmountCkb} CKB
             </p>
           )}
+
+          <div style={{ ...styles.filterBar, marginTop: '0.65rem' }}>
+            {(['active', 'pending', 'closed', 'all'] as const).map((filter) => (
+              <button
+                key={filter}
+                type="button"
+                style={channelFilter === filter ? styles.primaryButton : styles.actionButton}
+                onClick={() => setChannelFilter(filter)}
+              >
+                {filter === 'all'
+                  ? `All (${channelCounts.all})`
+                  : `${filter} (${channelCounts[filter]})`}
+              </button>
+            ))}
+          </div>
+
+          <div style={styles.channelList}>
+            {visibleChannels.length === 0 ? (
+              <p style={styles.compactText}>No channels found.</p>
+            ) : (
+              visibleChannels.map((channel) => {
+                const stateName = channel.state.state_name;
+                const pending = isPendingChannelState(stateName);
+                const canClose =
+                  stateName !== ChannelState.Closed && stateName !== ChannelState.ShuttingDown;
+                const isClosing = closingChannelId === channel.channel_id;
+
+                return (
+                  <article key={channel.channel_id} style={styles.channelItem}>
+                    <div style={styles.rowBetween}>
+                      <p style={styles.inlineCode}>ID: {shorten(channel.channel_id, 16, 10)}</p>
+                      <span style={styles.badge}>{stateName}</span>
+                    </div>
+                    <p style={styles.inlineCode}>Peer: {shorten(channel.pubkey, 18, 10)}</p>
+                    <div style={styles.statGrid}>
+                      <div style={styles.statTile}>
+                        <span style={styles.statValue}>
+                          {formatChannelBalance(channel.local_balance)}
+                        </span>
+                        <span style={styles.statLabel}>Local CKB</span>
+                      </div>
+                      <div style={styles.statTile}>
+                        <span style={styles.statValue}>
+                          {formatChannelBalance(channel.remote_balance)}
+                        </span>
+                        <span style={styles.statLabel}>Remote CKB</span>
+                      </div>
+                      <div style={styles.statTile}>
+                        <span style={styles.statValue}>{channel.pending_tlcs.length}</span>
+                        <span style={styles.statLabel}>TLCs</span>
+                      </div>
+                    </div>
+                    {channel.shutdown_transaction_hash ? (
+                      <p style={styles.inlineCode}>
+                        Shutdown: {shorten(channel.shutdown_transaction_hash, 16, 10)}
+                      </p>
+                    ) : null}
+                    {channel.failure_detail ? (
+                      <p style={styles.compactText}>{channel.failure_detail}</p>
+                    ) : null}
+                    <div style={{ ...styles.row, marginBottom: 0, justifyContent: 'flex-end' }}>
+                      <button
+                        type="button"
+                        style={pending ? styles.actionButton : styles.dangerButton}
+                        disabled={!canClose || isClosing}
+                        onClick={() => {
+                          void closeChannel(channel.channel_id, false);
+                        }}
+                      >
+                        {isClosing ? 'Closing...' : pending ? 'Abandon Pending' : 'Close Channel'}
+                      </button>
+                      <button
+                        type="button"
+                        style={styles.ghostButton}
+                        disabled={pending || !canClose || isClosing}
+                        onClick={() => {
+                          void closeChannel(channel.channel_id, true);
+                        }}
+                      >
+                        Force Close
+                      </button>
+                    </div>
+                  </article>
+                );
+              })
+            )}
+          </div>
         </section>
 
         <section style={styles.section}>
@@ -574,13 +1080,6 @@ export function FiberNodeButton(props: FiberNodeButtonProps) {
           </div>
         </section>
 
-        {renderConnectorSection ? (
-          <section style={styles.section}>
-            <h4 style={styles.sectionTitle}>Connector</h4>
-            {renderConnectorSection(connectorContext)}
-          </section>
-        ) : null}
-
         {mergedError && <div style={styles.errorBox}>{mergedError}</div>}
         {channelOpenFlow.diagnostic && (
           <div
@@ -601,17 +1100,26 @@ export function FiberNodeButton(props: FiberNodeButtonProps) {
       channelOpenFlow.isOpening,
       channelOpenFlow.lastResult,
       channelOpenFlow.suggestedFundingAmountCkb,
+      channelCounts,
+      channelFilter,
+      closeChannel,
+      closingChannelId,
       connectPeerByAddress,
+      connectedPeers,
       connectorContext,
       createdInvoice,
       externalFunding?.enabled,
       fiber.nodeInfo?.pubkey,
       fiber.state,
       fundingAmountCkb,
+      graphChannels,
+      graphNodes,
       invoiceInput,
       isConnectingPeer,
       isCreatingInvoice,
       isPaying,
+      isRefreshingChannels,
+      isRefreshingGraph,
       isRefreshingPeers,
       mergedError,
       openChannel,
@@ -619,11 +1127,13 @@ export function FiberNodeButton(props: FiberNodeButtonProps) {
       peerAddress,
       peerListId,
       peerPubkey,
+      refreshChannels,
       refreshConnectedPeers,
+      refreshGraph,
       renderConnectorSection,
       submitPayment,
       createInvoice,
-      connectedPeers,
+      visibleChannels,
     ],
   );
 

--- a/packages/react/src/fiber-node-button.tsx
+++ b/packages/react/src/fiber-node-button.tsx
@@ -426,6 +426,7 @@ export function FiberNodeButton(props: FiberNodeButtonProps) {
     }
 
     setIsRefreshingGraph(true);
+    setLocalError(null);
 
     try {
       const [nodesResult, channelsResult] = await Promise.all([
@@ -483,6 +484,7 @@ export function FiberNodeButton(props: FiberNodeButtonProps) {
     }
 
     setIsRefreshingChannels(true);
+    setLocalError(null);
 
     try {
       const result = await fiber.node.listChannels({ include_closed: true });
@@ -852,7 +854,10 @@ export function FiberNodeButton(props: FiberNodeButtonProps) {
 
           {graphNodes.length > 0 || graphChannels.length > 0 ? (
             <div style={{ ...styles.stack, marginTop: '0.55rem' }}>
-              <p style={styles.compactText}>Graph sample</p>
+              <p style={styles.compactText}>
+                Graph sample (showing {Math.min(graphNodes.length, 3)} of {graphNodes.length} nodes,{' '}
+                {Math.min(graphChannels.length, 2)} of {graphChannels.length} channels)
+              </p>
               {graphNodes.slice(0, 3).map((node) => (
                 <p key={node.pubkey} style={styles.inlineCode}>
                   Node: {node.node_name || shorten(node.pubkey, 18, 10)}
@@ -901,55 +906,6 @@ export function FiberNodeButton(props: FiberNodeButtonProps) {
             </div>
           </div>
 
-          <div style={{ ...styles.stack, marginTop: '0.65rem' }}>
-            <label style={styles.fieldLabel}>
-              Target peer pubkey
-              <input
-                style={styles.input}
-                list={peerListId}
-                value={peerPubkey}
-                onChange={(event) => setPeerPubkey(event.target.value)}
-                placeholder={connectedPeers[0]?.pubkey ?? '0x...'}
-              />
-              <datalist id={peerListId}>
-                {connectedPeers.map((peer) => (
-                  <option key={peer.pubkey} value={peer.pubkey} />
-                ))}
-              </datalist>
-            </label>
-            <label style={styles.fieldLabel}>
-              Funding amount
-              <input
-                style={styles.input}
-                value={fundingAmountCkb}
-                onChange={(event) => setFundingAmountCkb(event.target.value)}
-                placeholder="1000"
-              />
-            </label>
-          </div>
-          <div style={{ ...styles.row, marginTop: '0.55rem', marginBottom: 0 }}>
-            <button
-              type="button"
-              style={styles.primaryButton}
-              disabled={channelOpenFlow.isOpening || !peerPubkey.trim()}
-              onClick={() => {
-                void openChannel();
-              }}
-            >
-              {channelOpenFlow.isOpening ? 'Opening...' : 'Open Channel'}
-            </button>
-          </div>
-          {channelOpenFlow.lastResult && (
-            <p style={{ ...styles.compactText, marginTop: '0.45rem' }}>
-              Channel: {shorten(channelOpenFlow.lastResult.channelId, 12, 8)}
-            </p>
-          )}
-          {channelOpenFlow.suggestedFundingAmountCkb && (
-            <p style={{ ...styles.compactText, marginTop: '0.35rem' }}>
-              Suggested amount: {channelOpenFlow.suggestedFundingAmountCkb} CKB
-            </p>
-          )}
-
           <div style={{ ...styles.filterBar, marginTop: '0.65rem' }}>
             {(['active', 'pending', 'closed', 'all'] as const).map((filter) => (
               <button
@@ -996,7 +952,10 @@ export function FiberNodeButton(props: FiberNodeButtonProps) {
                         </span>
                         <span style={styles.statLabel}>Remote CKB</span>
                       </div>
-                      <div style={styles.statTile}>
+                      <div
+                        style={styles.statTile}
+                        title="Pending TLCs (in-flight HTLC-like payment locks on this channel)"
+                      >
                         <span style={styles.statValue}>{channel.pending_tlcs.length}</span>
                         <span style={styles.statLabel}>TLCs</span>
                       </div>
@@ -1012,7 +971,7 @@ export function FiberNodeButton(props: FiberNodeButtonProps) {
                     <div style={{ ...styles.row, marginBottom: 0, justifyContent: 'flex-end' }}>
                       <button
                         type="button"
-                        style={pending ? styles.actionButton : styles.dangerButton}
+                        style={styles.actionButton}
                         disabled={!canClose || isClosing}
                         onClick={() => {
                           void closeChannel(channel.channel_id, false);
@@ -1022,7 +981,7 @@ export function FiberNodeButton(props: FiberNodeButtonProps) {
                       </button>
                       <button
                         type="button"
-                        style={styles.ghostButton}
+                        style={styles.dangerButton}
                         disabled={pending || !canClose || isClosing}
                         onClick={() => {
                           void closeChannel(channel.channel_id, true);
@@ -1036,6 +995,72 @@ export function FiberNodeButton(props: FiberNodeButtonProps) {
               })
             )}
           </div>
+
+          <div
+            style={{
+              marginTop: '0.75rem',
+              paddingTop: '0.6rem',
+              borderTop: '1px solid #e2e8f0',
+            }}
+          >
+            <h5
+              style={{
+                ...styles.sectionTitle,
+                margin: '0 0 0.5rem',
+                fontSize: '0.72rem',
+              }}
+            >
+              Open new channel
+            </h5>
+            <div style={styles.stack}>
+              <label style={styles.fieldLabel}>
+                Target peer pubkey
+                <input
+                  style={styles.input}
+                  list={peerListId}
+                  value={peerPubkey}
+                  onChange={(event) => setPeerPubkey(event.target.value)}
+                  placeholder={connectedPeers[0]?.pubkey ?? '0x...'}
+                />
+                <datalist id={peerListId}>
+                  {connectedPeers.map((peer) => (
+                    <option key={peer.pubkey} value={peer.pubkey} />
+                  ))}
+                </datalist>
+              </label>
+              <label style={styles.fieldLabel}>
+                Funding amount (CKB)
+                <input
+                  style={styles.input}
+                  value={fundingAmountCkb}
+                  onChange={(event) => setFundingAmountCkb(event.target.value)}
+                  placeholder="1000"
+                />
+              </label>
+            </div>
+            <div style={{ ...styles.row, marginTop: '0.55rem', marginBottom: 0 }}>
+              <button
+                type="button"
+                style={styles.primaryButton}
+                disabled={channelOpenFlow.isOpening || !peerPubkey.trim()}
+                onClick={() => {
+                  void openChannel();
+                }}
+              >
+                {channelOpenFlow.isOpening ? 'Opening...' : 'Open Channel'}
+              </button>
+            </div>
+            {channelOpenFlow.lastResult && (
+              <p style={{ ...styles.compactText, marginTop: '0.45rem' }}>
+                Channel: {shorten(channelOpenFlow.lastResult.channelId, 12, 8)}
+              </p>
+            )}
+            {channelOpenFlow.suggestedFundingAmountCkb && (
+              <p style={{ ...styles.compactText, marginTop: '0.35rem' }}>
+                Suggested amount: {channelOpenFlow.suggestedFundingAmountCkb} CKB
+              </p>
+            )}
+          </div>
         </section>
 
         <section style={styles.section}>
@@ -1044,7 +1069,7 @@ export function FiberNodeButton(props: FiberNodeButtonProps) {
             <button
               type="button"
               style={styles.actionButton}
-              disabled={isCreatingInvoice}
+              disabled={isCreatingInvoice || !fiber.isRunning}
               onClick={() => {
                 void createInvoice();
               }}
@@ -1067,7 +1092,7 @@ export function FiberNodeButton(props: FiberNodeButtonProps) {
             <button
               type="button"
               style={styles.primaryButton}
-              disabled={isPaying}
+              disabled={isPaying || !fiber.isRunning || !invoiceInput.trim()}
               onClick={() => {
                 void submitPayment();
               }}
@@ -1109,6 +1134,7 @@ export function FiberNodeButton(props: FiberNodeButtonProps) {
       connectorContext,
       createdInvoice,
       externalFunding?.enabled,
+      fiber.isRunning,
       fiber.nodeInfo?.pubkey,
       fiber.state,
       fundingAmountCkb,

--- a/packages/react/src/fiber-node-button.tsx
+++ b/packages/react/src/fiber-node-button.tsx
@@ -20,6 +20,7 @@ import {
   useEffect,
   useId,
   useMemo,
+  useRef,
   useState,
 } from 'react';
 import {
@@ -35,6 +36,7 @@ import { useFiberPayment } from './use-fiber-payment.js';
 const ONE_CKB_SHANNONS = '0x5f5e100';
 
 type ChannelFilter = 'active' | 'pending' | 'closed' | 'all';
+type PanelTab = 'workbench' | 'channels' | 'diagnostics';
 type GraphChannelInfo = GraphChannelsResult['channels'][number];
 type GraphNodeInfo = GraphNodesResult['nodes'][number];
 type PeerInfo = ListPeersResult['peers'][number];
@@ -44,6 +46,14 @@ function shorten(value: string, head = 10, tail = 8): string {
     return value;
   }
   return `${value.slice(0, head)}...${value.slice(-tail)}`;
+}
+
+function summarizeError(message: string, max = 72): string {
+  const trimmed = message.trim();
+  if (trimmed.length <= max) {
+    return trimmed;
+  }
+  return `${trimmed.slice(0, max - 3)}...`;
 }
 
 function toHexPrefixed(value: string): HexString {
@@ -78,6 +88,17 @@ function getChannelFilterState(channel: Channel): ChannelFilter {
   if (isPendingChannelState(state)) return 'pending';
   if (isClosedChannelState(state)) return 'closed';
   return 'active';
+}
+
+function withDisabledStyle(style: CSSProperties, disabled: boolean): CSSProperties {
+  if (!disabled) {
+    return style;
+  }
+  return {
+    ...style,
+    opacity: 0.55,
+    cursor: 'not-allowed',
+  };
 }
 
 export interface FiberNodeButtonExternalFundingResolved {
@@ -131,46 +152,228 @@ export interface FiberNodeButtonProps {
   renderConnectorSection?: (context: FiberNodeButtonConnectorSectionContext) => ReactNode;
 }
 
+interface FiberNodeButtonPanelProps {
+  dropdownContext: ConnectButtonConnectedDropdownContext;
+  network: 'testnet' | 'mainnet';
+  fiber: UseFiberNodeResult;
+  onLog?: (message: string) => void;
+  onError?: (error: string) => void;
+  initialPeerPubkey: string;
+  initialPeerAddress: string;
+  initialFundingAmountCkb: string;
+  externalFunding?: FiberNodeButtonExternalFundingConfig;
+  renderConnectorSection?: (context: FiberNodeButtonConnectorSectionContext) => ReactNode;
+}
+
+const TAB_ITEMS: ReadonlyArray<{ id: PanelTab; label: string }> = [
+  { id: 'workbench', label: 'Workbench' },
+  { id: 'channels', label: 'Channels' },
+  { id: 'diagnostics', label: 'Diagnostics' },
+];
+
+const FILTER_ITEMS: ReadonlyArray<ChannelFilter> = ['active', 'pending', 'closed', 'all'];
+
 const styles = {
-  panel: {
+  shell: {
+    position: 'relative',
     display: 'grid',
-    gap: '0.75rem',
+    gridTemplateRows: 'auto auto minmax(0, 1fr)',
+    gap: '0.7rem',
     minWidth: '360px',
+    width: 'min(460px, calc(100vw - 1rem))',
+    maxHeight: '72vh',
+  } satisfies CSSProperties,
+
+  globalBar: {
+    border: '1px solid var(--fpay-border, #d8dee8)',
+    borderRadius: '0.72rem',
+    background: 'linear-gradient(180deg, #ffffff 0%, #f8fafc 100%)',
+    padding: '0.52rem 0.56rem',
+    display: 'grid',
+    gap: '0.45rem',
+  } satisfies CSSProperties,
+
+  globalRow: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: '0.35rem',
+    flexWrap: 'wrap',
+  } satisfies CSSProperties,
+
+  globalMetrics: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '0.5rem',
+    flexWrap: 'wrap',
+    minWidth: 0,
+  } satisfies CSSProperties,
+
+  metricInline: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: '0.24rem',
+    whiteSpace: 'nowrap',
+  } satisfies CSSProperties,
+
+  metricDot: {
+    display: 'inline-flex',
+    width: '0.34rem',
+    height: '0.34rem',
+    borderRadius: '999px',
+    flexShrink: 0,
+    background: '#94a3b8',
+  } satisfies CSSProperties,
+
+  metricMain: {
+    fontSize: '0.82rem',
+    fontWeight: 750,
+    color: 'var(--fpay-text-primary, #0f172a)',
+    lineHeight: 1.1,
+  } satisfies CSSProperties,
+
+  metricSub: {
+    fontSize: '0.72rem',
+    color: 'var(--fpay-text-secondary, #64748b)',
+    lineHeight: 1.1,
+  } satisfies CSSProperties,
+
+  metricDivider: {
+    fontSize: '0.7rem',
+    color: '#94a3b8',
+    lineHeight: 1,
+  } satisfies CSSProperties,
+
+  globalMeta: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: '0.5rem',
+    flexWrap: 'wrap',
+  } satisfies CSSProperties,
+
+  globalErrorInline: {
+    margin: 0,
+    fontSize: '0.71rem',
+    color: '#9f1239',
+    lineHeight: 1.25,
+  } satisfies CSSProperties,
+
+  statusDot: {
+    display: 'inline-flex',
+    width: '0.45rem',
+    height: '0.45rem',
+    borderRadius: '999px',
+    flexShrink: 0,
+  } satisfies CSSProperties,
+
+  globalActions: {
+    display: 'flex',
+    gap: '0.36rem',
+    justifyContent: 'flex-end',
+    flexWrap: 'wrap',
+  } satisfies CSSProperties,
+
+  globalActionButton: {
+    border: '1px solid var(--fpay-border, #cbd5e1)',
+    borderRadius: '0.45rem',
+    padding: '0.28rem 0.48rem',
+    fontSize: '0.72rem',
+    fontWeight: 650,
+    background: '#fff',
+    color: 'var(--fpay-text-primary, #111827)',
+    cursor: 'pointer',
+  } satisfies CSSProperties,
+
+  tabList: {
+    borderRadius: '0.68rem',
+    border: 'none',
+    background: '#e9eef6',
+    padding: '0.14rem',
+    display: 'grid',
+    gridTemplateColumns: 'repeat(3, minmax(0, 1fr))',
+    gap: '0.14rem',
+    boxShadow: 'inset 0 0 0 1px var(--fpay-border, #d8dee8)',
+  } satisfies CSSProperties,
+
+  tabButton: {
+    border: 'none',
+    borderRadius: '0.5rem',
+    background: 'transparent',
+    color: '#334155',
+    fontSize: '0.74rem',
+    fontWeight: 700,
+    padding: '0.44rem 0.45rem',
+    cursor: 'pointer',
+  } satisfies CSSProperties,
+
+  tabButtonActive: {
+    border: 'none',
+    borderRadius: '0.5rem',
+    background: 'var(--fpay-accent, #1d4ed8)',
+    color: '#fff',
+    fontSize: '0.74rem',
+    fontWeight: 700,
+    padding: '0.44rem 0.45rem',
+    cursor: 'pointer',
+    boxShadow: 'none',
+  } satisfies CSSProperties,
+
+  content: {
+    overflowY: 'auto',
+    paddingRight: '0.15rem',
+    display: 'grid',
+    gap: '0.7rem',
+    minHeight: 0,
   } satisfies CSSProperties,
 
   section: {
-    border: '1px solid var(--fpay-border, #e5e7eb)',
-    borderRadius: '0.6rem',
-    padding: '0.6rem',
-    background: 'var(--fpay-bg-secondary, #f8fafc)',
+    border: 'none',
+    borderBottom: '1px solid var(--fpay-border, #e2e8f0)',
+    borderRadius: 0,
+    padding: '0.15rem 0 0.55rem',
+    background: 'transparent',
+    display: 'grid',
+    gap: '0.44rem',
   } satisfies CSSProperties,
 
   sectionTitle: {
-    margin: '0 0 0.5rem',
-    fontSize: '0.78rem',
-    fontWeight: 700,
-    color: 'var(--fpay-text-primary, #111827)',
-    letterSpacing: '0.02em',
+    margin: 0,
+    fontSize: '0.8rem',
+    fontWeight: 750,
+    color: 'var(--fpay-text-primary, #0f172a)',
+    letterSpacing: '0.01em',
   } satisfies CSSProperties,
 
   row: {
     display: 'flex',
     alignItems: 'center',
-    gap: '0.5rem',
-    marginBottom: '0.5rem',
+    gap: '0.45rem',
+    flexWrap: 'wrap',
   } satisfies CSSProperties,
 
   rowBetween: {
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'space-between',
-    gap: '0.5rem',
-    marginBottom: '0.5rem',
+    gap: '0.45rem',
+    flexWrap: 'wrap',
   } satisfies CSSProperties,
 
-  stack: {
-    display: 'grid',
-    gap: '0.5rem',
+  compactText: {
+    margin: 0,
+    fontSize: '0.74rem',
+    color: 'var(--fpay-text-secondary, #64748b)',
+    lineHeight: 1.4,
+  } satisfies CSSProperties,
+
+  inlineCode: {
+    margin: 0,
+    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+    fontSize: '0.72rem',
+    color: 'var(--fpay-text-primary, #111827)',
+    wordBreak: 'break-all',
+    lineHeight: 1.4,
   } satisfies CSSProperties,
 
   fieldLabel: {
@@ -182,29 +385,35 @@ const styles = {
     textTransform: 'uppercase',
   } satisfies CSSProperties,
 
-  compactText: {
-    fontSize: '0.75rem',
-    color: 'var(--fpay-text-secondary, #6b7280)',
-    margin: 0,
-  } satisfies CSSProperties,
-
   input: {
     width: '100%',
     border: '1px solid var(--fpay-border, #cbd5e1)',
-    borderRadius: '0.4rem',
-    padding: '0.35rem 0.45rem',
-    fontSize: '0.78rem',
+    borderRadius: '0.45rem',
+    padding: '0.38rem 0.48rem',
+    fontSize: '0.8rem',
     background: '#fff',
+    color: 'var(--fpay-text-primary, #0f172a)',
   } satisfies CSSProperties,
 
   actionButton: {
     border: '1px solid var(--fpay-border, #cbd5e1)',
     borderRadius: '0.45rem',
     padding: '0.35rem 0.55rem',
-    fontSize: '0.76rem',
-    fontWeight: 600,
+    fontSize: '0.74rem',
+    fontWeight: 650,
     background: '#fff',
     color: 'var(--fpay-text-primary, #111827)',
+    cursor: 'pointer',
+  } satisfies CSSProperties,
+
+  primaryButton: {
+    border: '1px solid var(--fpay-accent, #1d4ed8)',
+    borderRadius: '0.45rem',
+    padding: '0.35rem 0.55rem',
+    fontSize: '0.74rem',
+    fontWeight: 750,
+    background: 'var(--fpay-accent, #1d4ed8)',
+    color: '#fff',
     cursor: 'pointer',
   } satisfies CSSProperties,
 
@@ -213,7 +422,7 @@ const styles = {
     borderRadius: '0.45rem',
     padding: '0.32rem 0.5rem',
     fontSize: '0.74rem',
-    fontWeight: 600,
+    fontWeight: 650,
     background: 'transparent',
     color: 'var(--fpay-text-secondary, #475569)',
     cursor: 'pointer',
@@ -223,78 +432,11 @@ const styles = {
     border: '1px solid #fecaca',
     borderRadius: '0.45rem',
     padding: '0.35rem 0.55rem',
-    fontSize: '0.76rem',
-    fontWeight: 700,
-    background: '#fff1f2',
-    color: '#9f1239',
-    cursor: 'pointer',
-  } satisfies CSSProperties,
-
-  primaryButton: {
-    border: '1px solid var(--fpay-accent, #2563eb)',
-    borderRadius: '0.45rem',
-    padding: '0.35rem 0.55rem',
-    fontSize: '0.76rem',
-    fontWeight: 700,
-    background: 'var(--fpay-accent, #2563eb)',
-    color: '#fff',
-    cursor: 'pointer',
-  } satisfies CSSProperties,
-
-  errorBox: {
-    border: '1px solid #fecaca',
-    background: '#fff1f2',
-    color: '#9f1239',
-    borderRadius: '0.5rem',
-    padding: '0.45rem 0.55rem',
     fontSize: '0.74rem',
-    marginTop: '0.2rem',
-  } satisfies CSSProperties,
-
-  channelList: {
-    marginTop: '0.55rem',
-    display: 'grid',
-    gap: '0.45rem',
-    maxHeight: '220px',
-    overflowY: 'auto',
-    paddingRight: '0.15rem',
-  } satisfies CSSProperties,
-
-  channelItem: {
-    border: '1px solid var(--fpay-border, #dbe1ea)',
-    borderRadius: '0.45rem',
-    background: '#fff',
-    padding: '0.55rem',
-    display: 'grid',
-    gap: '0.45rem',
-  } satisfies CSSProperties,
-
-  statGrid: {
-    display: 'grid',
-    gridTemplateColumns: 'repeat(3, minmax(0, 1fr))',
-    gap: '0.4rem',
-  } satisfies CSSProperties,
-
-  statTile: {
-    border: '1px solid var(--fpay-border, #dbe1ea)',
-    borderRadius: '0.45rem',
-    background: '#fff',
-    padding: '0.45rem',
-  } satisfies CSSProperties,
-
-  statValue: {
-    display: 'block',
-    fontSize: '0.95rem',
     fontWeight: 750,
-    color: 'var(--fpay-text-primary, #0f172a)',
-    lineHeight: 1.1,
-  } satisfies CSSProperties,
-
-  statLabel: {
-    display: 'block',
-    marginTop: '0.12rem',
-    fontSize: '0.65rem',
-    color: 'var(--fpay-text-secondary, #64748b)',
+    background: '#fff1f2',
+    color: '#9f1239',
+    cursor: 'pointer',
   } satisfies CSSProperties,
 
   badge: {
@@ -305,24 +447,1256 @@ const styles = {
     border: '1px solid var(--fpay-border, #cbd5e1)',
     background: '#f8fafc',
     color: 'var(--fpay-text-secondary, #475569)',
-    padding: '0.12rem 0.42rem',
+    padding: '0.12rem 0.4rem',
     fontSize: '0.66rem',
     fontWeight: 700,
+    lineHeight: 1.1,
+  } satisfies CSSProperties,
+
+  notice: {
+    border: '1px solid #bfdbfe',
+    background: '#eff6ff',
+    color: '#1d4ed8',
+    borderRadius: '0.52rem',
+    padding: '0.46rem 0.52rem',
+    fontSize: '0.74rem',
+    lineHeight: 1.35,
+  } satisfies CSSProperties,
+
+  successNotice: {
+    borderColor: '#86efac',
+    background: '#f0fdf4',
+    color: '#166534',
+  } satisfies CSSProperties,
+
+  errorNotice: {
+    border: '1px solid #fecaca',
+    background: '#fff1f2',
+    color: '#9f1239',
+    borderRadius: '0.52rem',
+    padding: '0.46rem 0.52rem',
+    fontSize: '0.74rem',
+    lineHeight: 1.35,
+  } satisfies CSSProperties,
+
+  summaryGrid: {
+    display: 'none',
+  } satisfies CSSProperties,
+
+  summaryTile: {
+    display: 'none',
+  } satisfies CSSProperties,
+
+  summaryValue: {
+    display: 'block',
+    fontSize: '0.92rem',
+    fontWeight: 750,
+    color: 'var(--fpay-text-primary, #0f172a)',
+    lineHeight: 1.1,
+  } satisfies CSSProperties,
+
+  summaryLabel: {
+    display: 'block',
+    marginTop: '0.12rem',
+    fontSize: '0.64rem',
+    color: 'var(--fpay-text-secondary, #64748b)',
+  } satisfies CSSProperties,
+
+  summaryInline: {
+    margin: 0,
+    fontSize: '0.76rem',
+    color: 'var(--fpay-text-secondary, #475569)',
+    lineHeight: 1.35,
   } satisfies CSSProperties,
 
   filterBar: {
     display: 'flex',
-    gap: '0.25rem',
     flexWrap: 'wrap',
+    gap: '0.28rem',
   } satisfies CSSProperties,
 
-  inlineCode: {
-    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
-    fontSize: '0.72rem',
-    color: 'var(--fpay-text-primary, #111827)',
-    margin: 0,
+  list: {
+    display: 'grid',
+    gap: '0.34rem',
+    maxHeight: '240px',
+    overflowY: 'auto',
+    paddingRight: '0.1rem',
+  } satisfies CSSProperties,
+
+  compactChannelRow: {
+    border: '1px solid var(--fpay-border, #d8dee8)',
+    borderRadius: '0.5rem',
+    background: '#fff',
+    padding: '0.42rem 0.46rem',
+    cursor: 'pointer',
+    display: 'grid',
+    gap: '0.22rem',
+    textAlign: 'left',
+  } satisfies CSSProperties,
+
+  compactChannelRowActive: {
+    borderColor: 'var(--fpay-accent, #1d4ed8)',
+    boxShadow: '0 0 0 1px rgba(29, 78, 216, 0.12) inset',
+    background: '#f8fbff',
+  } satisfies CSSProperties,
+
+  compactChannelTop: {
+    display: 'grid',
+    gridTemplateColumns: '1fr auto',
+    alignItems: 'center',
+    gap: '0.35rem',
+  } satisfies CSSProperties,
+
+  detailPanel: {
+    border: '1px solid var(--fpay-border, #d8dee8)',
+    borderRadius: '0.6rem',
+    background: '#f8fafc',
+    padding: '0.6rem',
+    display: 'grid',
+    gap: '0.45rem',
+  } satisfies CSSProperties,
+
+  dialogBackdrop: {
+    position: 'absolute',
+    inset: 0,
+    background: 'rgba(15, 23, 42, 0.36)',
+    display: 'grid',
+    placeItems: 'center',
+    padding: '0.75rem',
+    zIndex: 3,
+  } satisfies CSSProperties,
+
+  dialogCard: {
+    width: 'min(100%, 360px)',
+    borderRadius: '0.68rem',
+    border: '1px solid #fecaca',
+    background: '#fff',
+    padding: '0.72rem',
+    display: 'grid',
+    gap: '0.55rem',
+  } satisfies CSSProperties,
+
+  srOnly: {
+    position: 'absolute',
+    width: 1,
+    height: 1,
+    padding: 0,
+    margin: -1,
+    overflow: 'hidden',
+    clip: 'rect(0, 0, 0, 0)',
+    border: 0,
   } satisfies CSSProperties,
 };
+
+function FiberNodeButtonPanel(props: FiberNodeButtonPanelProps) {
+  const {
+    dropdownContext,
+    network,
+    fiber,
+    onLog,
+    onError,
+    initialPeerPubkey,
+    initialPeerAddress,
+    initialFundingAmountCkb,
+    externalFunding,
+    renderConnectorSection,
+  } = props;
+
+  const [activeTab, setActiveTab] = useState<PanelTab>('workbench');
+
+  const [peerPubkey, setPeerPubkey] = useState(initialPeerPubkey);
+  const [peerAddress, setPeerAddress] = useState(initialPeerAddress);
+  const [fundingAmountCkb, setFundingAmountCkb] = useState(initialFundingAmountCkb);
+
+  const [connectedPeers, setConnectedPeers] = useState<PeerInfo[]>([]);
+  const [isRefreshingPeers, setIsRefreshingPeers] = useState(false);
+  const [isConnectingPeer, setIsConnectingPeer] = useState(false);
+
+  const [graphNodes, setGraphNodes] = useState<GraphNodeInfo[]>([]);
+  const [graphChannels, setGraphChannels] = useState<GraphChannelInfo[]>([]);
+  const [isRefreshingGraph, setIsRefreshingGraph] = useState(false);
+
+  const [channels, setChannels] = useState<Channel[]>([]);
+  const [channelFilter, setChannelFilter] = useState<ChannelFilter>('active');
+  const [isRefreshingChannels, setIsRefreshingChannels] = useState(false);
+  const [closingChannelId, setClosingChannelId] = useState<string | null>(null);
+  const [selectedChannelId, setSelectedChannelId] = useState<string | null>(null);
+  const [forceCloseConfirmOpen, setForceCloseConfirmOpen] = useState(false);
+
+  const [invoiceInput, setInvoiceInput] = useState('');
+  const [createdInvoice, setCreatedInvoice] = useState('');
+  const [isCreatingInvoice, setIsCreatingInvoice] = useState(false);
+
+  const [latestError, setLatestError] = useState<string | null>(null);
+  const [statusNotice, setStatusNotice] = useState<{
+    tone: 'info' | 'success';
+    text: string;
+  } | null>(null);
+
+  const statusTimerRef = useRef<number | null>(null);
+  const peerListId = useId();
+  const tabPanelId = useId();
+
+  const channelOpenFlow = useChannelOpenFlow({
+    node: fiber.node,
+    onLog,
+  });
+
+  const { payInvoice, isPaying, paymentResult, error: paymentError } = useFiberPayment(fiber.node);
+
+  const isNodeReady = fiber.isRunning && !!fiber.node;
+
+  useEffect(() => {
+    return () => {
+      if (statusTimerRef.current !== null) {
+        window.clearTimeout(statusTimerRef.current);
+      }
+    };
+  }, []);
+
+  const flashStatus = useCallback((text: string, tone: 'info' | 'success' = 'info') => {
+    setStatusNotice({ tone, text });
+    if (statusTimerRef.current !== null) {
+      window.clearTimeout(statusTimerRef.current);
+    }
+    statusTimerRef.current = window.setTimeout(() => {
+      setStatusNotice(null);
+      statusTimerRef.current = null;
+    }, 3200);
+  }, []);
+
+  const reportError = useCallback(
+    (message: string) => {
+      setLatestError(message);
+      onError?.(message);
+      onLog?.(`fiber_panel_error_shown: ${summarizeError(message, 120)}`);
+    },
+    [onError, onLog],
+  );
+
+  const refreshConnectedPeers = useCallback(async () => {
+    if (!fiber.node) {
+      setConnectedPeers([]);
+      return;
+    }
+
+    setIsRefreshingPeers(true);
+
+    try {
+      const peers = await fiber.node.listPeers();
+      setConnectedPeers(peers.peers);
+      setPeerPubkey((prev) => (prev.trim() ? prev : (peers.peers[0]?.pubkey ?? prev)));
+      onLog?.(`Loaded connected peers: ${peers.peers.length}.`);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      reportError(message);
+      onLog?.(`Refresh peers failed: ${message}`);
+    } finally {
+      setIsRefreshingPeers(false);
+    }
+  }, [fiber.node, onLog, reportError]);
+
+  const refreshGraph = useCallback(async () => {
+    if (!fiber.node) {
+      setGraphNodes([]);
+      setGraphChannels([]);
+      return;
+    }
+
+    setIsRefreshingGraph(true);
+
+    try {
+      const [nodesResult, channelsResult] = await Promise.all([
+        fiber.node.graphNodes({ limit: '0x8' }),
+        fiber.node.graphChannels({ limit: '0x8' }),
+      ]);
+      setGraphNodes(nodesResult.nodes);
+      setGraphChannels(channelsResult.channels);
+      onLog?.(
+        `Loaded graph: ${nodesResult.nodes.length} nodes, ${channelsResult.channels.length} channels.`,
+      );
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      reportError(message);
+      onLog?.(`Refresh graph failed: ${message}`);
+    } finally {
+      setIsRefreshingGraph(false);
+    }
+  }, [fiber.node, onLog, reportError]);
+
+  const refreshChannels = useCallback(async () => {
+    if (!fiber.node) {
+      setChannels([]);
+      return;
+    }
+
+    setIsRefreshingChannels(true);
+
+    try {
+      const result = await fiber.node.listChannels({ include_closed: true });
+      setChannels(result.channels);
+      onLog?.(`Loaded channels: ${result.channels.length}.`);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      reportError(message);
+      onLog?.(`Refresh channels failed: ${message}`);
+    } finally {
+      setIsRefreshingChannels(false);
+    }
+  }, [fiber.node, onLog, reportError]);
+
+  const closeChannel = useCallback(
+    async (channelId: string, force = false) => {
+      if (!fiber.node) {
+        reportError('Node is not connected.');
+        return;
+      }
+
+      setClosingChannelId(channelId);
+
+      try {
+        const latest = await fiber.node.listChannels({ include_closed: true });
+        const target = latest.channels.find((item) => item.channel_id === channelId);
+
+        if (!target) {
+          throw new Error(`Channel not found in latest snapshot: ${channelId}.`);
+        }
+
+        if (target.state.state_name === ChannelState.Closed) {
+          setChannels(latest.channels);
+          flashStatus('Channel is already closed.', 'info');
+          onLog?.(`Channel already closed: ${channelId}`);
+          return;
+        }
+
+        if (target.state.state_name === ChannelState.ShuttingDown) {
+          setChannels(latest.channels);
+          flashStatus('Channel is already shutting down.', 'info');
+          onLog?.(`Channel is already shutting down: ${channelId}`);
+          return;
+        }
+
+        if (isPendingChannelState(target.state.state_name)) {
+          const params: AbandonChannelParams = {
+            channel_id: channelId as HexString,
+          };
+          await fiber.node.abandonChannel(params);
+          flashStatus('Pending channel abandoned.', 'success');
+          onLog?.(`Pending channel abandoned: ${channelId}`);
+        } else {
+          const params: ShutdownChannelParams = {
+            channel_id: channelId as HexString,
+            force,
+          };
+          await fiber.node.shutdownChannel(params);
+          flashStatus(force ? 'Force close requested.' : 'Close requested.', 'success');
+          onLog?.(`${force ? 'Force close' : 'Close'} channel requested: ${channelId}`);
+        }
+
+        await refreshChannels();
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        reportError(message);
+      } finally {
+        setClosingChannelId(null);
+      }
+    },
+    [fiber.node, flashStatus, onLog, refreshChannels, reportError],
+  );
+
+  const connectPeerByAddress = useCallback(async () => {
+    if (!fiber.node) {
+      reportError('Node is not connected.');
+      return;
+    }
+
+    if (!peerAddress.trim()) {
+      reportError('Peer address is empty.');
+      return;
+    }
+
+    setIsConnectingPeer(true);
+
+    try {
+      await fiber.node.connectPeer({
+        address: peerAddress.trim(),
+        save: true,
+      });
+      flashStatus('Peer connected.', 'success');
+      onLog?.('Peer connected from address input.');
+      await refreshConnectedPeers();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      reportError(message);
+      onLog?.(`Connect peer failed: ${message}`);
+    } finally {
+      setIsConnectingPeer(false);
+    }
+  }, [fiber.node, flashStatus, onLog, peerAddress, refreshConnectedPeers, reportError]);
+
+  const openChannel = useCallback(async () => {
+    if (!fiber.node) {
+      reportError('Node is not connected.');
+      return;
+    }
+
+    if (!peerPubkey.trim()) {
+      reportError('Target peer pubkey is empty.');
+      return;
+    }
+
+    channelOpenFlow.reset();
+
+    try {
+      const pubkey = toHexPrefixed(peerPubkey);
+
+      if (!externalFunding?.enabled) {
+        await channelOpenFlow.openChannel({
+          pubkey,
+          fundingAmountCkb,
+          externalWallet: false,
+        });
+        flashStatus('Open channel submitted.', 'success');
+        onLog?.('fiber_panel_primary_action_clicked: open_channel');
+        await refreshChannels();
+        return;
+      }
+
+      const resolved = await externalFunding.resolve({
+        node: fiber.node,
+        pubkey,
+        fundingAmountCkb,
+      });
+
+      await channelOpenFlow.openChannel({
+        pubkey,
+        fundingAmountCkb,
+        externalWallet: true,
+        shutdownScript: resolved.shutdownScript,
+        fundingLockScript: resolved.fundingLockScript,
+        fundingLockScriptCellDeps: resolved.fundingLockScriptCellDeps,
+        signFundingTx: resolved.signFundingTx,
+        ckbRpcUrl: resolved.ckbRpcUrl,
+      });
+      flashStatus('Open channel submitted.', 'success');
+      onLog?.('fiber_panel_primary_action_clicked: open_channel');
+      await refreshChannels();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      reportError(message);
+      onLog?.(`Open channel failed: ${message}`);
+    }
+  }, [
+    channelOpenFlow,
+    externalFunding,
+    fiber.node,
+    flashStatus,
+    fundingAmountCkb,
+    onLog,
+    peerPubkey,
+    refreshChannels,
+    reportError,
+  ]);
+
+  const createInvoice = useCallback(async () => {
+    if (!fiber.node) {
+      reportError('Node is not connected.');
+      return;
+    }
+
+    setIsCreatingInvoice(true);
+
+    try {
+      const created = await fiber.node.newInvoice({
+        amount: ONE_CKB_SHANNONS,
+        currency: network === 'mainnet' ? 'Fibb' : 'Fibt',
+        description: 'FiberNodeButton invoice',
+      });
+      setCreatedInvoice(created.invoice_address);
+      flashStatus('Invoice created.', 'success');
+      onLog?.('fiber_panel_primary_action_clicked: create_invoice');
+      onLog?.(`Invoice created: ${shorten(created.invoice_address, 20, 8)}`);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      reportError(message);
+    } finally {
+      setIsCreatingInvoice(false);
+    }
+  }, [fiber.node, flashStatus, network, onLog, reportError]);
+
+  const submitPayment = useCallback(async () => {
+    if (!invoiceInput.trim()) {
+      reportError('Invoice is empty.');
+      return;
+    }
+
+    onLog?.('fiber_panel_primary_action_clicked: pay_invoice');
+    await payInvoice(invoiceInput);
+  }, [invoiceInput, onLog, payInvoice, reportError]);
+
+  useEffect(() => {
+    if (!fiber.isRunning || !fiber.node) {
+      setConnectedPeers([]);
+      setGraphNodes([]);
+      setGraphChannels([]);
+      setChannels([]);
+      setSelectedChannelId(null);
+      return;
+    }
+
+    void refreshConnectedPeers();
+    void refreshGraph();
+    void refreshChannels();
+  }, [fiber.isRunning, fiber.node, refreshChannels, refreshConnectedPeers, refreshGraph]);
+
+  useEffect(() => {
+    if (paymentError) {
+      reportError(paymentError);
+    }
+  }, [paymentError, reportError]);
+
+  useEffect(() => {
+    if (channelOpenFlow.error) {
+      reportError(channelOpenFlow.error);
+    }
+  }, [channelOpenFlow.error, reportError]);
+
+  useEffect(() => {
+    if (!paymentResult) {
+      return;
+    }
+
+    flashStatus(`Payment ${paymentResult.status}.`, 'success');
+    onLog?.(`Payment status: ${paymentResult.status}`);
+  }, [flashStatus, onLog, paymentResult]);
+
+  const channelCounts = useMemo(() => {
+    const counts = { active: 0, pending: 0, closed: 0, all: channels.length };
+
+    for (const channel of channels) {
+      counts[getChannelFilterState(channel)] += 1;
+    }
+
+    return counts;
+  }, [channels]);
+
+  const visibleChannels = useMemo(
+    () =>
+      channelFilter === 'all'
+        ? channels
+        : channels.filter((channel) => getChannelFilterState(channel) === channelFilter),
+    [channelFilter, channels],
+  );
+
+  const activeChannelCount = channelCounts.active;
+
+  const selectedChannel = useMemo(
+    () => channels.find((channel) => channel.channel_id === selectedChannelId) ?? null,
+    [channels, selectedChannelId],
+  );
+
+  useEffect(() => {
+    if (!selectedChannelId) {
+      return;
+    }
+    if (!channels.some((channel) => channel.channel_id === selectedChannelId)) {
+      setSelectedChannelId(null);
+      setForceCloseConfirmOpen(false);
+    }
+  }, [channels, selectedChannelId]);
+
+  useEffect(() => {
+    if (!selectedChannelId && visibleChannels[0]) {
+      setSelectedChannelId(visibleChannels[0].channel_id);
+    }
+  }, [selectedChannelId, visibleChannels]);
+
+  useEffect(() => {
+    if (!forceCloseConfirmOpen) {
+      return;
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setForceCloseConfirmOpen(false);
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [forceCloseConfirmOpen]);
+
+  const selectedState = selectedChannel?.state.state_name;
+  const selectedPending = selectedChannel
+    ? isPendingChannelState(selectedState as ChannelState)
+    : false;
+  const selectedCanClose =
+    !!selectedChannel &&
+    selectedState !== ChannelState.Closed &&
+    selectedState !== ChannelState.ShuttingDown;
+  const selectedIsClosing = !!selectedChannel && closingChannelId === selectedChannel.channel_id;
+
+  const connectorContext: FiberNodeButtonConnectorSectionContext = useMemo(
+    () => ({
+      fiber,
+      externalFundingEnabled: !!externalFunding?.enabled,
+      isOpeningChannel: channelOpenFlow.isOpening,
+    }),
+    [channelOpenFlow.isOpening, externalFunding?.enabled, fiber],
+  );
+
+  const switchTab = useCallback(
+    (next: PanelTab) => {
+      setActiveTab(next);
+      onLog?.(`fiber_panel_tab_switched: ${next}`);
+    },
+    [onLog],
+  );
+
+  const refreshDiagnostics = useCallback(async () => {
+    await Promise.all([refreshConnectedPeers(), refreshGraph()]);
+    flashStatus('Diagnostics refreshed.', 'info');
+  }, [flashStatus, refreshConnectedPeers, refreshGraph]);
+
+  return (
+    <div style={styles.shell}>
+      <header style={styles.globalBar}>
+        <div style={styles.globalRow}>
+          <div style={styles.globalMetrics}>
+            <span style={styles.metricInline}>
+              <span
+                style={{
+                  ...styles.metricDot,
+                  background:
+                    fiber.state === 'running'
+                      ? '#16a34a'
+                      : fiber.state === 'error'
+                        ? '#dc2626'
+                        : '#64748b',
+                }}
+                aria-hidden="true"
+              />
+              <span style={styles.metricMain}>{fiber.state}</span>
+              <span style={styles.metricSub}>Node</span>
+            </span>
+
+            <span style={styles.metricDivider} aria-hidden="true">
+              |
+            </span>
+
+            <span style={styles.metricInline}>
+              <span style={styles.metricMain}>
+                {externalFunding?.enabled ? 'External' : 'Internal'}
+              </span>
+              <span style={styles.metricSub}>Funding</span>
+            </span>
+
+            <span style={styles.metricDivider} aria-hidden="true">
+              |
+            </span>
+
+            <span style={styles.metricInline}>
+              <span style={styles.metricMain}>{activeChannelCount}</span>
+              <span style={styles.metricSub}>Active</span>
+            </span>
+
+            <span style={styles.metricDivider} aria-hidden="true">
+              |
+            </span>
+
+            <span style={styles.metricInline}>
+              <span style={styles.metricMain}>{connectedPeers.length}</span>
+              <span style={styles.metricSub}>Peers</span>
+            </span>
+
+            {latestError ? (
+              <>
+                <span style={styles.metricDivider} aria-hidden="true">
+                  |
+                </span>
+                <span style={styles.metricInline}>
+                  <span
+                    style={{
+                      ...styles.metricDot,
+                      background: '#dc2626',
+                    }}
+                    aria-hidden="true"
+                  />
+                  <span style={styles.metricMain}>Error</span>
+                </span>
+              </>
+            ) : null}
+          </div>
+
+          <div style={styles.globalActions}>
+            <button
+              type="button"
+              style={styles.globalActionButton}
+              onClick={() => {
+                void dropdownContext.disconnect();
+              }}
+              aria-label="Disconnect node"
+            >
+              Disconnect
+            </button>
+            <button
+              type="button"
+              style={styles.globalActionButton}
+              onClick={() => {
+                dropdownContext.closeDropdown();
+              }}
+              aria-label="Close panel"
+            >
+              Close Panel
+            </button>
+          </div>
+        </div>
+
+        <div style={styles.globalMeta}>
+          <p style={styles.inlineCode}>
+            Node: {fiber.nodeInfo?.pubkey ? shorten(fiber.nodeInfo.pubkey, 18, 12) : 'N/A'}
+          </p>
+          {latestError ? (
+            <p style={styles.globalErrorInline}>Recent error: {summarizeError(latestError, 92)}</p>
+          ) : null}
+        </div>
+      </header>
+
+      <div role="tablist" aria-label="Fiber panel tabs" style={styles.tabList}>
+        {TAB_ITEMS.map((tab) => {
+          const selected = activeTab === tab.id;
+          return (
+            <button
+              key={tab.id}
+              id={`${tabPanelId}-tab-${tab.id}`}
+              type="button"
+              role="tab"
+              aria-selected={selected}
+              aria-controls={`${tabPanelId}-panel-${tab.id}`}
+              style={selected ? styles.tabButtonActive : styles.tabButton}
+              onClick={() => switchTab(tab.id)}
+            >
+              {tab.label}
+            </button>
+          );
+        })}
+      </div>
+
+      <div
+        id={`${tabPanelId}-panel-${activeTab}`}
+        role="tabpanel"
+        aria-labelledby={`${tabPanelId}-tab-${activeTab}`}
+        style={styles.content}
+      >
+        {statusNotice ? (
+          <div
+            style={{
+              ...styles.notice,
+              ...(statusNotice.tone === 'success' ? styles.successNotice : {}),
+            }}
+          >
+            {statusNotice.text}
+          </div>
+        ) : null}
+
+        {activeTab === 'workbench' ? (
+          <>
+            <section style={styles.section}>
+              <div style={styles.rowBetween}>
+                <h4 style={styles.sectionTitle}>Connection Prep</h4>
+                <span style={styles.badge}>{isNodeReady ? 'Connected' : 'Disconnected'}</span>
+              </div>
+              <p style={styles.compactText}>
+                Node: {fiber.nodeInfo?.pubkey ? shorten(fiber.nodeInfo.pubkey, 18, 12) : 'N/A'}
+              </p>
+              <p style={styles.compactText}>
+                External wallet: {externalFunding?.enabled ? 'Enabled' : 'Disabled'}
+              </p>
+
+              {renderConnectorSection ? (
+                <div style={{ borderTop: '1px solid #e2e8f0', paddingTop: '0.55rem' }}>
+                  {renderConnectorSection(connectorContext)}
+                </div>
+              ) : null}
+            </section>
+
+            <section style={styles.section}>
+              <div style={styles.rowBetween}>
+                <h4 style={styles.sectionTitle}>Open Channel</h4>
+                {channelOpenFlow.lastResult ? (
+                  <span style={styles.badge}>Recent Success</span>
+                ) : null}
+              </div>
+
+              <label style={styles.fieldLabel}>
+                Target Peer Pubkey
+                <input
+                  style={styles.input}
+                  list={peerListId}
+                  value={peerPubkey}
+                  onChange={(event) => setPeerPubkey(event.target.value)}
+                  placeholder={connectedPeers[0]?.pubkey ?? '0x...'}
+                />
+                <datalist id={peerListId}>
+                  {connectedPeers.map((peer) => (
+                    <option key={peer.pubkey} value={peer.pubkey} />
+                  ))}
+                </datalist>
+              </label>
+
+              <label style={styles.fieldLabel}>
+                Funding Amount (CKB)
+                <input
+                  style={styles.input}
+                  value={fundingAmountCkb}
+                  onChange={(event) => setFundingAmountCkb(event.target.value)}
+                  placeholder="1000"
+                />
+              </label>
+
+              <div style={styles.row}>
+                <button
+                  type="button"
+                  style={withDisabledStyle(
+                    styles.primaryButton,
+                    !isNodeReady || channelOpenFlow.isOpening || !peerPubkey.trim(),
+                  )}
+                  disabled={!isNodeReady || channelOpenFlow.isOpening || !peerPubkey.trim()}
+                  onClick={() => {
+                    void openChannel();
+                  }}
+                >
+                  {channelOpenFlow.isOpening ? 'Opening...' : 'Open Channel'}
+                </button>
+              </div>
+
+              {channelOpenFlow.lastResult ? (
+                <p style={styles.compactText}>
+                  Last channel: {shorten(channelOpenFlow.lastResult.channelId, 14, 8)}
+                </p>
+              ) : null}
+
+              {channelOpenFlow.suggestedFundingAmountCkb ? (
+                <p style={styles.compactText}>
+                  Suggested amount: {channelOpenFlow.suggestedFundingAmountCkb} CKB
+                </p>
+              ) : null}
+            </section>
+
+            <section style={styles.section}>
+              <h4 style={styles.sectionTitle}>Payments</h4>
+
+              <div style={styles.row}>
+                <button
+                  type="button"
+                  style={withDisabledStyle(styles.actionButton, isCreatingInvoice || !isNodeReady)}
+                  disabled={isCreatingInvoice || !isNodeReady}
+                  onClick={() => {
+                    void createInvoice();
+                  }}
+                >
+                  {isCreatingInvoice ? 'Creating...' : 'Create Invoice (1 CKB)'}
+                </button>
+                {createdInvoice ? (
+                  <span style={styles.compactText}>{shorten(createdInvoice, 20, 10)}</span>
+                ) : null}
+              </div>
+
+              <label style={styles.fieldLabel}>
+                Invoice
+                <input
+                  style={styles.input}
+                  value={invoiceInput}
+                  onChange={(event) => setInvoiceInput(event.target.value)}
+                  placeholder="Paste invoice to pay"
+                />
+              </label>
+
+              <div style={styles.rowBetween}>
+                <button
+                  type="button"
+                  style={withDisabledStyle(
+                    styles.primaryButton,
+                    isPaying || !isNodeReady || !invoiceInput.trim(),
+                  )}
+                  disabled={isPaying || !isNodeReady || !invoiceInput.trim()}
+                  onClick={() => {
+                    void submitPayment();
+                  }}
+                >
+                  {isPaying ? 'Paying...' : 'Pay Invoice'}
+                </button>
+
+                <span style={styles.compactText}>Status: {paymentResult?.status ?? 'Idle'}</span>
+              </div>
+            </section>
+          </>
+        ) : null}
+
+        {activeTab === 'channels' ? (
+          <>
+            <section style={styles.section}>
+              <div style={styles.rowBetween}>
+                <h4 style={styles.sectionTitle}>Channel Summary</h4>
+                <button
+                  type="button"
+                  style={withDisabledStyle(styles.actionButton, isRefreshingChannels)}
+                  disabled={isRefreshingChannels}
+                  onClick={() => {
+                    void refreshChannels();
+                  }}
+                >
+                  {isRefreshingChannels ? 'Refreshing...' : 'Refresh'}
+                </button>
+              </div>
+
+              <p style={styles.summaryInline}>
+                Active {channelCounts.active} | Pending {channelCounts.pending} | Closed{' '}
+                {channelCounts.closed} | Total {channelCounts.all}
+              </p>
+
+              <div style={styles.filterBar}>
+                {FILTER_ITEMS.map((filter) => (
+                  <button
+                    key={filter}
+                    type="button"
+                    style={channelFilter === filter ? styles.primaryButton : styles.actionButton}
+                    onClick={() => setChannelFilter(filter)}
+                  >
+                    {filter === 'all'
+                      ? `All (${channelCounts.all})`
+                      : `${filter} (${channelCounts[filter]})`}
+                  </button>
+                ))}
+              </div>
+
+              <div style={styles.list}>
+                {visibleChannels.length === 0 ? (
+                  <p style={styles.compactText}>No channels found for this filter.</p>
+                ) : (
+                  visibleChannels.map((channel) => {
+                    const selected = channel.channel_id === selectedChannelId;
+
+                    return (
+                      <button
+                        key={channel.channel_id}
+                        type="button"
+                        style={{
+                          ...styles.compactChannelRow,
+                          ...(selected ? styles.compactChannelRowActive : {}),
+                        }}
+                        onClick={() => {
+                          setSelectedChannelId(channel.channel_id);
+                          setForceCloseConfirmOpen(false);
+                        }}
+                      >
+                        <span style={styles.srOnly}>
+                          {selected ? 'Selected channel' : 'Select channel'}
+                        </span>
+                        <span style={styles.compactChannelTop}>
+                          <span style={styles.inlineCode}>
+                            ID: {shorten(channel.channel_id, 12, 8)}
+                          </span>
+                          <span style={styles.badge}>{channel.state.state_name}</span>
+                        </span>
+                        <span style={styles.compactText}>
+                          Peer: {shorten(channel.pubkey, 16, 10)}
+                        </span>
+                        <span style={styles.compactText}>
+                          L {formatChannelBalance(channel.local_balance)} / R{' '}
+                          {formatChannelBalance(channel.remote_balance)} CKB
+                        </span>
+                      </button>
+                    );
+                  })
+                )}
+              </div>
+            </section>
+
+            {selectedChannel ? (
+              <section style={styles.detailPanel}>
+                <div style={styles.rowBetween}>
+                  <h4 style={styles.sectionTitle}>Channel Details</h4>
+                  <span style={styles.badge}>{selectedChannel.state.state_name}</span>
+                </div>
+
+                <p style={styles.inlineCode}>Channel ID: {selectedChannel.channel_id}</p>
+                <p style={styles.inlineCode}>Peer: {selectedChannel.pubkey}</p>
+
+                <div style={styles.row}>
+                  <span style={styles.badge}>
+                    Local {formatChannelBalance(selectedChannel.local_balance)} CKB
+                  </span>
+                  <span style={styles.badge}>
+                    Remote {formatChannelBalance(selectedChannel.remote_balance)} CKB
+                  </span>
+                  <span
+                    style={styles.badge}
+                    title="Pending TLCs are in-flight payment locks associated with this channel."
+                  >
+                    TLCs {selectedChannel.pending_tlcs.length}
+                  </span>
+                </div>
+
+                {selectedChannel.failure_detail ? (
+                  <p style={styles.compactText}>Failure: {selectedChannel.failure_detail}</p>
+                ) : null}
+
+                {selectedChannel.shutdown_transaction_hash ? (
+                  <p style={styles.inlineCode}>
+                    Shutdown TX: {selectedChannel.shutdown_transaction_hash}
+                  </p>
+                ) : null}
+
+                <div style={{ ...styles.row, justifyContent: 'flex-end' }}>
+                  <button
+                    type="button"
+                    style={withDisabledStyle(
+                      styles.actionButton,
+                      !selectedCanClose || selectedIsClosing,
+                    )}
+                    disabled={!selectedCanClose || selectedIsClosing}
+                    onClick={() => {
+                      if (!selectedChannel) {
+                        return;
+                      }
+                      void closeChannel(selectedChannel.channel_id, false);
+                    }}
+                  >
+                    {selectedIsClosing
+                      ? 'Closing...'
+                      : selectedPending
+                        ? 'Abandon Pending'
+                        : 'Close Channel'}
+                  </button>
+
+                  <button
+                    type="button"
+                    style={withDisabledStyle(
+                      styles.dangerButton,
+                      !selectedCanClose || selectedPending || selectedIsClosing,
+                    )}
+                    disabled={!selectedCanClose || selectedPending || selectedIsClosing}
+                    onClick={() => {
+                      setForceCloseConfirmOpen(true);
+                      onLog?.('fiber_channel_force_close_confirm_opened');
+                    }}
+                  >
+                    Force Close
+                  </button>
+                </div>
+              </section>
+            ) : null}
+          </>
+        ) : null}
+
+        {activeTab === 'diagnostics' ? (
+          <>
+            <section style={styles.section}>
+              <div style={styles.rowBetween}>
+                <h4 style={styles.sectionTitle}>Connected Peers</h4>
+                <button
+                  type="button"
+                  style={withDisabledStyle(styles.actionButton, isRefreshingPeers)}
+                  disabled={isRefreshingPeers}
+                  onClick={() => {
+                    void refreshConnectedPeers();
+                  }}
+                >
+                  {isRefreshingPeers ? 'Refreshing...' : 'Refresh Peers'}
+                </button>
+              </div>
+
+              <p style={styles.compactText}>Peers: {connectedPeers.length}</p>
+
+              <div style={{ ...styles.list, maxHeight: '190px' }}>
+                {connectedPeers.length === 0 ? (
+                  <p style={styles.compactText}>No connected peers.</p>
+                ) : (
+                  connectedPeers.map((peer) => (
+                    <article key={peer.pubkey} style={styles.compactChannelRow}>
+                      <p style={styles.inlineCode}>{shorten(peer.pubkey, 18, 12)}</p>
+                      <details>
+                        <summary style={{ ...styles.compactText, cursor: 'pointer' }}>
+                          Address
+                        </summary>
+                        <p style={styles.inlineCode}>{peer.address}</p>
+                      </details>
+                      <div style={styles.row}>
+                        <button
+                          type="button"
+                          style={styles.ghostButton}
+                          onClick={() => {
+                            setPeerPubkey(peer.pubkey);
+                            switchTab('workbench');
+                          }}
+                        >
+                          Use for Open Channel
+                        </button>
+                      </div>
+                    </article>
+                  ))
+                )}
+              </div>
+
+              <label style={styles.fieldLabel}>
+                Connect Peer Address
+                <input
+                  style={styles.input}
+                  value={peerAddress}
+                  onChange={(event) => setPeerAddress(event.target.value)}
+                  placeholder="/dns4/.../wss/p2p/..."
+                />
+              </label>
+
+              <div style={styles.rowBetween}>
+                <button
+                  type="button"
+                  style={withDisabledStyle(
+                    styles.primaryButton,
+                    isConnectingPeer || !peerAddress.trim(),
+                  )}
+                  disabled={isConnectingPeer || !peerAddress.trim()}
+                  onClick={() => {
+                    void connectPeerByAddress();
+                  }}
+                >
+                  {isConnectingPeer ? 'Connecting...' : 'Connect Peer'}
+                </button>
+
+                <button
+                  type="button"
+                  style={withDisabledStyle(
+                    styles.actionButton,
+                    isRefreshingPeers || isRefreshingGraph,
+                  )}
+                  disabled={isRefreshingPeers || isRefreshingGraph}
+                  onClick={() => {
+                    void refreshDiagnostics();
+                  }}
+                >
+                  {isRefreshingPeers || isRefreshingGraph ? 'Refreshing...' : 'Refresh All'}
+                </button>
+              </div>
+            </section>
+
+            <section style={styles.section}>
+              <div style={styles.rowBetween}>
+                <h4 style={styles.sectionTitle}>Graph Snapshot</h4>
+                <button
+                  type="button"
+                  style={withDisabledStyle(styles.actionButton, isRefreshingGraph)}
+                  disabled={isRefreshingGraph}
+                  onClick={() => {
+                    void refreshGraph();
+                  }}
+                >
+                  {isRefreshingGraph ? 'Refreshing...' : 'Refresh Graph'}
+                </button>
+              </div>
+
+              <p style={styles.compactText}>
+                showing {Math.min(graphNodes.length, 3)} of {graphNodes.length} nodes,{' '}
+                {Math.min(graphChannels.length, 2)} of {graphChannels.length} channels.
+              </p>
+
+              {graphNodes.slice(0, 3).map((node) => (
+                <p key={node.pubkey} style={styles.inlineCode}>
+                  Node: {node.node_name || shorten(node.pubkey, 18, 10)}
+                </p>
+              ))}
+
+              {graphChannels.slice(0, 2).map((channel) => (
+                <p
+                  key={`${channel.node1}-${channel.node2}-${channel.channel_outpoint.tx_hash}`}
+                  style={styles.inlineCode}
+                >
+                  {shorten(channel.node1, 10, 6)} to {shorten(channel.node2, 10, 6)};{' '}
+                  {formatChannelBalance(channel.capacity)} CKB
+                </p>
+              ))}
+
+              <details>
+                <summary style={{ ...styles.compactText, cursor: 'pointer' }}>
+                  Raw graph snapshot
+                </summary>
+                <pre
+                  style={{
+                    ...styles.inlineCode,
+                    marginTop: '0.45rem',
+                    maxHeight: '160px',
+                    overflow: 'auto',
+                    background: '#f1f5f9',
+                    borderRadius: '0.45rem',
+                    padding: '0.45rem',
+                  }}
+                >
+                  {JSON.stringify(
+                    {
+                      nodes: graphNodes,
+                      channels: graphChannels,
+                    },
+                    null,
+                    2,
+                  )}
+                </pre>
+              </details>
+            </section>
+
+            {channelOpenFlow.diagnostic ? (
+              <div style={styles.notice}>{channelOpenFlow.diagnostic}</div>
+            ) : null}
+          </>
+        ) : null}
+
+        {latestError ? <div style={styles.errorNotice}>{latestError}</div> : null}
+      </div>
+
+      {forceCloseConfirmOpen && selectedChannel ? (
+        <div style={styles.dialogBackdrop}>
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-label="Force close confirmation"
+            style={styles.dialogCard}
+          >
+            <h4 style={styles.sectionTitle}>Force close this channel?</h4>
+            <p style={styles.compactText}>
+              This action may immediately broadcast a unilateral close transaction, can lock
+              liquidity until settlement, and may produce additional fees. Continue only if normal
+              close cannot proceed.
+            </p>
+            <p style={styles.inlineCode}>Channel: {shorten(selectedChannel.channel_id, 20, 12)}</p>
+            <div style={{ ...styles.row, justifyContent: 'flex-end' }}>
+              <button
+                type="button"
+                style={styles.actionButton}
+                onClick={() => {
+                  setForceCloseConfirmOpen(false);
+                }}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                style={styles.dangerButton}
+                onClick={() => {
+                  setForceCloseConfirmOpen(false);
+                  onLog?.('fiber_channel_force_close_confirmed');
+                  void closeChannel(selectedChannel.channel_id, true);
+                }}
+              >
+                Confirm Force Close
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}
 
 export function FiberNodeButton(props: FiberNodeButtonProps) {
   const {
@@ -357,809 +1731,41 @@ export function FiberNodeButton(props: FiberNodeButtonProps) {
     externalWallet,
     enabled: !externalFiber,
   });
+
   const fiber = externalFiber ?? managedFiber;
 
-  const [peerPubkey, setPeerPubkey] = useState(initialPeerPubkey);
-  const [peerAddress, setPeerAddress] = useState(initialPeerAddress);
-  const [fundingAmountCkb, setFundingAmountCkb] = useState(initialFundingAmountCkb);
-  const [connectedPeers, setConnectedPeers] = useState<PeerInfo[]>([]);
-  const [isRefreshingPeers, setIsRefreshingPeers] = useState(false);
-  const [isConnectingPeer, setIsConnectingPeer] = useState(false);
-  const [graphNodes, setGraphNodes] = useState<GraphNodeInfo[]>([]);
-  const [graphChannels, setGraphChannels] = useState<GraphChannelInfo[]>([]);
-  const [isRefreshingGraph, setIsRefreshingGraph] = useState(false);
-  const [channels, setChannels] = useState<Channel[]>([]);
-  const [channelFilter, setChannelFilter] = useState<ChannelFilter>('active');
-  const [isRefreshingChannels, setIsRefreshingChannels] = useState(false);
-  const [closingChannelId, setClosingChannelId] = useState<string | null>(null);
-
-  const [invoiceInput, setInvoiceInput] = useState('');
-  const [createdInvoice, setCreatedInvoice] = useState('');
-  const [isCreatingInvoice, setIsCreatingInvoice] = useState(false);
-  const [localError, setLocalError] = useState<string | null>(null);
-
-  const peerListId = useId();
-
-  const channelOpenFlow = useChannelOpenFlow({
-    node: fiber.node,
-    onLog,
-  });
-
-  const { payInvoice, isPaying, paymentResult, error: paymentError } = useFiberPayment(fiber.node);
-
-  const reportError = useCallback(
-    (message: string) => {
-      setLocalError(message);
-      onError?.(message);
+  const handleConnectButtonError = useCallback(
+    (error: string) => {
+      onError?.(error);
     },
     [onError],
   );
 
-  const refreshConnectedPeers = useCallback(async () => {
-    if (!fiber.node) {
-      setConnectedPeers([]);
-      return;
-    }
-
-    setIsRefreshingPeers(true);
-    setLocalError(null);
-
-    try {
-      const peers = await fiber.node.listPeers();
-      setConnectedPeers(peers.peers);
-      setPeerPubkey((prev) => (prev.trim() ? prev : (peers.peers[0]?.pubkey ?? prev)));
-      onLog?.(`Loaded connected peers: ${peers.peers.length}.`);
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      reportError(message);
-      onLog?.(`Refresh peers failed: ${message}`);
-    } finally {
-      setIsRefreshingPeers(false);
-    }
-  }, [fiber.node, onLog, reportError]);
-
-  const refreshGraph = useCallback(async () => {
-    if (!fiber.node) {
-      setGraphNodes([]);
-      setGraphChannels([]);
-      return;
-    }
-
-    setIsRefreshingGraph(true);
-    setLocalError(null);
-
-    try {
-      const [nodesResult, channelsResult] = await Promise.all([
-        fiber.node.graphNodes({ limit: '0x8' }),
-        fiber.node.graphChannels({ limit: '0x8' }),
-      ]);
-      setGraphNodes(nodesResult.nodes);
-      setGraphChannels(channelsResult.channels);
-      onLog?.(
-        `Loaded graph: ${nodesResult.nodes.length} nodes, ${channelsResult.channels.length} channels.`,
-      );
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      reportError(message);
-      onLog?.(`Refresh graph failed: ${message}`);
-    } finally {
-      setIsRefreshingGraph(false);
-    }
-  }, [fiber.node, onLog, reportError]);
-
-  const connectPeerByAddress = useCallback(async () => {
-    if (!fiber.node) {
-      reportError('Node is not connected.');
-      return;
-    }
-
-    if (!peerAddress.trim()) {
-      reportError('Peer address is empty.');
-      return;
-    }
-
-    setIsConnectingPeer(true);
-    setLocalError(null);
-
-    try {
-      await fiber.node.connectPeer({
-        address: peerAddress.trim(),
-        save: true,
-      });
-      onLog?.('Peer connected from address input.');
-      await refreshConnectedPeers();
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      reportError(message);
-      onLog?.(`Connect peer failed: ${message}`);
-    } finally {
-      setIsConnectingPeer(false);
-    }
-  }, [fiber.node, onLog, peerAddress, refreshConnectedPeers, reportError]);
-
-  const refreshChannels = useCallback(async () => {
-    if (!fiber.node) {
-      setChannels([]);
-      return;
-    }
-
-    setIsRefreshingChannels(true);
-    setLocalError(null);
-
-    try {
-      const result = await fiber.node.listChannels({ include_closed: true });
-      setChannels(result.channels);
-      onLog?.(`Loaded channels: ${result.channels.length}.`);
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      reportError(message);
-      onLog?.(`Refresh channels failed: ${message}`);
-    } finally {
-      setIsRefreshingChannels(false);
-    }
-  }, [fiber.node, onLog, reportError]);
-
-  const closeChannel = useCallback(
-    async (channelId: string, force = false) => {
-      if (!fiber.node) {
-        reportError('Node is not connected.');
-        return;
-      }
-
-      setClosingChannelId(channelId);
-      setLocalError(null);
-
-      try {
-        const latest = await fiber.node.listChannels({ include_closed: true });
-        const target = latest.channels.find((item) => item.channel_id === channelId);
-
-        if (!target) {
-          throw new Error(`Channel not found in latest snapshot: ${channelId}.`);
-        }
-
-        if (target.state.state_name === ChannelState.Closed) {
-          setChannels(latest.channels);
-          onLog?.(`Channel already closed: ${channelId}`);
-          return;
-        }
-
-        if (target.state.state_name === ChannelState.ShuttingDown) {
-          setChannels(latest.channels);
-          onLog?.(`Channel is already shutting down: ${channelId}`);
-          return;
-        }
-
-        if (isPendingChannelState(target.state.state_name)) {
-          const params: AbandonChannelParams = {
-            channel_id: channelId as HexString,
-          };
-          await fiber.node.abandonChannel(params);
-          onLog?.(`Pending channel abandoned: ${channelId}`);
-        } else {
-          const params: ShutdownChannelParams = {
-            channel_id: channelId as HexString,
-            force,
-          };
-          await fiber.node.shutdownChannel(params);
-          onLog?.(`${force ? 'Force close' : 'Close'} channel requested: ${channelId}`);
-        }
-
-        await refreshChannels();
-      } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        reportError(message);
-      } finally {
-        setClosingChannelId(null);
-      }
-    },
-    [fiber.node, onLog, refreshChannels, reportError],
-  );
-
-  const openChannel = useCallback(async () => {
-    if (!fiber.node) {
-      reportError('Node is not connected.');
-      return;
-    }
-
-    if (!peerPubkey.trim()) {
-      reportError('Target peer pubkey is empty.');
-      return;
-    }
-
-    setLocalError(null);
-    channelOpenFlow.reset();
-
-    try {
-      const pubkey = toHexPrefixed(peerPubkey);
-
-      if (!externalFunding?.enabled) {
-        await channelOpenFlow.openChannel({
-          pubkey,
-          fundingAmountCkb,
-          externalWallet: false,
-        });
-        await refreshChannels();
-        return;
-      }
-
-      const resolved = await externalFunding.resolve({
-        node: fiber.node,
-        pubkey,
-        fundingAmountCkb,
-      });
-
-      await channelOpenFlow.openChannel({
-        pubkey,
-        fundingAmountCkb,
-        externalWallet: true,
-        shutdownScript: resolved.shutdownScript,
-        fundingLockScript: resolved.fundingLockScript,
-        fundingLockScriptCellDeps: resolved.fundingLockScriptCellDeps,
-        signFundingTx: resolved.signFundingTx,
-        ckbRpcUrl: resolved.ckbRpcUrl,
-      });
-      await refreshChannels();
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      reportError(message);
-      onLog?.(`Open channel failed: ${message}`);
-    }
-  }, [
-    channelOpenFlow,
-    externalFunding,
-    fiber.node,
-    fundingAmountCkb,
-    onLog,
-    peerPubkey,
-    refreshChannels,
-    reportError,
-  ]);
-
-  const createInvoice = useCallback(async () => {
-    if (!fiber.node) {
-      reportError('Node is not connected.');
-      return;
-    }
-
-    setIsCreatingInvoice(true);
-    setLocalError(null);
-
-    try {
-      const created = await fiber.node.newInvoice({
-        amount: ONE_CKB_SHANNONS,
-        currency: network === 'mainnet' ? 'Fibb' : 'Fibt',
-        description: 'FiberNodeButton invoice',
-      });
-      setCreatedInvoice(created.invoice_address);
-      onLog?.(`Invoice created: ${shorten(created.invoice_address, 20, 8)}`);
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      reportError(message);
-    } finally {
-      setIsCreatingInvoice(false);
-    }
-  }, [fiber.node, network, onLog, reportError]);
-
-  const submitPayment = useCallback(async () => {
-    if (!invoiceInput.trim()) {
-      reportError('Invoice is empty.');
-      return;
-    }
-
-    setLocalError(null);
-    await payInvoice(invoiceInput);
-  }, [invoiceInput, payInvoice, reportError]);
-
-  useEffect(() => {
-    if (paymentError) {
-      reportError(paymentError);
-    }
-  }, [paymentError, reportError]);
-
-  useEffect(() => {
-    if (paymentResult) {
-      onLog?.(`Payment status: ${paymentResult.status}`);
-    }
-  }, [onLog, paymentResult]);
-
-  useEffect(() => {
-    if (!fiber.isRunning || !fiber.node) {
-      setConnectedPeers([]);
-      setGraphNodes([]);
-      setGraphChannels([]);
-      setChannels([]);
-      return;
-    }
-
-    void refreshConnectedPeers();
-    void refreshGraph();
-    void refreshChannels();
-  }, [fiber.isRunning, fiber.node, refreshChannels, refreshConnectedPeers, refreshGraph]);
-
-  const channelCounts = useMemo(() => {
-    const counts = { active: 0, pending: 0, closed: 0, all: channels.length };
-
-    for (const channel of channels) {
-      counts[getChannelFilterState(channel)] += 1;
-    }
-
-    return counts;
-  }, [channels]);
-
-  const visibleChannels = useMemo(
-    () =>
-      channelFilter === 'all'
-        ? channels
-        : channels.filter((channel) => getChannelFilterState(channel) === channelFilter),
-    [channelFilter, channels],
-  );
-
-  const mergedError = useMemo(
-    () => localError ?? channelOpenFlow.error ?? paymentError,
-    [channelOpenFlow.error, localError, paymentError],
-  );
-
-  const handleConnectButtonError = useCallback(
-    (error: string) => {
-      reportError(error);
-    },
-    [reportError],
-  );
-
-  const connectorContext: FiberNodeButtonConnectorSectionContext = useMemo(
-    () => ({
-      fiber,
-      externalFundingEnabled: !!externalFunding?.enabled,
-      isOpeningChannel: channelOpenFlow.isOpening,
-    }),
-    [channelOpenFlow.isOpening, externalFunding?.enabled, fiber],
-  );
-
   const renderDropdown = useCallback(
     (dropdownContext: ConnectButtonConnectedDropdownContext) => (
-      <div style={styles.panel}>
-        <section style={styles.section}>
-          <h4 style={styles.sectionTitle}>Connection</h4>
-          <div style={styles.statGrid}>
-            <div style={styles.statTile}>
-              <span style={styles.statValue}>{fiber.state}</span>
-              <span style={styles.statLabel}>State</span>
-            </div>
-            <div style={styles.statTile}>
-              <span style={styles.statValue}>
-                {externalFunding?.enabled ? 'External' : 'Internal'}
-              </span>
-              <span style={styles.statLabel}>Funding</span>
-            </div>
-            <div style={styles.statTile}>
-              <span style={styles.statValue}>{connectedPeers.length}</span>
-              <span style={styles.statLabel}>Peers</span>
-            </div>
-          </div>
-          <p style={{ ...styles.inlineCode, marginTop: '0.5rem' }}>
-            Node: {fiber.nodeInfo?.pubkey ? shorten(fiber.nodeInfo.pubkey, 18, 12) : 'N/A'}
-          </p>
-          <div style={{ ...styles.row, marginBottom: 0 }}>
-            <button
-              type="button"
-              style={styles.actionButton}
-              onClick={() => {
-                void dropdownContext.disconnect();
-              }}
-            >
-              Disconnect
-            </button>
-            <button
-              type="button"
-              style={styles.actionButton}
-              onClick={() => {
-                dropdownContext.closeDropdown();
-              }}
-            >
-              Close
-            </button>
-          </div>
-          {renderConnectorSection ? (
-            <div
-              style={{ marginTop: '0.6rem', paddingTop: '0.55rem', borderTop: '1px solid #e2e8f0' }}
-            >
-              {renderConnectorSection(connectorContext)}
-            </div>
-          ) : null}
-        </section>
-
-        <section style={styles.section}>
-          <div style={styles.rowBetween}>
-            <h4 style={{ ...styles.sectionTitle, margin: 0 }}>Peers & Graph</h4>
-            <div style={styles.filterBar}>
-              <button
-                type="button"
-                style={styles.actionButton}
-                disabled={isRefreshingPeers}
-                onClick={() => {
-                  void refreshConnectedPeers();
-                }}
-              >
-                {isRefreshingPeers ? 'Refreshing...' : 'Refresh Peers'}
-              </button>
-              <button
-                type="button"
-                style={styles.actionButton}
-                disabled={isRefreshingGraph}
-                onClick={() => {
-                  void refreshGraph();
-                }}
-              >
-                {isRefreshingGraph ? 'Loading...' : 'Refresh Graph'}
-              </button>
-            </div>
-          </div>
-
-          <div style={styles.statGrid}>
-            <div style={styles.statTile}>
-              <span style={styles.statValue}>{connectedPeers.length}</span>
-              <span style={styles.statLabel}>Connected</span>
-            </div>
-            <div style={styles.statTile}>
-              <span style={styles.statValue}>{graphNodes.length}</span>
-              <span style={styles.statLabel}>Graph Nodes</span>
-            </div>
-            <div style={styles.statTile}>
-              <span style={styles.statValue}>{graphChannels.length}</span>
-              <span style={styles.statLabel}>Graph Channels</span>
-            </div>
-          </div>
-
-          <div style={{ ...styles.stack, marginTop: '0.55rem' }}>
-            <label style={styles.fieldLabel}>
-              Connect peer
-              <input
-                style={styles.input}
-                value={peerAddress}
-                onChange={(event) => setPeerAddress(event.target.value)}
-                placeholder="Peer address (/dns4/.../wss/p2p/...)"
-              />
-            </label>
-            <button
-              type="button"
-              style={styles.primaryButton}
-              disabled={isConnectingPeer || !peerAddress.trim()}
-              onClick={() => {
-                void connectPeerByAddress();
-              }}
-            >
-              {isConnectingPeer ? 'Connecting...' : 'Connect Peer'}
-            </button>
-          </div>
-
-          <div style={styles.channelList}>
-            {connectedPeers.length === 0 ? (
-              <p style={styles.compactText}>No connected peers.</p>
-            ) : (
-              connectedPeers.map((peer) => (
-                <article key={peer.pubkey} style={styles.channelItem}>
-                  <p style={styles.inlineCode}>Peer: {shorten(peer.pubkey, 18, 12)}</p>
-                  <p style={styles.compactText}>{peer.address}</p>
-                  <button
-                    type="button"
-                    style={styles.ghostButton}
-                    onClick={() => setPeerPubkey(peer.pubkey)}
-                  >
-                    Use for Channel
-                  </button>
-                </article>
-              ))
-            )}
-          </div>
-
-          {graphNodes.length > 0 || graphChannels.length > 0 ? (
-            <div style={{ ...styles.stack, marginTop: '0.55rem' }}>
-              <p style={styles.compactText}>
-                Graph sample (showing {Math.min(graphNodes.length, 3)} of {graphNodes.length} nodes,{' '}
-                {Math.min(graphChannels.length, 2)} of {graphChannels.length} channels)
-              </p>
-              {graphNodes.slice(0, 3).map((node) => (
-                <p key={node.pubkey} style={styles.inlineCode}>
-                  Node: {node.node_name || shorten(node.pubkey, 18, 10)}
-                </p>
-              ))}
-              {graphChannels.slice(0, 2).map((channel) => (
-                <p
-                  key={`${channel.node1}-${channel.node2}-${channel.channel_outpoint.tx_hash}`}
-                  style={styles.inlineCode}
-                >
-                  Route: {shorten(channel.node1, 10, 6)} {'to'} {shorten(channel.node2, 10, 6)};{' '}
-                  {formatChannelBalance(channel.capacity)} CKB
-                </p>
-              ))}
-            </div>
-          ) : null}
-        </section>
-
-        <section style={styles.section}>
-          <div style={styles.rowBetween}>
-            <h4 style={{ ...styles.sectionTitle, margin: 0 }}>Channels</h4>
-            <button
-              type="button"
-              style={styles.actionButton}
-              disabled={isRefreshingChannels}
-              onClick={() => {
-                void refreshChannels();
-              }}
-            >
-              {isRefreshingChannels ? 'Refreshing...' : 'Refresh Channels'}
-            </button>
-          </div>
-
-          <div style={styles.statGrid}>
-            <div style={styles.statTile}>
-              <span style={styles.statValue}>{channelCounts.active}</span>
-              <span style={styles.statLabel}>Active</span>
-            </div>
-            <div style={styles.statTile}>
-              <span style={styles.statValue}>{channelCounts.pending}</span>
-              <span style={styles.statLabel}>Pending</span>
-            </div>
-            <div style={styles.statTile}>
-              <span style={styles.statValue}>{channelCounts.closed}</span>
-              <span style={styles.statLabel}>Closed</span>
-            </div>
-          </div>
-
-          <div style={{ ...styles.filterBar, marginTop: '0.65rem' }}>
-            {(['active', 'pending', 'closed', 'all'] as const).map((filter) => (
-              <button
-                key={filter}
-                type="button"
-                style={channelFilter === filter ? styles.primaryButton : styles.actionButton}
-                onClick={() => setChannelFilter(filter)}
-              >
-                {filter === 'all'
-                  ? `All (${channelCounts.all})`
-                  : `${filter} (${channelCounts[filter]})`}
-              </button>
-            ))}
-          </div>
-
-          <div style={styles.channelList}>
-            {visibleChannels.length === 0 ? (
-              <p style={styles.compactText}>No channels found.</p>
-            ) : (
-              visibleChannels.map((channel) => {
-                const stateName = channel.state.state_name;
-                const pending = isPendingChannelState(stateName);
-                const canClose =
-                  stateName !== ChannelState.Closed && stateName !== ChannelState.ShuttingDown;
-                const isClosing = closingChannelId === channel.channel_id;
-
-                return (
-                  <article key={channel.channel_id} style={styles.channelItem}>
-                    <div style={styles.rowBetween}>
-                      <p style={styles.inlineCode}>ID: {shorten(channel.channel_id, 16, 10)}</p>
-                      <span style={styles.badge}>{stateName}</span>
-                    </div>
-                    <p style={styles.inlineCode}>Peer: {shorten(channel.pubkey, 18, 10)}</p>
-                    <div style={styles.statGrid}>
-                      <div style={styles.statTile}>
-                        <span style={styles.statValue}>
-                          {formatChannelBalance(channel.local_balance)}
-                        </span>
-                        <span style={styles.statLabel}>Local CKB</span>
-                      </div>
-                      <div style={styles.statTile}>
-                        <span style={styles.statValue}>
-                          {formatChannelBalance(channel.remote_balance)}
-                        </span>
-                        <span style={styles.statLabel}>Remote CKB</span>
-                      </div>
-                      <div
-                        style={styles.statTile}
-                        title="Pending TLCs (in-flight HTLC-like payment locks on this channel)"
-                      >
-                        <span style={styles.statValue}>{channel.pending_tlcs.length}</span>
-                        <span style={styles.statLabel}>TLCs</span>
-                      </div>
-                    </div>
-                    {channel.shutdown_transaction_hash ? (
-                      <p style={styles.inlineCode}>
-                        Shutdown: {shorten(channel.shutdown_transaction_hash, 16, 10)}
-                      </p>
-                    ) : null}
-                    {channel.failure_detail ? (
-                      <p style={styles.compactText}>{channel.failure_detail}</p>
-                    ) : null}
-                    <div style={{ ...styles.row, marginBottom: 0, justifyContent: 'flex-end' }}>
-                      <button
-                        type="button"
-                        style={styles.actionButton}
-                        disabled={!canClose || isClosing}
-                        onClick={() => {
-                          void closeChannel(channel.channel_id, false);
-                        }}
-                      >
-                        {isClosing ? 'Closing...' : pending ? 'Abandon Pending' : 'Close Channel'}
-                      </button>
-                      <button
-                        type="button"
-                        style={styles.dangerButton}
-                        disabled={pending || !canClose || isClosing}
-                        onClick={() => {
-                          void closeChannel(channel.channel_id, true);
-                        }}
-                      >
-                        Force Close
-                      </button>
-                    </div>
-                  </article>
-                );
-              })
-            )}
-          </div>
-
-          <div
-            style={{
-              marginTop: '0.75rem',
-              paddingTop: '0.6rem',
-              borderTop: '1px solid #e2e8f0',
-            }}
-          >
-            <h5
-              style={{
-                ...styles.sectionTitle,
-                margin: '0 0 0.5rem',
-                fontSize: '0.72rem',
-              }}
-            >
-              Open new channel
-            </h5>
-            <div style={styles.stack}>
-              <label style={styles.fieldLabel}>
-                Target peer pubkey
-                <input
-                  style={styles.input}
-                  list={peerListId}
-                  value={peerPubkey}
-                  onChange={(event) => setPeerPubkey(event.target.value)}
-                  placeholder={connectedPeers[0]?.pubkey ?? '0x...'}
-                />
-                <datalist id={peerListId}>
-                  {connectedPeers.map((peer) => (
-                    <option key={peer.pubkey} value={peer.pubkey} />
-                  ))}
-                </datalist>
-              </label>
-              <label style={styles.fieldLabel}>
-                Funding amount (CKB)
-                <input
-                  style={styles.input}
-                  value={fundingAmountCkb}
-                  onChange={(event) => setFundingAmountCkb(event.target.value)}
-                  placeholder="1000"
-                />
-              </label>
-            </div>
-            <div style={{ ...styles.row, marginTop: '0.55rem', marginBottom: 0 }}>
-              <button
-                type="button"
-                style={styles.primaryButton}
-                disabled={channelOpenFlow.isOpening || !peerPubkey.trim()}
-                onClick={() => {
-                  void openChannel();
-                }}
-              >
-                {channelOpenFlow.isOpening ? 'Opening...' : 'Open Channel'}
-              </button>
-            </div>
-            {channelOpenFlow.lastResult && (
-              <p style={{ ...styles.compactText, marginTop: '0.45rem' }}>
-                Channel: {shorten(channelOpenFlow.lastResult.channelId, 12, 8)}
-              </p>
-            )}
-            {channelOpenFlow.suggestedFundingAmountCkb && (
-              <p style={{ ...styles.compactText, marginTop: '0.35rem' }}>
-                Suggested amount: {channelOpenFlow.suggestedFundingAmountCkb} CKB
-              </p>
-            )}
-          </div>
-        </section>
-
-        <section style={styles.section}>
-          <h4 style={styles.sectionTitle}>Payments</h4>
-          <div style={styles.row}>
-            <button
-              type="button"
-              style={styles.actionButton}
-              disabled={isCreatingInvoice || !fiber.isRunning}
-              onClick={() => {
-                void createInvoice();
-              }}
-            >
-              {isCreatingInvoice ? 'Creating...' : 'Create Invoice (1 CKB)'}
-            </button>
-            {createdInvoice && (
-              <span style={styles.compactText}>{shorten(createdInvoice, 18, 10)}</span>
-            )}
-          </div>
-          <div style={styles.row}>
-            <input
-              style={styles.input}
-              value={invoiceInput}
-              onChange={(event) => setInvoiceInput(event.target.value)}
-              placeholder="Paste invoice to pay"
-            />
-          </div>
-          <div style={{ ...styles.row, marginBottom: 0 }}>
-            <button
-              type="button"
-              style={styles.primaryButton}
-              disabled={isPaying || !fiber.isRunning || !invoiceInput.trim()}
-              onClick={() => {
-                void submitPayment();
-              }}
-            >
-              {isPaying ? 'Paying...' : 'Pay Invoice'}
-            </button>
-            {paymentResult && (
-              <span style={styles.compactText}>Status: {paymentResult.status}</span>
-            )}
-          </div>
-        </section>
-
-        {mergedError && <div style={styles.errorBox}>{mergedError}</div>}
-        {channelOpenFlow.diagnostic && (
-          <div
-            style={{
-              ...styles.errorBox,
-              borderColor: '#bfdbfe',
-              color: '#1d4ed8',
-              background: '#eff6ff',
-            }}
-          >
-            {channelOpenFlow.diagnostic}
-          </div>
-        )}
-      </div>
+      <FiberNodeButtonPanel
+        dropdownContext={dropdownContext}
+        network={network}
+        fiber={fiber}
+        onLog={onLog}
+        onError={onError}
+        initialPeerPubkey={initialPeerPubkey}
+        initialPeerAddress={initialPeerAddress}
+        initialFundingAmountCkb={initialFundingAmountCkb}
+        externalFunding={externalFunding}
+        renderConnectorSection={renderConnectorSection}
+      />
     ),
     [
-      channelOpenFlow.diagnostic,
-      channelOpenFlow.isOpening,
-      channelOpenFlow.lastResult,
-      channelOpenFlow.suggestedFundingAmountCkb,
-      channelCounts,
-      channelFilter,
-      closeChannel,
-      closingChannelId,
-      connectPeerByAddress,
-      connectedPeers,
-      connectorContext,
-      createdInvoice,
-      externalFunding?.enabled,
-      fiber.isRunning,
-      fiber.nodeInfo?.pubkey,
-      fiber.state,
-      fundingAmountCkb,
-      graphChannels,
-      graphNodes,
-      invoiceInput,
-      isConnectingPeer,
-      isCreatingInvoice,
-      isPaying,
-      isRefreshingChannels,
-      isRefreshingGraph,
-      isRefreshingPeers,
-      mergedError,
-      openChannel,
-      paymentResult,
-      peerAddress,
-      peerListId,
-      peerPubkey,
-      refreshChannels,
-      refreshConnectedPeers,
-      refreshGraph,
+      externalFunding,
+      fiber,
+      initialFundingAmountCkb,
+      initialPeerAddress,
+      initialPeerPubkey,
+      network,
+      onError,
+      onLog,
       renderConnectorSection,
-      submitPayment,
-      createInvoice,
-      visibleChannels,
     ],
   );
 
@@ -1174,7 +1780,7 @@ export function FiberNodeButton(props: FiberNodeButtonProps) {
       onError={handleConnectButtonError}
       className={className}
       style={style}
-      dropdownStyle={{ width: 420, ...dropdownStyle }}
+      dropdownStyle={{ width: 460, ...dropdownStyle }}
       renderConnectedDropdown={renderDropdown}
     />
   );

--- a/packages/react/src/fiber-node-button.tsx
+++ b/packages/react/src/fiber-node-button.tsx
@@ -179,7 +179,7 @@ const styles = {
     display: 'grid',
     gridTemplateRows: 'auto auto minmax(0, 1fr)',
     gap: '0.7rem',
-    minWidth: '360px',
+    minWidth: '280px',
     width: 'min(460px, calc(100vw - 1rem))',
     maxHeight: '72vh',
   } satisfies CSSProperties,
@@ -851,11 +851,14 @@ function FiberNodeButtonPanel(props: FiberNodeButtonPanelProps) {
       const pubkey = toHexPrefixed(peerPubkey);
 
       if (!externalFunding?.enabled) {
-        await channelOpenFlow.openChannel({
+        const openResult = await channelOpenFlow.openChannel({
           pubkey,
           fundingAmountCkb,
           externalWallet: false,
         });
+        if (!openResult) {
+          return;
+        }
         flashStatus('Open channel submitted.', 'success');
         onLog?.('fiber_panel_primary_action_clicked: open_channel');
         await refreshChannels();
@@ -868,7 +871,7 @@ function FiberNodeButtonPanel(props: FiberNodeButtonPanelProps) {
         fundingAmountCkb,
       });
 
-      await channelOpenFlow.openChannel({
+      const openResult = await channelOpenFlow.openChannel({
         pubkey,
         fundingAmountCkb,
         externalWallet: true,
@@ -878,6 +881,9 @@ function FiberNodeButtonPanel(props: FiberNodeButtonPanelProps) {
         signFundingTx: resolved.signFundingTx,
         ckbRpcUrl: resolved.ckbRpcUrl,
       });
+      if (!openResult) {
+        return;
+      }
       flashStatus('Open channel submitted.', 'success');
       onLog?.('fiber_panel_primary_action_clicked: open_channel');
       await refreshChannels();
@@ -1006,8 +1012,13 @@ function FiberNodeButtonPanel(props: FiberNodeButtonPanelProps) {
   }, [channels, selectedChannelId]);
 
   useEffect(() => {
-    if (!selectedChannelId && visibleChannels[0]) {
-      setSelectedChannelId(visibleChannels[0].channel_id);
+    const isSelectedVisible = selectedChannelId
+      ? visibleChannels.some((channel) => channel.channel_id === selectedChannelId)
+      : false;
+
+    if (!isSelectedVisible) {
+      setSelectedChannelId(visibleChannels[0]?.channel_id ?? null);
+      setForceCloseConfirmOpen(false);
     }
   }, [selectedChannelId, visibleChannels]);
 
@@ -1174,7 +1185,7 @@ function FiberNodeButtonPanel(props: FiberNodeButtonPanelProps) {
               type="button"
               role="tab"
               aria-selected={selected}
-              aria-controls={`${tabPanelId}-panel-${tab.id}`}
+              aria-controls={selected ? `${tabPanelId}-panel-${tab.id}` : undefined}
               style={selected ? styles.tabButtonActive : styles.tabButton}
               onClick={() => switchTab(tab.id)}
             >
@@ -1780,7 +1791,7 @@ export function FiberNodeButton(props: FiberNodeButtonProps) {
       onError={handleConnectButtonError}
       className={className}
       style={style}
-      dropdownStyle={{ width: 460, ...dropdownStyle }}
+      dropdownStyle={{ maxWidth: 460, width: 'calc(100vw - 1rem)', ...dropdownStyle }}
       renderConnectedDropdown={renderDropdown}
     />
   );

--- a/packages/react/src/fiber-pay-quick-card.tsx
+++ b/packages/react/src/fiber-pay-quick-card.tsx
@@ -1,9 +1,11 @@
 import type { GetPaymentResult } from '@fiber-pay/sdk/browser';
 import { type CSSProperties, useEffect, useId, useState } from 'react';
-import { useFiberNode } from './use-fiber-node.js';
+import { type UseFiberNodeResult, useFiberNode } from './use-fiber-node.js';
 import { useFiberPayment } from './use-fiber-payment.js';
 
 export interface FiberPayQuickCardProps {
+  /** Reuse an existing useFiberNode() result instead of creating a new session. */
+  fiber?: UseFiberNodeResult;
   network?: 'testnet' | 'mainnet';
   walletId?: string;
   passkeyUsername?: string;
@@ -38,11 +40,20 @@ export function FiberPayQuickCard(props: FiberPayQuickCardProps) {
   const network = props.network ?? 'testnet';
   const passkeyUsername = props.passkeyUsername ?? 'User';
   const title = props.title ?? 'FiberPay Quick Card';
+  const usesExternalFiber = !!props.fiber;
   const onError = props.onError;
   const onInvoiceCreated = props.onInvoiceCreated;
   const onPaymentResult = props.onPaymentResult;
   const passwordInputId = useId();
   const invoiceInputId = useId();
+
+  const managedFiber = useFiberNode({
+    network,
+    walletId: props.walletId,
+    enabled: !usesExternalFiber,
+  });
+
+  const fiber = props.fiber ?? managedFiber;
 
   const {
     node,
@@ -55,7 +66,7 @@ export function FiberPayQuickCard(props: FiberPayQuickCardProps) {
     startWithPasskey,
     createPasskeyAndStart,
     stop,
-  } = useFiberNode({ network, walletId: props.walletId });
+  } = fiber;
 
   const { payInvoice, isPaying, error: payError, paymentResult } = useFiberPayment(node);
 
@@ -117,37 +128,44 @@ export function FiberPayQuickCard(props: FiberPayQuickCardProps) {
       </h3>
 
       {!nodeInfo ? (
-        <>
-          {isPasskeySupported ? (
-            <div style={rowWithMarginStyle}>
-              {hasPasskeyConfigured ? (
-                <button type="button" onClick={() => void startWithPasskey()}>
-                  Login with Passkey
-                </button>
-              ) : (
-                <button type="button" onClick={() => void createPasskeyAndStart(passkeyUsername)}>
-                  Register Passkey
-                </button>
-              )}
-            </div>
-          ) : null}
+        usesExternalFiber ? (
+          <p>
+            <strong>Connection required:</strong> connect the shared node first, then return here to
+            create or pay invoices.
+          </p>
+        ) : (
+          <>
+            {isPasskeySupported ? (
+              <div style={rowWithMarginStyle}>
+                {hasPasskeyConfigured ? (
+                  <button type="button" onClick={() => void startWithPasskey()}>
+                    Login with Passkey
+                  </button>
+                ) : (
+                  <button type="button" onClick={() => void createPasskeyAndStart(passkeyUsername)}>
+                    Register Passkey
+                  </button>
+                )}
+              </div>
+            ) : null}
 
-          <label htmlFor={passwordInputId}>Password</label>
-          <div style={rowStyle}>
-            <input
-              id={passwordInputId}
-              type="password"
-              autoComplete="current-password"
-              aria-label="Node password"
-              value={password}
-              onChange={(event) => setPassword(event.target.value)}
-              placeholder="Password"
-            />
-            <button type="button" onClick={() => void startWithPassword(password)}>
-              Start with Password
-            </button>
-          </div>
-        </>
+            <label htmlFor={passwordInputId}>Password</label>
+            <div style={rowStyle}>
+              <input
+                id={passwordInputId}
+                type="password"
+                autoComplete="current-password"
+                aria-label="Node password"
+                value={password}
+                onChange={(event) => setPassword(event.target.value)}
+                placeholder="Password"
+              />
+              <button type="button" onClick={() => void startWithPassword(password)}>
+                Start with Password
+              </button>
+            </div>
+          </>
+        )
       ) : (
         <>
           <p>

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -29,6 +29,14 @@ export type {
   ConnectStrategy,
 } from './connect-button.js';
 export { ConnectButton } from './connect-button.js';
+export type {
+  FiberNodeButtonConnectorSectionContext,
+  FiberNodeButtonExternalFundingConfig,
+  FiberNodeButtonExternalFundingResolved,
+  FiberNodeButtonExternalFundingResolverContext,
+  FiberNodeButtonProps,
+} from './fiber-node-button.js';
+export { FiberNodeButton } from './fiber-node-button.js';
 export type { FiberPayQuickCardProps } from './fiber-pay-quick-card.js';
 export { FiberPayQuickCard } from './fiber-pay-quick-card.js';
 export type { NodeInfoPanelProps } from './node-info-panel.js';

--- a/packages/react/tests/connect-button.test.tsx
+++ b/packages/react/tests/connect-button.test.tsx
@@ -72,7 +72,7 @@ describe('ConnectButton', () => {
     fireEvent.click(button);
 
     expect(button.getAttribute('aria-expanded')).toBe('true');
-    expect(screen.getByRole('menu')).toBeTruthy();
+    expect(screen.getByRole('dialog', { name: 'Connection panel' })).toBeTruthy();
   });
 
   it('emits onConnect and onDisconnect exactly once per transition', async () => {

--- a/packages/react/tests/connect-button.test.tsx
+++ b/packages/react/tests/connect-button.test.tsx
@@ -1,0 +1,131 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ConnectButton } from '../src/connect-button.js';
+import type { UseFiberNodeResult } from '../src/use-fiber-node.js';
+
+afterEach(() => {
+  cleanup();
+});
+
+function createFiberMock(overrides: Partial<UseFiberNodeResult> = {}): UseFiberNodeResult {
+  return {
+    state: 'idle',
+    node: null,
+    nodeInfo: null,
+    error: null,
+    isStarting: false,
+    isRunning: false,
+    isPasskeySupported: true,
+    passkeySupportReason: 'supported',
+    passkeyUnavailableReason: null,
+    hasPasskeyConfigured: true,
+    startWithPassword: vi.fn(async () => {}),
+    createPasskeyAndStart: vi.fn(async () => {}),
+    startWithPasskey: vi.fn(async () => {}),
+    startWithRawKey: vi.fn(async () => {}),
+    stop: vi.fn(async () => {}),
+    ...overrides,
+  };
+}
+
+describe('ConnectButton', () => {
+  it('reports a repeated error message only once', async () => {
+    const onError = vi.fn();
+    const startWithPassword = vi.fn(async () => {
+      throw new Error('boom');
+    });
+
+    const fiber = createFiberMock({
+      error: 'boom',
+      startWithPassword,
+    });
+
+    render(<ConnectButton fiber={fiber} strategy="password" password="secret" onError={onError} />);
+
+    await waitFor(() => {
+      expect(onError).toHaveBeenCalledTimes(1);
+      expect(onError).toHaveBeenCalledWith('boom');
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Connect' }));
+
+    await waitFor(() => {
+      expect(startWithPassword).toHaveBeenCalledWith('secret');
+    });
+
+    expect(onError).toHaveBeenCalledTimes(1);
+  });
+
+  it('exposes dropdown state via aria-expanded when connected', () => {
+    const fiber = createFiberMock({
+      state: 'running',
+      isRunning: true,
+      node: {} as UseFiberNodeResult['node'],
+      nodeInfo: { pubkey: '0x0123456789abcdef0123456789abcdef' } as UseFiberNodeResult['nodeInfo'],
+    });
+
+    render(<ConnectButton fiber={fiber} strategy="passkey" />);
+
+    const button = screen.getByRole('button');
+    expect(button.getAttribute('aria-expanded')).toBe('false');
+
+    fireEvent.click(button);
+
+    expect(button.getAttribute('aria-expanded')).toBe('true');
+    expect(screen.getByRole('menu')).toBeTruthy();
+  });
+
+  it('emits onConnect and onDisconnect exactly once per transition', async () => {
+    const onConnect = vi.fn();
+    const onDisconnect = vi.fn();
+
+    const disconnectedFiber = createFiberMock({
+      state: 'idle',
+      isRunning: false,
+      node: null,
+      nodeInfo: null,
+    });
+
+    const connectedFiber = createFiberMock({
+      state: 'running',
+      isRunning: true,
+      node: {} as UseFiberNodeResult['node'],
+      nodeInfo: { pubkey: '0x0123456789abcdef0123456789abcdef' } as UseFiberNodeResult['nodeInfo'],
+    });
+
+    const { rerender } = render(
+      <ConnectButton
+        fiber={disconnectedFiber}
+        strategy="passkey"
+        onConnect={onConnect}
+        onDisconnect={onDisconnect}
+      />,
+    );
+
+    rerender(
+      <ConnectButton
+        fiber={connectedFiber}
+        strategy="passkey"
+        onConnect={onConnect}
+        onDisconnect={onDisconnect}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(onConnect).toHaveBeenCalledTimes(1);
+    });
+
+    rerender(
+      <ConnectButton
+        fiber={disconnectedFiber}
+        strategy="passkey"
+        onConnect={onConnect}
+        onDisconnect={onDisconnect}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(onDisconnect).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/react/tests/fiber-node-button.test.tsx
+++ b/packages/react/tests/fiber-node-button.test.tsx
@@ -54,7 +54,7 @@ describe('FiberNodeButton', () => {
     expect(screen.getByRole('button', { name: 'Connect' })).toBeTruthy();
   });
 
-  it('shows connection/channel/payment sections in dropdown when connected', async () => {
+  it('shows tabbed panel sections in dropdown when connected', async () => {
     const node = createNodeMock();
     const fiber = createFiberMock({
       state: 'running',
@@ -74,9 +74,11 @@ describe('FiberNodeButton', () => {
     const toggle = screen.getByRole('button', { name: /0x012345/i });
     fireEvent.click(toggle);
 
-    expect(screen.getByText('Connection')).toBeTruthy();
-    expect(screen.getByText('Peers & Graph')).toBeTruthy();
-    expect(screen.getByText('Channels')).toBeTruthy();
+    expect(screen.getByRole('tab', { name: 'Workbench' })).toBeTruthy();
+    expect(screen.getByRole('tab', { name: 'Channels' })).toBeTruthy();
+    expect(screen.getByRole('tab', { name: 'Diagnostics' })).toBeTruthy();
+    expect(screen.getByText('Connection Prep')).toBeTruthy();
+    expect(screen.getByRole('heading', { name: 'Open Channel' })).toBeTruthy();
     expect(screen.getByText('Payments')).toBeTruthy();
     expect(screen.getByText('Connector slot')).toBeTruthy();
 
@@ -132,8 +134,14 @@ describe('FiberNodeButton', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /0x012345/i }));
 
+    fireEvent.click(screen.getByRole('tab', { name: 'Channels' }));
+
     await waitFor(() => {
-      expect(screen.getByText('active (1)')).toBeTruthy();
+      expect(screen.getByRole('button', { name: 'active (1)' })).toBeTruthy();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Close Channel' })).toBeTruthy();
     });
 
     fireEvent.click(screen.getByRole('button', { name: 'Close Channel' }));

--- a/packages/react/tests/fiber-node-button.test.tsx
+++ b/packages/react/tests/fiber-node-button.test.tsx
@@ -1,0 +1,81 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { FiberNodeButton } from '../src/fiber-node-button.js';
+import type { UseFiberNodeResult } from '../src/use-fiber-node.js';
+
+afterEach(() => {
+  cleanup();
+});
+
+function createNodeMock() {
+  return {
+    listPeers: vi.fn(async () => ({ peers: [{ pubkey: '0xabc' }] })),
+    connectPeer: vi.fn(async () => ({})),
+    newInvoice: vi.fn(async () => ({ invoice_address: 'ln-fake-invoice' })),
+    parseInvoice: vi.fn(async () => ({ invoice: { data: { payment_hash: '0x1' } } })),
+    sendPayment: vi.fn(async () => ({})),
+    waitForPayment: vi.fn(async () => ({ status: 'Succeeded' })),
+  };
+}
+
+function createFiberMock(overrides: Partial<UseFiberNodeResult> = {}): UseFiberNodeResult {
+  return {
+    state: 'idle',
+    node: null,
+    nodeInfo: null,
+    error: null,
+    isStarting: false,
+    isRunning: false,
+    isPasskeySupported: true,
+    passkeySupportReason: 'supported',
+    passkeyUnavailableReason: null,
+    hasPasskeyConfigured: true,
+    startWithPassword: vi.fn(async () => {}),
+    createPasskeyAndStart: vi.fn(async () => {}),
+    startWithPasskey: vi.fn(async () => {}),
+    startWithRawKey: vi.fn(async () => {}),
+    stop: vi.fn(async () => {}),
+    ...overrides,
+  };
+}
+
+describe('FiberNodeButton', () => {
+  it('renders as a connect button when disconnected', () => {
+    const fiber = createFiberMock();
+
+    render(<FiberNodeButton fiber={fiber} strategy="password" password="secret" />);
+
+    expect(screen.getByRole('button', { name: 'Connect' })).toBeTruthy();
+  });
+
+  it('shows connection/channel/payment sections in dropdown when connected', async () => {
+    const node = createNodeMock();
+    const fiber = createFiberMock({
+      state: 'running',
+      isRunning: true,
+      node: node as unknown as UseFiberNodeResult['node'],
+      nodeInfo: { pubkey: '0x0123456789abcdef0123456789abcdef' } as UseFiberNodeResult['nodeInfo'],
+    });
+
+    render(
+      <FiberNodeButton
+        fiber={fiber}
+        strategy="passkey"
+        renderConnectorSection={() => <div>Connector slot</div>}
+      />,
+    );
+
+    const toggle = screen.getByRole('button', { name: /0x012345/i });
+    fireEvent.click(toggle);
+
+    expect(screen.getByText('Connection')).toBeTruthy();
+    expect(screen.getByText('Channels')).toBeTruthy();
+    expect(screen.getByText('Payments')).toBeTruthy();
+    expect(screen.getByText('Connector')).toBeTruthy();
+    expect(screen.getByText('Connector slot')).toBeTruthy();
+
+    await waitFor(() => {
+      expect(node.listPeers).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/react/tests/fiber-node-button.test.tsx
+++ b/packages/react/tests/fiber-node-button.test.tsx
@@ -1,5 +1,6 @@
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ChannelState } from '@fiber-pay/sdk/browser';
 import { FiberNodeButton } from '../src/fiber-node-button.js';
 import type { UseFiberNodeResult } from '../src/use-fiber-node.js';
 
@@ -10,7 +11,12 @@ afterEach(() => {
 function createNodeMock() {
   return {
     listPeers: vi.fn(async () => ({ peers: [{ pubkey: '0xabc' }] })),
+    listChannels: vi.fn(async () => ({ channels: [] })),
+    graphNodes: vi.fn(async () => ({ nodes: [], last_cursor: '0x0' })),
+    graphChannels: vi.fn(async () => ({ channels: [], last_cursor: '0x0' })),
     connectPeer: vi.fn(async () => ({})),
+    shutdownChannel: vi.fn(async () => ({})),
+    abandonChannel: vi.fn(async () => ({})),
     newInvoice: vi.fn(async () => ({ invoice_address: 'ln-fake-invoice' })),
     parseInvoice: vi.fn(async () => ({ invoice: { data: { payment_hash: '0x1' } } })),
     sendPayment: vi.fn(async () => ({})),
@@ -69,13 +75,74 @@ describe('FiberNodeButton', () => {
     fireEvent.click(toggle);
 
     expect(screen.getByText('Connection')).toBeTruthy();
+    expect(screen.getByText('Peers & Graph')).toBeTruthy();
     expect(screen.getByText('Channels')).toBeTruthy();
     expect(screen.getByText('Payments')).toBeTruthy();
-    expect(screen.getByText('Connector')).toBeTruthy();
     expect(screen.getByText('Connector slot')).toBeTruthy();
 
     await waitFor(() => {
       expect(node.listPeers).toHaveBeenCalled();
+    });
+
+    await waitFor(() => {
+      expect(node.listChannels).toHaveBeenCalled();
+    });
+
+    await waitFor(() => {
+      expect(node.graphNodes).toHaveBeenCalled();
+    });
+  });
+
+  it('lists channels and requests close for ready channel', async () => {
+    const readyChannel = {
+      channel_id: '0xchannel',
+      is_public: false,
+      is_acceptor: false,
+      is_one_way: false,
+      channel_outpoint: null,
+      pubkey: '0xpeer',
+      funding_udt_type_script: null,
+      state: {
+        state_name: ChannelState.ChannelReady,
+      },
+      local_balance: '0x5f5e100',
+      offered_tlc_balance: '0x0',
+      remote_balance: '0x3b9aca00',
+      received_tlc_balance: '0x0',
+      pending_tlcs: [],
+      latest_commitment_transaction_hash: null,
+      created_at: '0x1',
+      enabled: true,
+      tlc_expiry_delta: '0x0',
+      tlc_fee_proportional_millionths: '0x0',
+      shutdown_transaction_hash: null,
+    };
+
+    const node = createNodeMock();
+    node.listChannels = vi.fn(async () => ({ channels: [readyChannel] }));
+
+    const fiber = createFiberMock({
+      state: 'running',
+      isRunning: true,
+      node: node as unknown as UseFiberNodeResult['node'],
+      nodeInfo: { pubkey: '0x0123456789abcdef0123456789abcdef' } as UseFiberNodeResult['nodeInfo'],
+    });
+
+    render(<FiberNodeButton fiber={fiber} strategy="passkey" />);
+
+    fireEvent.click(screen.getByRole('button', { name: /0x012345/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('active (1)')).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Close Channel' }));
+
+    await waitFor(() => {
+      expect(node.shutdownChannel).toHaveBeenCalledWith({
+        channel_id: '0xchannel',
+        force: false,
+      });
     });
   });
 });

--- a/packages/react/tests/fiber-pay-quick-card.test.tsx
+++ b/packages/react/tests/fiber-pay-quick-card.test.tsx
@@ -1,0 +1,59 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { FiberPayQuickCard } from '../src/fiber-pay-quick-card.js';
+import type { UseFiberNodeResult } from '../src/use-fiber-node.js';
+
+afterEach(() => {
+  cleanup();
+});
+
+function createFiberMock(overrides: Partial<UseFiberNodeResult> = {}): UseFiberNodeResult {
+  return {
+    state: 'idle',
+    node: null,
+    nodeInfo: null,
+    error: null,
+    isStarting: false,
+    isRunning: false,
+    isPasskeySupported: true,
+    passkeySupportReason: 'supported',
+    passkeyUnavailableReason: null,
+    hasPasskeyConfigured: true,
+    startWithPassword: vi.fn(async () => {}),
+    createPasskeyAndStart: vi.fn(async () => {}),
+    startWithPasskey: vi.fn(async () => {}),
+    startWithRawKey: vi.fn(async () => {}),
+    stop: vi.fn(async () => {}),
+    ...overrides,
+  };
+}
+
+describe('FiberPayQuickCard', () => {
+  it('shows shared-session guidance when an external fiber is disconnected', () => {
+    const fiber = createFiberMock();
+
+    render(<FiberPayQuickCard fiber={fiber} network="testnet" />);
+
+    expect(screen.getByText(/Connection required/i)).toBeTruthy();
+    expect(screen.queryByLabelText('Node password')).toBeNull();
+  });
+
+  it('renders payment actions when shared fiber is connected', () => {
+    const fiber = createFiberMock({
+      state: 'running',
+      isRunning: true,
+      node: {
+        newInvoice: vi.fn(async () => ({ invoice_address: 'ln-fake' })),
+        parseInvoice: vi.fn(async () => ({ invoice: { data: { payment_hash: '0x1' } } })),
+        sendPayment: vi.fn(async () => ({})),
+        waitForPayment: vi.fn(async () => ({ status: 'Succeeded' })),
+      } as unknown as UseFiberNodeResult['node'],
+      nodeInfo: { pubkey: '0x0123456789abcdef0123456789abcdef' } as UseFiberNodeResult['nodeInfo'],
+    });
+
+    render(<FiberPayQuickCard fiber={fiber} network="testnet" />);
+
+    expect(screen.getByText(/State:/i)).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Create Invoice (1 CKB)' })).toBeTruthy();
+  });
+});

--- a/packages/react/vitest.config.ts
+++ b/packages/react/vitest.config.ts
@@ -2,7 +2,8 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    include: ['tests/**/*.test.ts'],
+    include: ['tests/**/*.test.{ts,tsx}'],
+    environment: 'jsdom',
     globals: false,
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,7 +31,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(@types/node@25.1.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.0.18(@types/node@25.1.0)(jsdom@26.1.0)(tsx@4.21.0)(yaml@2.8.2)
 
   apps/browser-wallet:
     dependencies:
@@ -117,10 +117,10 @@ importers:
     dependencies:
       '@ckb-ccc/connector-react':
         specifier: ^1.0.34
-        version: 1.0.34(@types/react@19.2.14)(react@19.2.4)(typescript@5.9.3)(zod@4.3.6)
+        version: 1.0.34(@types/react@19.2.14)(react@19.2.4)(typescript@5.9.3)
       '@ckb-ccc/core':
         specifier: ^1.12.5
-        version: 1.12.5(typescript@5.9.3)(zod@4.3.6)
+        version: 1.12.5(typescript@5.9.3)
       '@fiber-pay/react':
         specifier: workspace:*
         version: link:../../packages/react
@@ -257,9 +257,15 @@ importers:
         specifier: ^18.0.0 || ^19.0.0
         version: 19.2.4
     devDependencies:
+      '@testing-library/react':
+        specifier: ^16.3.0
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@types/react':
         specifier: ^18.0.0 || ^19.0.0
         version: 19.2.14
+      jsdom:
+        specifier: ^26.1.0
+        version: 26.1.0
 
   packages/runtime:
     dependencies:
@@ -300,6 +306,9 @@ packages:
 
   '@adraffy/ens-normalize@1.10.1':
     resolution: {integrity: sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==}
+
+  '@asamuzakjp/css-color@3.2.0':
+    resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -549,6 +558,34 @@ packages:
 
   '@ckb-ccc/xverse@1.0.32':
     resolution: {integrity: sha512-B8L/6y8dq5U5y+TDaV2n0LWXuJViiMJrUkIvQvodA8LcVFuXT/nOtKKNRHxUJ5tiz82eTYq3NBR9vhsBiohAQQ==}
+
+  '@csstools/color-helpers@5.1.0':
+    resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
+    engines: {node: '>=18'}
+
+  '@csstools/css-calc@2.1.4':
+    resolution: {integrity: sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-color-parser@3.1.0':
+    resolution: {integrity: sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5':
+    resolution: {integrity: sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-tokenizer@3.0.4':
+    resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
+    engines: {node: '>=18'}
 
   '@esbuild/aix-ppc64@0.25.12':
     resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
@@ -1154,6 +1191,28 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
+
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
 
@@ -1364,6 +1423,10 @@ packages:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
 
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
   ajv@6.14.0:
     resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
 
@@ -1387,6 +1450,10 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   ansi-styles@6.2.3:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
@@ -1399,6 +1466,9 @@ packages:
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
   array-union@2.1.0:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
@@ -1622,8 +1692,16 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  cssstyle@4.6.0:
+    resolution: {integrity: sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==}
+    engines: {node: '>=18'}
+
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  data-urls@5.0.0:
+    resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
+    engines: {node: '>=18'}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -1637,6 +1715,9 @@ packages:
   decamelize@1.2.0:
     resolution: {integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==}
     engines: {node: '>=0.10.0'}
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   decompress-response@6.0.0:
     resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
@@ -1657,6 +1738,10 @@ packages:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
 
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
   detect-indent@6.1.0:
     resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
     engines: {node: '>=8'}
@@ -1671,6 +1756,9 @@ packages:
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -1701,6 +1789,10 @@ packages:
   enquirer@2.4.1:
     resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
     engines: {node: '>=8.6'}
+
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
 
   environment@1.1.0:
     resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
@@ -2033,9 +2125,17 @@ packages:
   hmac-drbg@1.0.1:
     resolution: {integrity: sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==}
 
+  html-encoding-sniffer@4.0.0:
+    resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
+    engines: {node: '>=18'}
+
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
+
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
 
   http-proxy-middleware@3.0.5:
     resolution: {integrity: sha512-GLZZm1X38BPY4lkXA01jhwxvDoOkkXqjgVyUzVxiEK4iuRu03PZoYHhHRwxnfhQMDuaxi3vVri0YgSro/1oWqg==}
@@ -2049,6 +2149,10 @@ packages:
     resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
     engines: {node: '>= 6'}
 
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
+
   human-id@4.1.3:
     resolution: {integrity: sha512-tsYlhAYpjCKa//8rXZ9DqKEawhPoSytweBC2eNvcaDK+57RZLHGqNs3PZTQO6yekLFSuvA6AlnAfrw1uBvtb+Q==}
     hasBin: true
@@ -2057,6 +2161,10 @@ packages:
     resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
     engines: {node: '>=18'}
     hasBin: true
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
 
   iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
@@ -2115,6 +2223,9 @@ packages:
     resolution: {integrity: sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==}
     engines: {node: '>=0.10.0'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   is-promise@4.0.0:
     resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
@@ -2151,6 +2262,15 @@ packages:
 
   jsbi@3.1.3:
     resolution: {integrity: sha512-nBJqA0C6Qns+ZxurbEoIR56wyjiUszpNy70FHvxO5ervMoCbZVE3z3kxr5nKGhlxr/9MhKTSUBs7cAwwuf3g9w==}
+
+  jsdom@26.1.0:
+    resolution: {integrity: sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
@@ -2228,6 +2348,9 @@ packages:
     resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
     engines: {node: '>=18'}
 
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
@@ -2235,6 +2358,10 @@ packages:
     resolution: {integrity: sha512-eHfdbJExWtTaZ0tBMGtI7PA/MbqV5wt+o4/yitDce17tadH/75Gq3Tq8jSteb3LhLr0eay/j5YUuN4yXjnI3aw==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0
+
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
 
   macaroon@3.0.4:
     resolution: {integrity: sha512-Tja2jvupseKxltPZbu5RPSz2Pgh6peYA3O46YCTcYL8PI1VqtGwDqRhGfP8pows26xx9wTiygk+en62Bq+Y8JA==}
@@ -2353,6 +2480,9 @@ packages:
   node-releases@2.0.36:
     resolution: {integrity: sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==}
 
+  nwsapi@2.2.23:
+    resolution: {integrity: sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==}
+
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
@@ -2416,6 +2546,9 @@ packages:
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
+
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
@@ -2517,6 +2650,10 @@ packages:
     engines: {node: '>=10.13.0'}
     hasBin: true
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
@@ -2568,6 +2705,9 @@ packages:
     resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
     peerDependencies:
       react: ^19.2.4
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
   react-refresh@0.17.0:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
@@ -2630,6 +2770,9 @@ packages:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
     engines: {node: '>= 18'}
 
+  rrweb-cssom@0.8.0:
+    resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -2638,6 +2781,10 @@ packages:
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
@@ -2788,6 +2935,9 @@ packages:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
 
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
   tar-fs@2.1.4:
     resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
 
@@ -2824,6 +2974,13 @@ packages:
     resolution: {integrity: sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==}
     engines: {node: '>=14.0.0'}
 
+  tldts-core@6.1.86:
+    resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
+
+  tldts@6.1.86:
+    resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
+    hasBin: true
+
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
@@ -2832,8 +2989,16 @@ packages:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
 
+  tough-cookie@5.1.2:
+    resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
+    engines: {node: '>=16'}
+
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
+  tr46@5.1.1:
+    resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
+    engines: {node: '>=18'}
 
   tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
@@ -3072,8 +3237,29 @@ packages:
       jsdom:
         optional: true
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
+  webidl-conversions@7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
+
+  whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
+
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
+
+  whatwg-url@14.2.0:
+    resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
+    engines: {node: '>=18'}
 
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
@@ -3130,6 +3316,13 @@ packages:
       utf-8-validate:
         optional: true
 
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
   y18n@4.0.3:
     resolution: {integrity: sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==}
 
@@ -3165,6 +3358,14 @@ packages:
 snapshots:
 
   '@adraffy/ens-normalize@1.10.1': {}
+
+  '@asamuzakjp/css-color@3.2.0':
+    dependencies:
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+      lru-cache: 10.4.3
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -3459,17 +3660,17 @@ snapshots:
       human-id: 4.1.3
       prettier: 2.8.8
 
-  '@ckb-ccc/ccc@1.1.25(typescript@5.9.3)(zod@4.3.6)':
+  '@ckb-ccc/ccc@1.1.25(typescript@5.9.3)':
     dependencies:
-      '@ckb-ccc/eip6963': 1.0.32(typescript@5.9.3)(zod@4.3.6)
-      '@ckb-ccc/joy-id': 1.0.32(typescript@5.9.3)(zod@4.3.6)
-      '@ckb-ccc/nip07': 1.0.32(typescript@5.9.3)(zod@4.3.6)
-      '@ckb-ccc/okx': 1.0.32(typescript@5.9.3)(zod@4.3.6)
-      '@ckb-ccc/rei': 1.0.32(typescript@5.9.3)(zod@4.3.6)
-      '@ckb-ccc/shell': 1.1.25(typescript@5.9.3)(zod@4.3.6)
-      '@ckb-ccc/uni-sat': 1.0.32(typescript@5.9.3)(zod@4.3.6)
-      '@ckb-ccc/utxo-global': 1.0.32(typescript@5.9.3)(zod@4.3.6)
-      '@ckb-ccc/xverse': 1.0.32(typescript@5.9.3)(zod@4.3.6)
+      '@ckb-ccc/eip6963': 1.0.32(typescript@5.9.3)
+      '@ckb-ccc/joy-id': 1.0.32(typescript@5.9.3)
+      '@ckb-ccc/nip07': 1.0.32(typescript@5.9.3)
+      '@ckb-ccc/okx': 1.0.32(typescript@5.9.3)
+      '@ckb-ccc/rei': 1.0.32(typescript@5.9.3)
+      '@ckb-ccc/shell': 1.1.25(typescript@5.9.3)
+      '@ckb-ccc/uni-sat': 1.0.32(typescript@5.9.3)
+      '@ckb-ccc/utxo-global': 1.0.32(typescript@5.9.3)
+      '@ckb-ccc/xverse': 1.0.32(typescript@5.9.3)
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -3479,9 +3680,9 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@ckb-ccc/connector-react@1.0.34(@types/react@19.2.14)(react@19.2.4)(typescript@5.9.3)(zod@4.3.6)':
+  '@ckb-ccc/connector-react@1.0.34(@types/react@19.2.14)(react@19.2.4)(typescript@5.9.3)':
     dependencies:
-      '@ckb-ccc/connector': 1.0.33(typescript@5.9.3)(zod@4.3.6)
+      '@ckb-ccc/connector': 1.0.33(typescript@5.9.3)
       '@lit/react': 1.0.8(@types/react@19.2.14)
       react: 19.2.4
     transitivePeerDependencies:
@@ -3494,9 +3695,9 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@ckb-ccc/connector@1.0.33(typescript@5.9.3)(zod@4.3.6)':
+  '@ckb-ccc/connector@1.0.33(typescript@5.9.3)':
     dependencies:
-      '@ckb-ccc/ccc': 1.1.25(typescript@5.9.3)(zod@4.3.6)
+      '@ckb-ccc/ccc': 1.1.25(typescript@5.9.3)
       lit: 3.3.3
     transitivePeerDependencies:
       - bufferutil
@@ -3507,9 +3708,9 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@ckb-ccc/core@1.12.5(typescript@5.9.3)(zod@4.3.6)':
+  '@ckb-ccc/core@1.12.5(typescript@5.9.3)':
     dependencies:
-      '@joyid/ckb': 1.1.4(typescript@5.9.3)(zod@4.3.6)
+      '@joyid/ckb': 1.1.4(typescript@5.9.3)
       '@noble/ciphers': 0.5.3
       '@noble/curves': 1.9.7
       '@noble/hashes': 1.8.0
@@ -3526,9 +3727,9 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@ckb-ccc/eip6963@1.0.32(typescript@5.9.3)(zod@4.3.6)':
+  '@ckb-ccc/eip6963@1.0.32(typescript@5.9.3)':
     dependencies:
-      '@ckb-ccc/core': 1.12.5(typescript@5.9.3)(zod@4.3.6)
+      '@ckb-ccc/core': 1.12.5(typescript@5.9.3)
     transitivePeerDependencies:
       - bufferutil
       - encoding
@@ -3536,11 +3737,11 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@ckb-ccc/joy-id@1.0.32(typescript@5.9.3)(zod@4.3.6)':
+  '@ckb-ccc/joy-id@1.0.32(typescript@5.9.3)':
     dependencies:
-      '@ckb-ccc/core': 1.12.5(typescript@5.9.3)(zod@4.3.6)
-      '@joyid/ckb': 1.1.4(typescript@5.9.3)(zod@4.3.6)
-      '@joyid/common': 0.2.2(typescript@5.9.3)(zod@4.3.6)
+      '@ckb-ccc/core': 1.12.5(typescript@5.9.3)
+      '@joyid/ckb': 1.1.4(typescript@5.9.3)
+      '@joyid/common': 0.2.2(typescript@5.9.3)
     transitivePeerDependencies:
       - bufferutil
       - encoding
@@ -3548,9 +3749,9 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@ckb-ccc/nip07@1.0.32(typescript@5.9.3)(zod@4.3.6)':
+  '@ckb-ccc/nip07@1.0.32(typescript@5.9.3)':
     dependencies:
-      '@ckb-ccc/core': 1.12.5(typescript@5.9.3)(zod@4.3.6)
+      '@ckb-ccc/core': 1.12.5(typescript@5.9.3)
     transitivePeerDependencies:
       - bufferutil
       - encoding
@@ -3558,11 +3759,11 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@ckb-ccc/okx@1.0.32(typescript@5.9.3)(zod@4.3.6)':
+  '@ckb-ccc/okx@1.0.32(typescript@5.9.3)':
     dependencies:
-      '@ckb-ccc/core': 1.12.5(typescript@5.9.3)(zod@4.3.6)
-      '@ckb-ccc/nip07': 1.0.32(typescript@5.9.3)(zod@4.3.6)
-      '@ckb-ccc/uni-sat': 1.0.32(typescript@5.9.3)(zod@4.3.6)
+      '@ckb-ccc/core': 1.12.5(typescript@5.9.3)
+      '@ckb-ccc/nip07': 1.0.32(typescript@5.9.3)
+      '@ckb-ccc/uni-sat': 1.0.32(typescript@5.9.3)
     transitivePeerDependencies:
       - bufferutil
       - encoding
@@ -3570,9 +3771,9 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@ckb-ccc/rei@1.0.32(typescript@5.9.3)(zod@4.3.6)':
+  '@ckb-ccc/rei@1.0.32(typescript@5.9.3)':
     dependencies:
-      '@ckb-ccc/core': 1.12.5(typescript@5.9.3)(zod@4.3.6)
+      '@ckb-ccc/core': 1.12.5(typescript@5.9.3)
     transitivePeerDependencies:
       - bufferutil
       - encoding
@@ -3580,12 +3781,12 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@ckb-ccc/shell@1.1.25(typescript@5.9.3)(zod@4.3.6)':
+  '@ckb-ccc/shell@1.1.25(typescript@5.9.3)':
     dependencies:
-      '@ckb-ccc/core': 1.12.5(typescript@5.9.3)(zod@4.3.6)
-      '@ckb-ccc/spore': 1.5.17(typescript@5.9.3)(zod@4.3.6)
-      '@ckb-ccc/ssri': 0.2.22(typescript@5.9.3)(zod@4.3.6)
-      '@ckb-ccc/udt': 0.1.24(typescript@5.9.3)(zod@4.3.6)
+      '@ckb-ccc/core': 1.12.5(typescript@5.9.3)
+      '@ckb-ccc/spore': 1.5.17(typescript@5.9.3)
+      '@ckb-ccc/ssri': 0.2.22(typescript@5.9.3)
+      '@ckb-ccc/udt': 0.1.24(typescript@5.9.3)
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -3595,9 +3796,9 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@ckb-ccc/spore@1.5.17(typescript@5.9.3)(zod@4.3.6)':
+  '@ckb-ccc/spore@1.5.17(typescript@5.9.3)':
     dependencies:
-      '@ckb-ccc/core': 1.12.5(typescript@5.9.3)(zod@4.3.6)
+      '@ckb-ccc/core': 1.12.5(typescript@5.9.3)
       axios: 1.16.1
     transitivePeerDependencies:
       - bufferutil
@@ -3608,9 +3809,9 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@ckb-ccc/ssri@0.2.22(typescript@5.9.3)(zod@4.3.6)':
+  '@ckb-ccc/ssri@0.2.22(typescript@5.9.3)':
     dependencies:
-      '@ckb-ccc/core': 1.12.5(typescript@5.9.3)(zod@4.3.6)
+      '@ckb-ccc/core': 1.12.5(typescript@5.9.3)
     transitivePeerDependencies:
       - bufferutil
       - encoding
@@ -3618,10 +3819,10 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@ckb-ccc/udt@0.1.24(typescript@5.9.3)(zod@4.3.6)':
+  '@ckb-ccc/udt@0.1.24(typescript@5.9.3)':
     dependencies:
-      '@ckb-ccc/core': 1.12.5(typescript@5.9.3)(zod@4.3.6)
-      '@ckb-ccc/ssri': 0.2.22(typescript@5.9.3)(zod@4.3.6)
+      '@ckb-ccc/core': 1.12.5(typescript@5.9.3)
+      '@ckb-ccc/ssri': 0.2.22(typescript@5.9.3)
     transitivePeerDependencies:
       - bufferutil
       - encoding
@@ -3629,9 +3830,9 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@ckb-ccc/uni-sat@1.0.32(typescript@5.9.3)(zod@4.3.6)':
+  '@ckb-ccc/uni-sat@1.0.32(typescript@5.9.3)':
     dependencies:
-      '@ckb-ccc/core': 1.12.5(typescript@5.9.3)(zod@4.3.6)
+      '@ckb-ccc/core': 1.12.5(typescript@5.9.3)
     transitivePeerDependencies:
       - bufferutil
       - encoding
@@ -3639,9 +3840,9 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@ckb-ccc/utxo-global@1.0.32(typescript@5.9.3)(zod@4.3.6)':
+  '@ckb-ccc/utxo-global@1.0.32(typescript@5.9.3)':
     dependencies:
-      '@ckb-ccc/core': 1.12.5(typescript@5.9.3)(zod@4.3.6)
+      '@ckb-ccc/core': 1.12.5(typescript@5.9.3)
     transitivePeerDependencies:
       - bufferutil
       - encoding
@@ -3649,9 +3850,9 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@ckb-ccc/xverse@1.0.32(typescript@5.9.3)(zod@4.3.6)':
+  '@ckb-ccc/xverse@1.0.32(typescript@5.9.3)':
     dependencies:
-      '@ckb-ccc/core': 1.12.5(typescript@5.9.3)(zod@4.3.6)
+      '@ckb-ccc/core': 1.12.5(typescript@5.9.3)
       valibot: 1.4.0(typescript@5.9.3)
     transitivePeerDependencies:
       - bufferutil
@@ -3659,6 +3860,26 @@ snapshots:
       - typescript
       - utf-8-validate
       - zod
+
+  '@csstools/color-helpers@5.1.0': {}
+
+  '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-color-parser@3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/color-helpers': 5.1.0
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-tokenizer@3.0.4': {}
 
   '@esbuild/aix-ppc64@0.25.12':
     optional: true
@@ -3880,9 +4101,9 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.1.0
 
-  '@joyid/ckb@1.1.4(typescript@5.9.3)(zod@4.3.6)':
+  '@joyid/ckb@1.1.4(typescript@5.9.3)':
     dependencies:
-      '@joyid/common': 0.2.2(typescript@5.9.3)(zod@4.3.6)
+      '@joyid/common': 0.2.2(typescript@5.9.3)
       '@nervosnetwork/ckb-sdk-utils': 0.109.5
       cross-fetch: 4.0.0
       uncrypto: 0.1.3
@@ -3891,9 +4112,9 @@ snapshots:
       - typescript
       - zod
 
-  '@joyid/common@0.2.2(typescript@5.9.3)(zod@4.3.6)':
+  '@joyid/common@0.2.2(typescript@5.9.3)':
     dependencies:
-      abitype: 0.8.7(typescript@5.9.3)(zod@4.3.6)
+      abitype: 0.8.7(typescript@5.9.3)
       type-fest: 4.6.0
     transitivePeerDependencies:
       - typescript
@@ -4070,6 +4291,29 @@ snapshots:
     optional: true
 
   '@standard-schema/spec@1.1.0': {}
+
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/runtime': 7.28.6
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@babel/runtime': 7.28.6
+      '@testing-library/dom': 10.4.1
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@types/aria-query@5.0.4': {}
 
   '@types/babel__core@7.20.5':
     dependencies:
@@ -4334,11 +4578,9 @@ snapshots:
       '@vitest/pretty-format': 4.0.18
       tinyrainbow: 3.0.3
 
-  abitype@0.8.7(typescript@5.9.3)(zod@4.3.6):
+  abitype@0.8.7(typescript@5.9.3):
     dependencies:
       typescript: 5.9.3
-    optionalDependencies:
-      zod: 4.3.6
 
   accepts@2.0.0:
     dependencies:
@@ -4358,6 +4600,8 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
+
+  agent-base@7.1.4: {}
 
   ajv@6.14.0:
     dependencies:
@@ -4380,6 +4624,8 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
+  ansi-styles@5.2.0: {}
+
   ansi-styles@6.2.3: {}
 
   any-promise@1.3.0: {}
@@ -4389,6 +4635,10 @@ snapshots:
       sprintf-js: 1.0.3
 
   argparse@2.0.1: {}
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
 
   array-union@2.1.0: {}
 
@@ -4607,13 +4857,25 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  cssstyle@4.6.0:
+    dependencies:
+      '@asamuzakjp/css-color': 3.2.0
+      rrweb-cssom: 0.8.0
+
   csstype@3.2.3: {}
+
+  data-urls@5.0.0:
+    dependencies:
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
 
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
 
   decamelize@1.2.0: {}
+
+  decimal.js@10.6.0: {}
 
   decompress-response@6.0.0:
     dependencies:
@@ -4627,6 +4889,8 @@ snapshots:
 
   depd@2.0.0: {}
 
+  dequal@2.0.3: {}
+
   detect-indent@6.1.0: {}
 
   detect-libc@2.1.2: {}
@@ -4636,6 +4900,8 @@ snapshots:
   dir-glob@3.0.1:
     dependencies:
       path-type: 4.0.0
+
+  dom-accessibility-api@0.5.16: {}
 
   dunder-proto@1.0.1:
     dependencies:
@@ -4671,6 +4937,8 @@ snapshots:
     dependencies:
       ansi-colors: 4.1.3
       strip-ansi: 6.0.1
+
+  entities@6.0.1: {}
 
   environment@1.1.0: {}
 
@@ -5092,6 +5360,10 @@ snapshots:
       minimalistic-assert: 1.0.1
       minimalistic-crypto-utils: 1.0.1
 
+  html-encoding-sniffer@4.0.0:
+    dependencies:
+      whatwg-encoding: 3.1.1
+
   http-errors@2.0.1:
     dependencies:
       depd: 2.0.0
@@ -5099,6 +5371,13 @@ snapshots:
       setprototypeof: 1.2.0
       statuses: 2.0.2
       toidentifier: 1.0.1
+
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   http-proxy-middleware@3.0.5:
     dependencies:
@@ -5126,9 +5405,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   human-id@4.1.3: {}
 
   husky@9.1.7: {}
+
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
 
   iconv-lite@0.7.2:
     dependencies:
@@ -5169,6 +5459,8 @@ snapshots:
 
   is-plain-object@5.0.0: {}
 
+  is-potential-custom-element-name@1.0.1: {}
+
   is-promise@4.0.0: {}
 
   is-subdir@1.2.0:
@@ -5197,6 +5489,33 @@ snapshots:
       argparse: 2.0.1
 
   jsbi@3.1.3: {}
+
+  jsdom@26.1.0:
+    dependencies:
+      cssstyle: 4.6.0
+      data-urls: 5.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 4.0.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      is-potential-custom-element-name: 1.0.1
+      nwsapi: 2.2.23
+      parse5: 7.3.0
+      rrweb-cssom: 0.8.0
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 5.1.2
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 7.0.0
+      whatwg-encoding: 3.1.1
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
+      ws: 8.20.1
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   jsesc@3.1.0: {}
 
@@ -5282,6 +5601,8 @@ snapshots:
       strip-ansi: 7.1.2
       wrap-ansi: 9.0.2
 
+  lru-cache@10.4.3: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
@@ -5289,6 +5610,8 @@ snapshots:
   lucide-react@0.364.0(react@19.2.4):
     dependencies:
       react: 19.2.4
+
+  lz-string@1.5.0: {}
 
   macaroon@3.0.4:
     dependencies:
@@ -5382,6 +5705,8 @@ snapshots:
 
   node-releases@2.0.36: {}
 
+  nwsapi@2.2.23: {}
+
   object-assign@4.1.1: {}
 
   object-inspect@1.13.4: {}
@@ -5442,6 +5767,10 @@ snapshots:
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
+
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
 
   parseurl@1.3.3: {}
 
@@ -5516,6 +5845,12 @@ snapshots:
 
   prettier@2.8.8: {}
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
   proxy-addr@2.0.7:
     dependencies:
       forwarded: 0.2.0
@@ -5568,6 +5903,8 @@ snapshots:
     dependencies:
       react: 19.2.4
       scheduler: 0.27.0
+
+  react-is@17.0.2: {}
 
   react-refresh@0.17.0: {}
 
@@ -5650,6 +5987,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  rrweb-cssom@0.8.0: {}
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -5657,6 +5996,10 @@ snapshots:
   safe-buffer@5.2.1: {}
 
   safer-buffer@2.1.2: {}
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
 
   scheduler@0.27.0: {}
 
@@ -5821,6 +6164,8 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
+  symbol-tree@3.2.4: {}
+
   tar-fs@2.1.4:
     dependencies:
       chownr: 1.1.4
@@ -5859,13 +6204,27 @@ snapshots:
 
   tinyrainbow@3.0.3: {}
 
+  tldts-core@6.1.86: {}
+
+  tldts@6.1.86:
+    dependencies:
+      tldts-core: 6.1.86
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
 
   toidentifier@1.0.1: {}
 
+  tough-cookie@5.1.2:
+    dependencies:
+      tldts: 6.1.86
+
   tr46@0.0.3: {}
+
+  tr46@5.1.1:
+    dependencies:
+      punycode: 2.3.1
 
   tree-kill@1.2.2: {}
 
@@ -6021,7 +6380,7 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.8.2
 
-  vitest@4.0.18(@types/node@25.1.0)(tsx@4.21.0)(yaml@2.8.2):
+  vitest@4.0.18(@types/node@25.1.0)(jsdom@26.1.0)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       '@vitest/expect': 4.0.18
       '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@25.1.0)(tsx@4.21.0)(yaml@2.8.2))
@@ -6045,6 +6404,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.1.0
+      jsdom: 26.1.0
     transitivePeerDependencies:
       - jiti
       - less
@@ -6058,7 +6418,24 @@ snapshots:
       - tsx
       - yaml
 
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
   webidl-conversions@3.0.1: {}
+
+  webidl-conversions@7.0.0: {}
+
+  whatwg-encoding@3.1.1:
+    dependencies:
+      iconv-lite: 0.6.3
+
+  whatwg-mimetype@4.0.0: {}
+
+  whatwg-url@14.2.0:
+    dependencies:
+      tr46: 5.1.1
+      webidl-conversions: 7.0.0
 
   whatwg-url@5.0.0:
     dependencies:
@@ -6095,6 +6472,10 @@ snapshots:
   ws@8.17.1: {}
 
   ws@8.20.1: {}
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   y18n@4.0.3: {}
 


### PR DESCRIPTION
## Summary\n- refactor FiberNodeButton connected dropdown into task-oriented tabbed panel with global status bar\n- improve panel visual hierarchy (compact status area, stronger selected tab semantics, reduced nested card feel)\n- redesign apps/react-quick-card demo to be developer-onboarding focused around FiberNodeButton only\n- remove legacy Quick Payment comparison section\n- update README and tests to match new interaction model\n\n## Validation\n- pnpm --filter @fiber-pay/react test\n- pnpm --filter @fiber-pay/react build\n- cd apps/react-quick-card && pnpm build\n\n## Notes\n- includes design/spec doc for this iteration under docs/plan\n