### PR TITLE
feat(react): FiberNodeButton extensibility APIs for tabs/actions/i18n

### DIFF
--- a/.changeset/slimy-bikes-smile.md
+++ b/.changeset/slimy-bikes-smile.md
@@ -1,0 +1,11 @@
+---
+"@fiber-pay/react": minor
+---
+
+Add extensibility APIs to `FiberNodeButton` without breaking default behavior:
+- configurable `tabs` (reorder, hide, add custom tabs)
+- `renderTabContent(tabId, context)` for per-tab content override
+- `renderAction(context)` for overriding built-in action UI/behavior
+- `t(key, fallback, vars?)` i18n hook for panel copy customization
+
+Also update `react-quick-card` with a custom tab mode demo and add tests covering extensibility paths and default compatibility.

--- a/apps/react-quick-card/src/App.tsx
+++ b/apps/react-quick-card/src/App.tsx
@@ -1,12 +1,17 @@
 import { ccc } from '@ckb-ccc/connector-react';
-import { FiberNodeButton, useFiberNode } from '@fiber-pay/react';
+import {
+  FiberNodeButton,
+  type FiberNodeButtonRenderAction,
+  type FiberNodeButtonTabConfig,
+  useFiberNode,
+} from '@fiber-pay/react';
 import {
   cccScriptToFiberScript,
   createCccSignFundingTx,
   resolveFundingLockCellDepsByKnownScript,
   type Script,
 } from '@fiber-pay/sdk/browser';
-import { type CSSProperties, useCallback, useEffect, useState } from 'react';
+import { type CSSProperties, useCallback, useEffect, useMemo, useState } from 'react';
 
 type ConnectStrategy = 'password' | 'passkey';
 
@@ -302,6 +307,7 @@ export function App() {
 
   const [strategy, setStrategy] = useState<ConnectStrategy>('password');
   const [externalWallet, setExternalWallet] = useState(false);
+  const [customTabMode, setCustomTabMode] = useState(false);
   const [password, setPassword] = useState('demo-secret');
   const [externalWalletAddress, setExternalWalletAddress] = useState<string | null>(null);
   const [eventLogs, setEventLogs] = useState<EventLogEntry[]>([]);
@@ -388,6 +394,78 @@ export function App() {
 
   const externalWalletToggleLocked = fiber.isRunning || fiber.isStarting;
 
+  const customI18n = useCallback((key: string, fallback: string) => {
+    const dictionary: Record<string, string> = {
+      'tabs.workbench': '操作台',
+      'tabs.channels': '通道',
+      'actions.payInvoice': '立即支付',
+      'actions.payInvoice.loading': '支付中...',
+      'workbench.payments.title': '支付操作',
+      'workbench.openChannel.title': '开通道',
+      'workbench.connectionPrep.title': '连接准备',
+    };
+
+    return dictionary[key] ?? fallback;
+  }, []);
+
+  const customTabs = useMemo<ReadonlyArray<FiberNodeButtonTabConfig>>(
+    () => [
+      { id: 'workbench' },
+      {
+        id: 'my-stats',
+        label: (t) => t('demo.customTab.title', 'My Stats'),
+        render: ({ state, t }) => (
+          <section style={{ border: '1px solid #dbe4f3', borderRadius: 10, padding: 10 }}>
+            <h4 style={{ margin: 0, fontSize: '0.86rem' }}>
+              {t('demo.customTab.heading', 'Custom Runtime Stats')}
+            </h4>
+            <p style={{ margin: '8px 0 0', fontSize: '0.78rem', color: '#475569' }}>
+              {t('demo.customTab.peerCount', 'Connected peers')}: {state.connectedPeers.length}
+            </p>
+            <p style={{ margin: '6px 0 0', fontSize: '0.78rem', color: '#475569' }}>
+              {t('demo.customTab.activeChannels', 'Active channels')}: {state.activeChannelCount}
+            </p>
+            <p style={{ margin: '6px 0 0', fontSize: '0.78rem', color: '#475569' }}>
+              {t('demo.customTab.paymentStatus', 'Payment status')}: {state.paymentResult?.status ?? 'Idle'}
+            </p>
+          </section>
+        ),
+      },
+      { id: 'channels' },
+      { id: 'diagnostics', hidden: true },
+    ],
+    [],
+  );
+
+  const customRenderAction = useCallback<FiberNodeButtonRenderAction>(({ id, defaultProps }) => {
+    if (id !== 'pay-invoice') {
+      return undefined;
+    }
+
+    return (
+      <button
+        type="button"
+        style={{
+          border: '1px solid #0f766e',
+          borderRadius: 8,
+          padding: '6px 10px',
+          background: '#0f766e',
+          color: '#fff',
+          fontSize: '0.78rem',
+          fontWeight: 700,
+          cursor: defaultProps.disabled ? 'not-allowed' : 'pointer',
+          opacity: defaultProps.disabled ? 0.6 : 1,
+        }}
+        disabled={defaultProps.disabled}
+        onClick={() => {
+          void defaultProps.onTrigger();
+        }}
+      >
+        {defaultProps.loading ? '支付中...' : '立即支付（自定义）'}
+      </button>
+    );
+  }, []);
+
   const hookStateItems = [
     { label: 'Node state', value: fiber.state },
     { label: 'Connected', value: fiber.isRunning ? 'Yes' : 'No' },
@@ -456,6 +534,35 @@ export function App() {
             <div style={styles.row}>
               <button
                 type="button"
+                onClick={() => setCustomTabMode(false)}
+                style={{
+                  ...styles.modeButton,
+                  ...(customTabMode ? {} : styles.modeButtonActive),
+                }}
+              >
+                Default Panel
+              </button>
+              <button
+                type="button"
+                onClick={() => setCustomTabMode(true)}
+                style={{
+                  ...styles.modeButton,
+                  ...(customTabMode ? styles.modeButtonActive : {}),
+                }}
+              >
+                Custom Tab Mode
+              </button>
+            </div>
+
+            <p style={styles.helperText}>
+              {customTabMode
+                ? 'Custom mode enabled: adds a My Stats tab, hides Diagnostics, localizes labels, and overrides Pay action button.'
+                : 'Default mode enabled: built-in tabs and default actions.'}
+            </p>
+
+            <div style={styles.row}>
+              <button
+                type="button"
                 onClick={() => setStrategy('password')}
                 style={{
                   ...styles.modeButton,
@@ -503,6 +610,9 @@ export function App() {
                 enabled: externalWallet,
                 resolve: resolveExternalFunding,
               }}
+              tabs={customTabMode ? customTabs : undefined}
+              t={customTabMode ? customI18n : undefined}
+              renderAction={customTabMode ? customRenderAction : undefined}
               renderConnectorSection={() => (
                 <div style={{ display: 'grid', gap: 6 }}>
                   <div style={{ fontSize: 12, color: '#475569' }}>

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -100,7 +100,7 @@ For external funding, pass `externalFunding` with an async `resolve` callback th
 
 - `tabs`: reorder / hide built-in tabs and add custom tabs
 - `renderTabContent(tabId, context)`: override tab body rendering
-- `renderAction(context)`: replace default action button UI/behavior for selected actions
+- `renderAction(context)`: replace default action button UI/behavior for selected actions (context includes `state`)
 - `t(key, fallback, vars?)`: localize labels and copy
 
 Render precedence for a tab body is:

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -103,6 +103,15 @@ For external funding, pass `externalFunding` with an async `resolve` callback th
 - `renderAction(context)`: replace default action button UI/behavior for selected actions
 - `t(key, fallback, vars?)`: localize labels and copy
 
+Render precedence for a tab body is:
+1. `renderTabContent(tabId, context)` when it returns a value other than `undefined`
+2. `tabs[i].render(context)` for the selected tab (including built-in tab ids)
+3. built-in tab body (`Workbench`, `Channels`, `Diagnostics`)
+
+`renderTabContent` semantics:
+- return `undefined` to fall back to the next renderer
+- return `null` to intentionally render an empty tab body
+
 ```tsx
 import { FiberNodeButton, useFiberNode } from '@fiber-pay/react';
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -94,6 +94,66 @@ export function WalletEntry() {
 For external funding, pass `externalFunding` with an async `resolve` callback that returns
 `signFundingTx` and optional script / dep overrides.
 
+### Customizing The Panel
+
+`FiberNodeButton` now supports additive panel customization without forking the component:
+
+- `tabs`: reorder / hide built-in tabs and add custom tabs
+- `renderTabContent(tabId, context)`: override tab body rendering
+- `renderAction(context)`: replace default action button UI/behavior for selected actions
+- `t(key, fallback, vars?)`: localize labels and copy
+
+```tsx
+import { FiberNodeButton, useFiberNode } from '@fiber-pay/react';
+
+export function CustomPanelDemo() {
+  const fiber = useFiberNode({ network: 'testnet', walletId: 'custom-panel-demo' });
+
+  return (
+    <FiberNodeButton
+      fiber={fiber}
+      strategy="passkey"
+      tabs={[
+        { id: 'workbench' },
+        {
+          id: 'my-stats',
+          label: 'My Stats',
+          render: ({ state }) => <div>Peers: {state.connectedPeers.length}</div>,
+        },
+        { id: 'channels' },
+        { id: 'diagnostics', hidden: true },
+      ]}
+      renderAction={({ id, defaultProps }) => {
+        if (id !== 'pay-invoice') {
+          return undefined;
+        }
+
+        return (
+          <button
+            type="button"
+            disabled={defaultProps.disabled}
+            onClick={() => {
+              void defaultProps.onTrigger();
+            }}
+          >
+            {defaultProps.loading ? 'Paying...' : 'Pay Now'}
+          </button>
+        );
+      }}
+      t={(key, fallback) => {
+        const zh: Record<string, string> = {
+          'tabs.workbench': '操作台',
+          'tabs.channels': '通道',
+          'actions.payInvoice': '立即支付',
+        };
+
+        return zh[key] ?? fallback;
+      }}
+    />
+  );
+}
+```
+
 `ConnectButton` uses explicit strategy selection and supports only `"passkey"` or `"password"`.
 
 For custom connected-state panels (for example peer/channel controls), use `renderConnectedDropdown`:

--- a/packages/react/src/fiber-node-button/channels-tab.tsx
+++ b/packages/react/src/fiber-node-button/channels-tab.tsx
@@ -1,14 +1,24 @@
+import type { UseFiberNodeResult } from '../use-fiber-node.js';
+import { renderPanelAction } from './render-action.js';
 import { styles } from './styles.js';
-import { FILTER_ITEMS } from './types.js';
+import {
+  FILTER_ITEMS,
+  type FiberNodeButtonActionDefaultProps,
+  type FiberNodeButtonRenderAction,
+  type FiberNodeButtonTabContext,
+} from './types.js';
 import type { FiberNodeButtonPanelState } from './use-panel-state.js';
 import { formatChannelBalance, shorten, withDisabledStyle } from './utils.js';
 
 export interface ChannelsTabProps {
   state: FiberNodeButtonPanelState;
+  fiber: UseFiberNodeResult;
   onLog?: (message: string) => void;
+  renderAction?: FiberNodeButtonRenderAction;
+  t: FiberNodeButtonTabContext['t'];
 }
 
-export function ChannelsTab({ state, onLog }: ChannelsTabProps) {
+export function ChannelsTab({ state, fiber, onLog, renderAction, t }: ChannelsTabProps) {
   const {
     isRefreshingChannels,
     refreshChannels,
@@ -30,7 +40,7 @@ export function ChannelsTab({ state, onLog }: ChannelsTabProps) {
     <>
       <section style={styles.section}>
         <div style={styles.rowBetween}>
-          <h4 style={styles.sectionTitle}>Channel Summary</h4>
+          <h4 style={styles.sectionTitle}>{t('channels.summary.title', 'Channel Summary')}</h4>
           <button
             type="button"
             style={withDisabledStyle(styles.actionButton, isRefreshingChannels)}
@@ -39,13 +49,17 @@ export function ChannelsTab({ state, onLog }: ChannelsTabProps) {
               void refreshChannels();
             }}
           >
-            {isRefreshingChannels ? 'Refreshing...' : 'Refresh'}
+            {isRefreshingChannels
+              ? t('channels.summary.refresh.loading', 'Refreshing...')
+              : t('channels.summary.refresh', 'Refresh')}
           </button>
         </div>
 
         <p style={styles.summaryInline}>
-          Active {channelCounts.active} | Pending {channelCounts.pending} | Closed{' '}
-          {channelCounts.closed} | Total {channelCounts.all}
+          {t('channels.summary.active', 'Active')} {channelCounts.active} |{' '}
+          {t('channels.summary.pending', 'Pending')} {channelCounts.pending} |{' '}
+          {t('channels.summary.closed', 'Closed')} {channelCounts.closed} |{' '}
+          {t('channels.summary.total', 'Total')} {channelCounts.all}
         </p>
 
         <div style={styles.filterBar}>
@@ -57,7 +71,7 @@ export function ChannelsTab({ state, onLog }: ChannelsTabProps) {
               onClick={() => setChannelFilter(filter)}
             >
               {filter === 'all'
-                ? `All (${channelCounts.all})`
+                ? `${t('channels.filter.all', 'All')} (${channelCounts.all})`
                 : `${filter} (${channelCounts[filter]})`}
             </button>
           ))}
@@ -65,7 +79,9 @@ export function ChannelsTab({ state, onLog }: ChannelsTabProps) {
 
         <div style={styles.list}>
           {visibleChannels.length === 0 ? (
-            <p style={styles.compactText}>No channels found for this filter.</p>
+            <p style={styles.compactText}>
+              {t('channels.list.empty', 'No channels found for this filter.')}
+            </p>
           ) : (
             visibleChannels.map((channel) => {
               const selected = channel.channel_id === selectedChannelId;
@@ -84,13 +100,19 @@ export function ChannelsTab({ state, onLog }: ChannelsTabProps) {
                   }}
                 >
                   <span style={styles.srOnly}>
-                    {selected ? 'Selected channel' : 'Select channel'}
+                    {selected
+                      ? t('channels.list.selected', 'Selected channel')
+                      : t('channels.list.select', 'Select channel')}
                   </span>
                   <span style={styles.compactChannelTop}>
-                    <span style={styles.inlineCode}>ID: {shorten(channel.channel_id, 12, 8)}</span>
+                    <span style={styles.inlineCode}>
+                      {t('channels.list.id', 'ID')}: {shorten(channel.channel_id, 12, 8)}
+                    </span>
                     <span style={styles.badge}>{channel.state.state_name}</span>
                   </span>
-                  <span style={styles.compactText}>Peer: {shorten(channel.pubkey, 16, 10)}</span>
+                  <span style={styles.compactText}>
+                    {t('channels.list.peer', 'Peer')}: {shorten(channel.pubkey, 16, 10)}
+                  </span>
                   <span style={styles.compactText}>
                     L {formatChannelBalance(channel.local_balance)} / R{' '}
                     {formatChannelBalance(channel.remote_balance)} CKB
@@ -105,71 +127,85 @@ export function ChannelsTab({ state, onLog }: ChannelsTabProps) {
       {selectedChannel ? (
         <section style={styles.detailPanel}>
           <div style={styles.rowBetween}>
-            <h4 style={styles.sectionTitle}>Channel Details</h4>
+            <h4 style={styles.sectionTitle}>{t('channels.details.title', 'Channel Details')}</h4>
             <span style={styles.badge}>{selectedChannel.state.state_name}</span>
           </div>
 
-          <p style={styles.inlineCode}>Channel ID: {selectedChannel.channel_id}</p>
-          <p style={styles.inlineCode}>Peer: {selectedChannel.pubkey}</p>
+          <p style={styles.inlineCode}>
+            {t('channels.details.channelId', 'Channel ID')}: {selectedChannel.channel_id}
+          </p>
+          <p style={styles.inlineCode}>
+            {t('channels.details.peer', 'Peer')}: {selectedChannel.pubkey}
+          </p>
 
           <div style={styles.row}>
             <span style={styles.badge}>
-              Local {formatChannelBalance(selectedChannel.local_balance)} CKB
+              {t('channels.details.local', 'Local')}{' '}
+              {formatChannelBalance(selectedChannel.local_balance)} CKB
             </span>
             <span style={styles.badge}>
-              Remote {formatChannelBalance(selectedChannel.remote_balance)} CKB
+              {t('channels.details.remote', 'Remote')}{' '}
+              {formatChannelBalance(selectedChannel.remote_balance)} CKB
             </span>
             <span
               style={styles.badge}
               title="Pending TLCs are in-flight payment locks associated with this channel."
             >
-              TLCs {selectedChannel.pending_tlcs.length}
+              {t('channels.details.tlcs', 'TLCs')} {selectedChannel.pending_tlcs.length}
             </span>
           </div>
 
           {selectedChannel.failure_detail ? (
-            <p style={styles.compactText}>Failure: {selectedChannel.failure_detail}</p>
+            <p style={styles.compactText}>
+              {t('channels.details.failure', 'Failure')}: {selectedChannel.failure_detail}
+            </p>
           ) : null}
 
           {selectedChannel.shutdown_transaction_hash ? (
             <p style={styles.inlineCode}>
-              Shutdown TX: {selectedChannel.shutdown_transaction_hash}
+              {t('channels.details.shutdownTx', 'Shutdown TX')}:{' '}
+              {selectedChannel.shutdown_transaction_hash}
             </p>
           ) : null}
 
           <div style={{ ...styles.row, justifyContent: 'flex-end' }}>
-            <button
-              type="button"
-              style={withDisabledStyle(styles.actionButton, !selectedCanClose || selectedIsClosing)}
-              disabled={!selectedCanClose || selectedIsClosing}
-              onClick={() => {
-                if (!selectedChannel) {
-                  return;
-                }
-                void closeChannel(selectedChannel.channel_id, false);
-              }}
-            >
-              {selectedIsClosing
-                ? 'Closing...'
-                : selectedPending
-                  ? 'Abandon Pending'
-                  : 'Close Channel'}
-            </button>
+            {renderPanelAction({
+              id: 'close-channel',
+              fiber,
+              renderAction,
+              t,
+              defaultProps: {
+                id: 'close-channel',
+                channelId: selectedChannel.channel_id,
+                label: selectedPending
+                  ? t('actions.abandonPending', 'Abandon Pending')
+                  : t('actions.closeChannel', 'Close Channel'),
+                loadingLabel: t('actions.closeChannel.loading', 'Closing...'),
+                disabled: !selectedCanClose || selectedIsClosing,
+                loading: selectedIsClosing,
+                onTrigger: async () => {
+                  await closeChannel(selectedChannel.channel_id, false);
+                },
+              } satisfies FiberNodeButtonActionDefaultProps,
+            })}
 
-            <button
-              type="button"
-              style={withDisabledStyle(
-                styles.dangerButton,
-                !selectedCanClose || selectedPending || selectedIsClosing,
-              )}
-              disabled={!selectedCanClose || selectedPending || selectedIsClosing}
-              onClick={() => {
-                setForceCloseConfirmOpen(true);
-                onLog?.('fiber_channel_force_close_confirm_opened');
-              }}
-            >
-              Force Close
-            </button>
+            {renderPanelAction({
+              id: 'force-close-channel',
+              fiber,
+              renderAction,
+              t,
+              buttonStyle: styles.dangerButton,
+              defaultProps: {
+                id: 'force-close-channel',
+                channelId: selectedChannel.channel_id,
+                label: t('actions.forceClose', 'Force Close'),
+                disabled: !selectedCanClose || selectedPending || selectedIsClosing,
+                onTrigger: () => {
+                  setForceCloseConfirmOpen(true);
+                  onLog?.('fiber_channel_force_close_confirm_opened');
+                },
+              } satisfies FiberNodeButtonActionDefaultProps,
+            })}
           </div>
         </section>
       ) : null}

--- a/packages/react/src/fiber-node-button/channels-tab.tsx
+++ b/packages/react/src/fiber-node-button/channels-tab.tsx
@@ -172,6 +172,7 @@ export function ChannelsTab({ state, fiber, onLog, renderAction, t }: ChannelsTa
             {renderPanelAction({
               id: 'close-channel',
               fiber,
+              state,
               renderAction,
               t,
               defaultProps: {
@@ -192,6 +193,7 @@ export function ChannelsTab({ state, fiber, onLog, renderAction, t }: ChannelsTa
             {renderPanelAction({
               id: 'force-close-channel',
               fiber,
+              state,
               renderAction,
               t,
               buttonStyle: styles.dangerButton,

--- a/packages/react/src/fiber-node-button/diagnostics-tab.tsx
+++ b/packages/react/src/fiber-node-button/diagnostics-tab.tsx
@@ -1,12 +1,14 @@
 import { styles } from './styles.js';
+import type { FiberNodeButtonTabContext } from './types.js';
 import type { FiberNodeButtonPanelState } from './use-panel-state.js';
 import { formatChannelBalance, shorten, withDisabledStyle } from './utils.js';
 
 export interface DiagnosticsTabProps {
   state: FiberNodeButtonPanelState;
+  t: FiberNodeButtonTabContext['t'];
 }
 
-export function DiagnosticsTab({ state }: DiagnosticsTabProps) {
+export function DiagnosticsTab({ state, t }: DiagnosticsTabProps) {
   const {
     isRefreshingPeers,
     refreshConnectedPeers,
@@ -29,7 +31,7 @@ export function DiagnosticsTab({ state }: DiagnosticsTabProps) {
     <>
       <section style={styles.section}>
         <div style={styles.rowBetween}>
-          <h4 style={styles.sectionTitle}>Connected Peers</h4>
+          <h4 style={styles.sectionTitle}>{t('diagnostics.peers.title', 'Connected Peers')}</h4>
           <button
             type="button"
             style={withDisabledStyle(styles.actionButton, isRefreshingPeers)}
@@ -38,21 +40,27 @@ export function DiagnosticsTab({ state }: DiagnosticsTabProps) {
               void refreshConnectedPeers();
             }}
           >
-            {isRefreshingPeers ? 'Refreshing...' : 'Refresh Peers'}
+            {isRefreshingPeers
+              ? t('diagnostics.peers.refresh.loading', 'Refreshing...')
+              : t('diagnostics.peers.refresh', 'Refresh Peers')}
           </button>
         </div>
 
-        <p style={styles.compactText}>Peers: {connectedPeers.length}</p>
+        <p style={styles.compactText}>
+          {t('diagnostics.peers.count', 'Peers')}: {connectedPeers.length}
+        </p>
 
         <div style={{ ...styles.list, maxHeight: '190px' }}>
           {connectedPeers.length === 0 ? (
-            <p style={styles.compactText}>No connected peers.</p>
+            <p style={styles.compactText}>{t('diagnostics.peers.empty', 'No connected peers.')}</p>
           ) : (
             connectedPeers.map((peer) => (
               <article key={peer.pubkey} style={styles.compactChannelRow}>
                 <p style={styles.inlineCode}>{shorten(peer.pubkey, 18, 12)}</p>
                 <details>
-                  <summary style={{ ...styles.compactText, cursor: 'pointer' }}>Address</summary>
+                  <summary style={{ ...styles.compactText, cursor: 'pointer' }}>
+                    {t('diagnostics.peers.address', 'Address')}
+                  </summary>
                   <p style={styles.inlineCode}>{peer.address}</p>
                 </details>
                 <div style={styles.row}>
@@ -64,7 +72,7 @@ export function DiagnosticsTab({ state }: DiagnosticsTabProps) {
                       switchTab('workbench');
                     }}
                   >
-                    Use for Open Channel
+                    {t('diagnostics.peers.useForOpenChannel', 'Use for Open Channel')}
                   </button>
                 </div>
               </article>
@@ -73,7 +81,7 @@ export function DiagnosticsTab({ state }: DiagnosticsTabProps) {
         </div>
 
         <label style={styles.fieldLabel}>
-          Connect Peer Address
+          {t('diagnostics.peers.connectPeerAddress', 'Connect Peer Address')}
           <input
             style={styles.input}
             value={peerAddress}
@@ -91,7 +99,9 @@ export function DiagnosticsTab({ state }: DiagnosticsTabProps) {
               void connectPeerByAddress();
             }}
           >
-            {isConnectingPeer ? 'Connecting...' : 'Connect Peer'}
+            {isConnectingPeer
+              ? t('diagnostics.peers.connect.loading', 'Connecting...')
+              : t('diagnostics.peers.connect', 'Connect Peer')}
           </button>
 
           <button
@@ -102,14 +112,16 @@ export function DiagnosticsTab({ state }: DiagnosticsTabProps) {
               void refreshDiagnostics();
             }}
           >
-            {isRefreshingPeers || isRefreshingGraph ? 'Refreshing...' : 'Refresh All'}
+            {isRefreshingPeers || isRefreshingGraph
+              ? t('diagnostics.peers.refreshAll.loading', 'Refreshing...')
+              : t('diagnostics.peers.refreshAll', 'Refresh All')}
           </button>
         </div>
       </section>
 
       <section style={styles.section}>
         <div style={styles.rowBetween}>
-          <h4 style={styles.sectionTitle}>Graph Snapshot</h4>
+          <h4 style={styles.sectionTitle}>{t('diagnostics.graph.title', 'Graph Snapshot')}</h4>
           <button
             type="button"
             style={withDisabledStyle(styles.actionButton, isRefreshingGraph)}
@@ -118,13 +130,18 @@ export function DiagnosticsTab({ state }: DiagnosticsTabProps) {
               void refreshGraph();
             }}
           >
-            {isRefreshingGraph ? 'Refreshing...' : 'Refresh Graph'}
+            {isRefreshingGraph
+              ? t('diagnostics.graph.refresh.loading', 'Refreshing...')
+              : t('diagnostics.graph.refresh', 'Refresh Graph')}
           </button>
         </div>
 
         <p style={styles.compactText}>
-          showing {Math.min(graphNodes.length, 3)} of {graphNodes.length} nodes,{' '}
-          {Math.min(graphChannels.length, 2)} of {graphChannels.length} channels.
+          {t('diagnostics.graph.showing', 'showing')} {Math.min(graphNodes.length, 3)}{' '}
+          {t('diagnostics.graph.of', 'of')} {graphNodes.length}{' '}
+          {t('diagnostics.graph.nodes', 'nodes')}, {Math.min(graphChannels.length, 2)}{' '}
+          {t('diagnostics.graph.of', 'of')} {graphChannels.length}{' '}
+          {t('diagnostics.graph.channels', 'channels')}.
         </p>
 
         {graphNodes.slice(0, 3).map((node) => (
@@ -144,7 +161,9 @@ export function DiagnosticsTab({ state }: DiagnosticsTabProps) {
         ))}
 
         <details>
-          <summary style={{ ...styles.compactText, cursor: 'pointer' }}>Raw graph snapshot</summary>
+          <summary style={{ ...styles.compactText, cursor: 'pointer' }}>
+            {t('diagnostics.graph.rawSnapshot', 'Raw graph snapshot')}
+          </summary>
           <pre
             style={{
               ...styles.inlineCode,

--- a/packages/react/src/fiber-node-button/i18n.ts
+++ b/packages/react/src/fiber-node-button/i18n.ts
@@ -1,0 +1,15 @@
+import type { FiberNodeButtonI18n } from './types.js';
+
+function applyVariables(template: string, vars?: Record<string, string | number>): string {
+  if (!vars) {
+    return template;
+  }
+
+  return template.replace(/\{(\w+)\}/g, (full, key: string) => {
+    const value = vars[key];
+    return value === undefined ? full : String(value);
+  });
+}
+
+export const defaultFiberNodeButtonI18n: FiberNodeButtonI18n = (_key, fallback, vars) =>
+  applyVariables(fallback, vars);

--- a/packages/react/src/fiber-node-button/index.tsx
+++ b/packages/react/src/fiber-node-button/index.tsx
@@ -5,11 +5,20 @@ import { FiberNodeButtonPanel } from './panel.js';
 import type { FiberNodeButtonProps } from './types.js';
 
 export type {
+  FiberNodeButtonActionDefaultProps,
+  FiberNodeButtonActionId,
   FiberNodeButtonConnectorSectionContext,
   FiberNodeButtonExternalFundingConfig,
   FiberNodeButtonExternalFundingResolved,
   FiberNodeButtonExternalFundingResolverContext,
+  FiberNodeButtonI18n,
   FiberNodeButtonProps,
+  FiberNodeButtonRenderAction,
+  FiberNodeButtonRenderActionContext,
+  FiberNodeButtonTabActions,
+  FiberNodeButtonTabConfig,
+  FiberNodeButtonTabContext,
+  FiberNodeButtonTabId,
 } from './types.js';
 
 export function FiberNodeButton(props: FiberNodeButtonProps) {
@@ -35,6 +44,10 @@ export function FiberNodeButton(props: FiberNodeButtonProps) {
     initialFundingAmountCkb = '1000',
     externalFunding,
     renderConnectorSection,
+    tabs,
+    renderTabContent,
+    renderAction,
+    t,
   } = props;
 
   const managedFiber = useFiberNode({
@@ -68,6 +81,10 @@ export function FiberNodeButton(props: FiberNodeButtonProps) {
         initialFundingAmountCkb={initialFundingAmountCkb}
         externalFunding={externalFunding}
         renderConnectorSection={renderConnectorSection}
+        tabs={tabs}
+        renderTabContent={renderTabContent}
+        renderAction={renderAction}
+        t={t}
       />
     ),
     [
@@ -79,7 +96,11 @@ export function FiberNodeButton(props: FiberNodeButtonProps) {
       network,
       onError,
       onLog,
+      renderAction,
       renderConnectorSection,
+      renderTabContent,
+      t,
+      tabs,
     ],
   );
 

--- a/packages/react/src/fiber-node-button/panel.tsx
+++ b/packages/react/src/fiber-node-button/panel.tsx
@@ -1,14 +1,106 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import { ChannelsTab } from './channels-tab.js';
 import { DiagnosticsTab } from './diagnostics-tab.js';
+import { defaultFiberNodeButtonI18n } from './i18n.js';
 import { styles } from './styles.js';
-import { type FiberNodeButtonPanelProps, TAB_ITEMS } from './types.js';
+import {
+  type FiberNodeButtonPanelProps,
+  type FiberNodeButtonTabConfig,
+  type FiberNodeButtonTabContext,
+  type FiberNodeButtonTabId,
+  TAB_ITEMS,
+} from './types.js';
 import { useFiberNodeButtonPanelState } from './use-panel-state.js';
 import { shorten, summarizeError } from './utils.js';
 import { WorkbenchTab } from './workbench-tab.js';
 
+interface ResolvedTabItem {
+  id: FiberNodeButtonTabId;
+  label: string;
+  render?: FiberNodeButtonTabConfig['render'];
+}
+
+function resolveTabLabel(tabId: FiberNodeButtonTabId, t: FiberNodeButtonTabContext['t']): string {
+  const builtIn = TAB_ITEMS.find((item) => item.id === tabId);
+  if (!builtIn) {
+    return tabId;
+  }
+
+  if (builtIn.id === 'workbench') {
+    return t('tabs.workbench', builtIn.label);
+  }
+  if (builtIn.id === 'channels') {
+    return t('tabs.channels', builtIn.label);
+  }
+  return t('tabs.diagnostics', builtIn.label);
+}
+
+function resolveTabs(
+  tabs: ReadonlyArray<FiberNodeButtonTabConfig> | undefined,
+  t: FiberNodeButtonTabContext['t'],
+): ResolvedTabItem[] {
+  const defaultIds = TAB_ITEMS.map((item) => item.id);
+
+  if (!tabs || tabs.length === 0) {
+    return defaultIds.map((id) => ({ id, label: resolveTabLabel(id, t) }));
+  }
+
+  const tabConfigById = new Map<FiberNodeButtonTabId, FiberNodeButtonTabConfig>();
+  const orderedIds: FiberNodeButtonTabId[] = [];
+
+  for (const tabConfig of tabs) {
+    tabConfigById.set(tabConfig.id, tabConfig);
+    if (!orderedIds.includes(tabConfig.id)) {
+      orderedIds.push(tabConfig.id);
+    }
+  }
+
+  for (const id of defaultIds) {
+    if (!orderedIds.includes(id)) {
+      orderedIds.push(id);
+    }
+  }
+
+  const resolvedTabs: ResolvedTabItem[] = [];
+
+  for (const id of orderedIds) {
+    const config = tabConfigById.get(id);
+    if (config?.hidden) {
+      continue;
+    }
+
+    const label =
+      typeof config?.label === 'function'
+        ? config.label(t)
+        : (config?.label ?? resolveTabLabel(id, t));
+
+    const tabItem: ResolvedTabItem = {
+      id,
+      label,
+    };
+
+    if (config?.render) {
+      tabItem.render = config.render;
+    }
+
+    resolvedTabs.push(tabItem);
+  }
+
+  return resolvedTabs;
+}
+
 export function FiberNodeButtonPanel(props: FiberNodeButtonPanelProps) {
-  const { dropdownContext, fiber, onLog, externalFunding, renderConnectorSection } = props;
+  const {
+    dropdownContext,
+    fiber,
+    onLog,
+    externalFunding,
+    renderConnectorSection,
+    tabs,
+    renderTabContent,
+    renderAction,
+  } = props;
+  const t = props.t ?? defaultFiberNodeButtonI18n;
   const state = useFiberNodeButtonPanelState(props);
   const forceCloseDialogRef = useRef<HTMLDivElement | null>(null);
 
@@ -26,11 +118,99 @@ export function FiberNodeButtonPanel(props: FiberNodeButtonPanelProps) {
     closeChannel,
   } = state;
 
+  const tabActions = useMemo<FiberNodeButtonTabContext['actions']>(
+    () => ({
+      openChannel: async () => {
+        await state.openChannel();
+      },
+      createInvoice: async () => {
+        await state.createInvoice();
+      },
+      payInvoice: async () => {
+        await state.submitPayment();
+      },
+      closeChannel: async (channelId: string) => {
+        await state.closeChannel(channelId, false);
+      },
+      forceCloseChannel: async (channelId: string) => {
+        await state.closeChannel(channelId, true);
+      },
+    }),
+    [state],
+  );
+
+  const tabContext = useMemo<FiberNodeButtonTabContext>(
+    () => ({
+      fiber,
+      state,
+      externalFundingEnabled: !!externalFunding?.enabled,
+      t,
+      actions: tabActions,
+    }),
+    [externalFunding?.enabled, fiber, state, t, tabActions],
+  );
+
+  const resolvedTabs = useMemo(() => resolveTabs(tabs, t), [t, tabs]);
+
+  const tabListStyle = useMemo(
+    () => ({
+      ...styles.tabList,
+      gridTemplateColumns: `repeat(${Math.max(1, resolvedTabs.length)}, minmax(0, 1fr))`,
+    }),
+    [resolvedTabs.length],
+  );
+
+  const selectedResolvedTab = useMemo(
+    () => resolvedTabs.find((tab) => tab.id === activeTab),
+    [activeTab, resolvedTabs],
+  );
+
+  const overriddenTabContent = renderTabContent?.(activeTab, tabContext);
+
+  let tabContent = overriddenTabContent;
+  if (tabContent === undefined) {
+    if (activeTab === 'workbench') {
+      tabContent = (
+        <WorkbenchTab
+          state={state}
+          fiber={fiber}
+          externalFunding={externalFunding}
+          renderConnectorSection={renderConnectorSection}
+          renderAction={renderAction}
+          t={t}
+        />
+      );
+    } else if (activeTab === 'channels') {
+      tabContent = (
+        <ChannelsTab state={state} onLog={onLog} renderAction={renderAction} t={t} fiber={fiber} />
+      );
+    } else if (activeTab === 'diagnostics') {
+      tabContent = <DiagnosticsTab state={state} t={t} />;
+    } else if (selectedResolvedTab?.render) {
+      tabContent = selectedResolvedTab.render(tabContext);
+    } else {
+      tabContent = (
+        <div style={styles.notice}>
+          {t('tabs.unimplemented', 'Tab content is not implemented.')}
+        </div>
+      );
+    }
+  }
+
   useEffect(() => {
     if (forceCloseConfirmOpen) {
       forceCloseDialogRef.current?.focus();
     }
   }, [forceCloseConfirmOpen]);
+
+  useEffect(() => {
+    if (resolvedTabs.length === 0) {
+      return;
+    }
+    if (!resolvedTabs.some((tab) => tab.id === activeTab)) {
+      switchTab(resolvedTabs[0].id);
+    }
+  }, [activeTab, resolvedTabs, switchTab]);
 
   return (
     <div style={styles.shell}>
@@ -51,7 +231,7 @@ export function FiberNodeButtonPanel(props: FiberNodeButtonPanelProps) {
                 aria-hidden="true"
               />
               <span style={styles.metricMain}>{fiber.state}</span>
-              <span style={styles.metricSub}>Node</span>
+              <span style={styles.metricSub}>{t('metrics.node', 'Node')}</span>
             </span>
 
             <span style={styles.metricDivider} aria-hidden="true">
@@ -60,9 +240,11 @@ export function FiberNodeButtonPanel(props: FiberNodeButtonPanelProps) {
 
             <span style={styles.metricInline}>
               <span style={styles.metricMain}>
-                {externalFunding?.enabled ? 'External' : 'Internal'}
+                {externalFunding?.enabled
+                  ? t('metrics.funding.external', 'External')
+                  : t('metrics.funding.internal', 'Internal')}
               </span>
-              <span style={styles.metricSub}>Funding</span>
+              <span style={styles.metricSub}>{t('metrics.funding', 'Funding')}</span>
             </span>
 
             <span style={styles.metricDivider} aria-hidden="true">
@@ -71,7 +253,7 @@ export function FiberNodeButtonPanel(props: FiberNodeButtonPanelProps) {
 
             <span style={styles.metricInline}>
               <span style={styles.metricMain}>{activeChannelCount}</span>
-              <span style={styles.metricSub}>Active</span>
+              <span style={styles.metricSub}>{t('metrics.active', 'Active')}</span>
             </span>
 
             <span style={styles.metricDivider} aria-hidden="true">
@@ -80,7 +262,7 @@ export function FiberNodeButtonPanel(props: FiberNodeButtonPanelProps) {
 
             <span style={styles.metricInline}>
               <span style={styles.metricMain}>{connectedPeers.length}</span>
-              <span style={styles.metricSub}>Peers</span>
+              <span style={styles.metricSub}>{t('metrics.peers', 'Peers')}</span>
             </span>
 
             {latestError ? (
@@ -96,7 +278,7 @@ export function FiberNodeButtonPanel(props: FiberNodeButtonPanelProps) {
                     }}
                     aria-hidden="true"
                   />
-                  <span style={styles.metricMain}>Error</span>
+                  <span style={styles.metricMain}>{t('metrics.error', 'Error')}</span>
                 </span>
               </>
             ) : null}
@@ -109,9 +291,9 @@ export function FiberNodeButtonPanel(props: FiberNodeButtonPanelProps) {
               onClick={() => {
                 void dropdownContext.disconnect();
               }}
-              aria-label="Disconnect node"
+              aria-label={t('actions.disconnect.aria', 'Disconnect node')}
             >
-              Disconnect
+              {t('actions.disconnect', 'Disconnect')}
             </button>
             <button
               type="button"
@@ -119,25 +301,28 @@ export function FiberNodeButtonPanel(props: FiberNodeButtonPanelProps) {
               onClick={() => {
                 dropdownContext.closeDropdown();
               }}
-              aria-label="Close panel"
+              aria-label={t('actions.closePanel.aria', 'Close panel')}
             >
-              Close Panel
+              {t('actions.closePanel', 'Close Panel')}
             </button>
           </div>
         </div>
 
         <div style={styles.globalMeta}>
           <p style={styles.inlineCode}>
-            Node: {fiber.nodeInfo?.pubkey ? shorten(fiber.nodeInfo.pubkey, 18, 12) : 'N/A'}
+            {t('meta.node', 'Node')}:{' '}
+            {fiber.nodeInfo?.pubkey ? shorten(fiber.nodeInfo.pubkey, 18, 12) : t('meta.na', 'N/A')}
           </p>
           {latestError ? (
-            <p style={styles.globalErrorInline}>Recent error: {summarizeError(latestError, 92)}</p>
+            <p style={styles.globalErrorInline}>
+              {t('meta.recentError', 'Recent error')}: {summarizeError(latestError, 92)}
+            </p>
           ) : null}
         </div>
       </header>
 
-      <div role="tablist" aria-label="Fiber panel tabs" style={styles.tabList}>
-        {TAB_ITEMS.map((tab) => {
+      <div role="tablist" aria-label={t('tabs.aria', 'Fiber panel tabs')} style={tabListStyle}>
+        {resolvedTabs.map((tab) => {
           const selected = activeTab === tab.id;
           return (
             <button
@@ -173,18 +358,7 @@ export function FiberNodeButtonPanel(props: FiberNodeButtonPanelProps) {
           </div>
         ) : null}
 
-        {activeTab === 'workbench' ? (
-          <WorkbenchTab
-            state={state}
-            fiber={fiber}
-            externalFunding={externalFunding}
-            renderConnectorSection={renderConnectorSection}
-          />
-        ) : null}
-
-        {activeTab === 'channels' ? <ChannelsTab state={state} onLog={onLog} /> : null}
-
-        {activeTab === 'diagnostics' ? <DiagnosticsTab state={state} /> : null}
+        {tabContent}
 
         {latestError ? <div style={styles.errorNotice}>{latestError}</div> : null}
       </div>
@@ -195,7 +369,7 @@ export function FiberNodeButtonPanel(props: FiberNodeButtonPanelProps) {
             ref={forceCloseDialogRef}
             role="dialog"
             aria-modal="true"
-            aria-label="Force close confirmation"
+            aria-label={t('dialog.forceClose.aria', 'Force close confirmation')}
             tabIndex={-1}
             style={styles.dialogCard}
             onKeyDown={(event) => {
@@ -204,13 +378,19 @@ export function FiberNodeButtonPanel(props: FiberNodeButtonPanelProps) {
               }
             }}
           >
-            <h4 style={styles.sectionTitle}>Force close this channel?</h4>
+            <h4 style={styles.sectionTitle}>
+              {t('dialog.forceClose.title', 'Force close this channel?')}
+            </h4>
             <p style={styles.compactText}>
-              This action may immediately broadcast a unilateral close transaction, can lock
-              liquidity until settlement, and may produce additional fees. Continue only if normal
-              close cannot proceed.
+              {t(
+                'dialog.forceClose.description',
+                'This action may immediately broadcast a unilateral close transaction, can lock liquidity until settlement, and may produce additional fees. Continue only if normal close cannot proceed.',
+              )}
             </p>
-            <p style={styles.inlineCode}>Channel: {shorten(selectedChannel.channel_id, 20, 12)}</p>
+            <p style={styles.inlineCode}>
+              {t('dialog.forceClose.channel', 'Channel')}:{' '}
+              {shorten(selectedChannel.channel_id, 20, 12)}
+            </p>
             <div style={{ ...styles.row, justifyContent: 'flex-end' }}>
               <button
                 type="button"
@@ -219,7 +399,7 @@ export function FiberNodeButtonPanel(props: FiberNodeButtonPanelProps) {
                   setForceCloseConfirmOpen(false);
                 }}
               >
-                Cancel
+                {t('dialog.forceClose.cancel', 'Cancel')}
               </button>
               <button
                 type="button"
@@ -230,7 +410,7 @@ export function FiberNodeButtonPanel(props: FiberNodeButtonPanelProps) {
                   void closeChannel(selectedChannel.channel_id, true);
                 }}
               >
-                Confirm Force Close
+                {t('dialog.forceClose.confirm', 'Confirm Force Close')}
               </button>
             </div>
           </div>

--- a/packages/react/src/fiber-node-button/panel.tsx
+++ b/packages/react/src/fiber-node-button/panel.tsx
@@ -16,8 +16,19 @@ import { WorkbenchTab } from './workbench-tab.js';
 
 interface ResolvedTabItem {
   id: FiberNodeButtonTabId;
+  domId: string;
   label: string;
   render?: FiberNodeButtonTabConfig['render'];
+}
+
+function toDomSafeTabId(tabId: FiberNodeButtonTabId, index: number): string {
+  const normalized = tabId
+    .trim()
+    .replace(/[^A-Za-z0-9_-]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+
+  const safeBase = normalized.length > 0 ? normalized : 'tab';
+  return `${safeBase}-${index + 1}`;
 }
 
 function resolveTabLabel(tabId: FiberNodeButtonTabId, t: FiberNodeButtonTabContext['t']): string {
@@ -42,7 +53,11 @@ function resolveTabs(
   const defaultIds = TAB_ITEMS.map((item) => item.id);
 
   if (!tabs || tabs.length === 0) {
-    return defaultIds.map((id) => ({ id, label: resolveTabLabel(id, t) }));
+    return defaultIds.map((id, index) => ({
+      id,
+      domId: toDomSafeTabId(id, index),
+      label: resolveTabLabel(id, t),
+    }));
   }
 
   const tabConfigById = new Map<FiberNodeButtonTabId, FiberNodeButtonTabConfig>();
@@ -63,7 +78,7 @@ function resolveTabs(
 
   const resolvedTabs: ResolvedTabItem[] = [];
 
-  for (const id of orderedIds) {
+  for (const [index, id] of orderedIds.entries()) {
     const config = tabConfigById.get(id);
     if (config?.hidden) {
       continue;
@@ -76,6 +91,7 @@ function resolveTabs(
 
     const tabItem: ResolvedTabItem = {
       id,
+      domId: toDomSafeTabId(id, index),
       label,
     };
 
@@ -116,27 +132,30 @@ export function FiberNodeButtonPanel(props: FiberNodeButtonPanelProps) {
     setForceCloseConfirmOpen,
     selectedChannel,
     closeChannel,
+    openChannel,
+    createInvoice,
+    submitPayment,
   } = state;
 
   const tabActions = useMemo<FiberNodeButtonTabContext['actions']>(
     () => ({
       openChannel: async () => {
-        await state.openChannel();
+        await openChannel();
       },
       createInvoice: async () => {
-        await state.createInvoice();
+        await createInvoice();
       },
       payInvoice: async () => {
-        await state.submitPayment();
+        await submitPayment();
       },
       closeChannel: async (channelId: string) => {
-        await state.closeChannel(channelId, false);
+        await closeChannel(channelId, false);
       },
       forceCloseChannel: async (channelId: string) => {
-        await state.closeChannel(channelId, true);
+        await closeChannel(channelId, true);
       },
     }),
-    [state],
+    [closeChannel, createInvoice, openChannel, submitPayment],
   );
 
   const tabContext = useMemo<FiberNodeButtonTabContext>(
@@ -152,24 +171,35 @@ export function FiberNodeButtonPanel(props: FiberNodeButtonPanelProps) {
 
   const resolvedTabs = useMemo(() => resolveTabs(tabs, t), [t, tabs]);
 
+  const effectiveActiveTab = useMemo(
+    () =>
+      resolvedTabs.some((tab) => tab.id === activeTab) ? activeTab : (resolvedTabs[0]?.id ?? null),
+    [activeTab, resolvedTabs],
+  );
+
+  const selectedResolvedTab = useMemo(
+    () => resolvedTabs.find((tab) => tab.id === effectiveActiveTab) ?? null,
+    [effectiveActiveTab, resolvedTabs],
+  );
+
   const tabListStyle = useMemo(
     () => ({
       ...styles.tabList,
-      gridTemplateColumns: `repeat(${Math.max(1, resolvedTabs.length)}, minmax(0, 1fr))`,
+      gridTemplateColumns: `repeat(${Math.max(1, resolvedTabs.length)}, minmax(112px, 1fr))`,
+      overflowX: 'auto' as const,
     }),
     [resolvedTabs.length],
   );
 
-  const selectedResolvedTab = useMemo(
-    () => resolvedTabs.find((tab) => tab.id === activeTab),
-    [activeTab, resolvedTabs],
-  );
-
-  const overriddenTabContent = renderTabContent?.(activeTab, tabContext);
+  const overriddenTabContent = effectiveActiveTab
+    ? renderTabContent?.(effectiveActiveTab, tabContext)
+    : undefined;
 
   let tabContent = overriddenTabContent;
   if (tabContent === undefined) {
-    if (activeTab === 'workbench') {
+    if (selectedResolvedTab?.render) {
+      tabContent = selectedResolvedTab.render(tabContext);
+    } else if (effectiveActiveTab === 'workbench') {
       tabContent = (
         <WorkbenchTab
           state={state}
@@ -180,14 +210,16 @@ export function FiberNodeButtonPanel(props: FiberNodeButtonPanelProps) {
           t={t}
         />
       );
-    } else if (activeTab === 'channels') {
+    } else if (effectiveActiveTab === 'channels') {
       tabContent = (
         <ChannelsTab state={state} onLog={onLog} renderAction={renderAction} t={t} fiber={fiber} />
       );
-    } else if (activeTab === 'diagnostics') {
+    } else if (effectiveActiveTab === 'diagnostics') {
       tabContent = <DiagnosticsTab state={state} t={t} />;
-    } else if (selectedResolvedTab?.render) {
-      tabContent = selectedResolvedTab.render(tabContext);
+    } else if (effectiveActiveTab === null) {
+      tabContent = (
+        <div style={styles.notice}>{t('tabs.empty', 'No visible tabs are configured.')}</div>
+      );
     } else {
       tabContent = (
         <div style={styles.notice}>
@@ -323,15 +355,15 @@ export function FiberNodeButtonPanel(props: FiberNodeButtonPanelProps) {
 
       <div role="tablist" aria-label={t('tabs.aria', 'Fiber panel tabs')} style={tabListStyle}>
         {resolvedTabs.map((tab) => {
-          const selected = activeTab === tab.id;
+          const selected = effectiveActiveTab === tab.id;
           return (
             <button
               key={tab.id}
-              id={`${tabPanelId}-tab-${tab.id}`}
+              id={`${tabPanelId}-tab-${tab.domId}`}
               type="button"
               role="tab"
               aria-selected={selected}
-              aria-controls={selected ? `${tabPanelId}-panel-${tab.id}` : undefined}
+              aria-controls={selected ? `${tabPanelId}-panel-${tab.domId}` : undefined}
               style={selected ? styles.tabButtonActive : styles.tabButton}
               onClick={() => switchTab(tab.id)}
             >
@@ -342,9 +374,11 @@ export function FiberNodeButtonPanel(props: FiberNodeButtonPanelProps) {
       </div>
 
       <div
-        id={`${tabPanelId}-panel-${activeTab}`}
+        id={`${tabPanelId}-panel-${selectedResolvedTab?.domId ?? 'empty'}`}
         role="tabpanel"
-        aria-labelledby={`${tabPanelId}-tab-${activeTab}`}
+        aria-labelledby={
+          selectedResolvedTab ? `${tabPanelId}-tab-${selectedResolvedTab.domId}` : undefined
+        }
         style={styles.content}
       >
         {statusNotice ? (

--- a/packages/react/src/fiber-node-button/render-action.tsx
+++ b/packages/react/src/fiber-node-button/render-action.tsx
@@ -1,0 +1,49 @@
+import type { CSSProperties, ReactNode } from 'react';
+import type { UseFiberNodeResult } from '../use-fiber-node.js';
+import { styles } from './styles.js';
+import type {
+  FiberNodeButtonActionDefaultProps,
+  FiberNodeButtonActionId,
+  FiberNodeButtonI18n,
+  FiberNodeButtonRenderAction,
+} from './types.js';
+import { withDisabledStyle } from './utils.js';
+
+export interface RenderPanelActionOptions {
+  id: FiberNodeButtonActionId;
+  defaultProps: FiberNodeButtonActionDefaultProps;
+  fiber: UseFiberNodeResult;
+  renderAction?: FiberNodeButtonRenderAction;
+  t: FiberNodeButtonI18n;
+  buttonStyle?: CSSProperties;
+}
+
+export function renderPanelAction(options: RenderPanelActionOptions): ReactNode {
+  const { id, defaultProps, fiber, renderAction, t, buttonStyle = styles.actionButton } = options;
+
+  const customAction = renderAction?.({
+    id,
+    defaultProps,
+    fiber,
+    t,
+  });
+
+  if (customAction !== undefined) {
+    return customAction;
+  }
+
+  const loadingText = defaultProps.loadingLabel ?? t('actions.loading.default', 'Processing...');
+
+  return (
+    <button
+      type="button"
+      style={withDisabledStyle(buttonStyle, defaultProps.disabled)}
+      disabled={defaultProps.disabled}
+      onClick={() => {
+        void defaultProps.onTrigger();
+      }}
+    >
+      {defaultProps.loading ? loadingText : defaultProps.label}
+    </button>
+  );
+}

--- a/packages/react/src/fiber-node-button/render-action.tsx
+++ b/packages/react/src/fiber-node-button/render-action.tsx
@@ -7,24 +7,35 @@ import type {
   FiberNodeButtonI18n,
   FiberNodeButtonRenderAction,
 } from './types.js';
+import type { FiberNodeButtonPanelState } from './use-panel-state.js';
 import { withDisabledStyle } from './utils.js';
 
 export interface RenderPanelActionOptions {
   id: FiberNodeButtonActionId;
   defaultProps: FiberNodeButtonActionDefaultProps;
   fiber: UseFiberNodeResult;
+  state: FiberNodeButtonPanelState;
   renderAction?: FiberNodeButtonRenderAction;
   t: FiberNodeButtonI18n;
   buttonStyle?: CSSProperties;
 }
 
 export function renderPanelAction(options: RenderPanelActionOptions): ReactNode {
-  const { id, defaultProps, fiber, renderAction, t, buttonStyle = styles.actionButton } = options;
+  const {
+    id,
+    defaultProps,
+    fiber,
+    state,
+    renderAction,
+    t,
+    buttonStyle = styles.actionButton,
+  } = options;
 
   const customAction = renderAction?.({
     id,
     defaultProps,
     fiber,
+    state,
     t,
   });
 

--- a/packages/react/src/fiber-node-button/types.ts
+++ b/packages/react/src/fiber-node-button/types.ts
@@ -12,14 +12,105 @@ import type {
 import type { CSSProperties, ReactNode } from 'react';
 import type { ConnectButtonConnectedDropdownContext, ConnectStrategy } from '../connect-button.js';
 import type { UseFiberNodeOptions, UseFiberNodeResult } from '../use-fiber-node.js';
+import type { FiberNodeButtonPanelState } from './use-panel-state.js';
 
 export const ONE_CKB_SHANNONS = '0x5f5e100';
 
 export type ChannelFilter = 'active' | 'pending' | 'closed' | 'all';
-export type PanelTab = 'workbench' | 'channels' | 'diagnostics';
+export type PanelTab = string;
+export type DefaultPanelTab = 'workbench' | 'channels' | 'diagnostics';
+export type FiberNodeButtonTabId = PanelTab;
 export type GraphChannelInfo = GraphChannelsResult['channels'][number];
 export type GraphNodeInfo = GraphNodesResult['nodes'][number];
 export type PeerInfo = ListPeersResult['peers'][number];
+export type FiberNodeButtonI18n = (
+  key: string,
+  fallback: string,
+  vars?: Record<string, string | number>,
+) => string;
+
+export type FiberNodeButtonActionId =
+  | 'open-channel'
+  | 'create-invoice'
+  | 'pay-invoice'
+  | 'close-channel'
+  | 'force-close-channel';
+
+export interface FiberNodeButtonActionDefaultPropsBase {
+  label: string;
+  loadingLabel?: string;
+  disabled: boolean;
+  loading?: boolean;
+  onTrigger: () => void | Promise<void>;
+}
+
+export interface FiberNodeButtonOpenChannelActionDefaultProps
+  extends FiberNodeButtonActionDefaultPropsBase {
+  id: 'open-channel';
+}
+
+export interface FiberNodeButtonCreateInvoiceActionDefaultProps
+  extends FiberNodeButtonActionDefaultPropsBase {
+  id: 'create-invoice';
+}
+
+export interface FiberNodeButtonPayInvoiceActionDefaultProps
+  extends FiberNodeButtonActionDefaultPropsBase {
+  id: 'pay-invoice';
+}
+
+export interface FiberNodeButtonCloseChannelActionDefaultProps
+  extends FiberNodeButtonActionDefaultPropsBase {
+  id: 'close-channel';
+  channelId?: string;
+}
+
+export interface FiberNodeButtonForceCloseChannelActionDefaultProps
+  extends FiberNodeButtonActionDefaultPropsBase {
+  id: 'force-close-channel';
+  channelId?: string;
+}
+
+export type FiberNodeButtonActionDefaultProps =
+  | FiberNodeButtonOpenChannelActionDefaultProps
+  | FiberNodeButtonCreateInvoiceActionDefaultProps
+  | FiberNodeButtonPayInvoiceActionDefaultProps
+  | FiberNodeButtonCloseChannelActionDefaultProps
+  | FiberNodeButtonForceCloseChannelActionDefaultProps;
+
+export interface FiberNodeButtonTabActions {
+  openChannel: () => Promise<void>;
+  createInvoice: () => Promise<void>;
+  payInvoice: () => Promise<void>;
+  closeChannel: (channelId: string) => Promise<void>;
+  forceCloseChannel: (channelId: string) => Promise<void>;
+}
+
+export interface FiberNodeButtonTabContext {
+  fiber: UseFiberNodeResult;
+  state: FiberNodeButtonPanelState;
+  externalFundingEnabled: boolean;
+  t: FiberNodeButtonI18n;
+  actions: FiberNodeButtonTabActions;
+}
+
+export interface FiberNodeButtonTabConfig {
+  id: FiberNodeButtonTabId;
+  label?: string | ((t: FiberNodeButtonI18n) => string);
+  hidden?: boolean;
+  render?: (context: FiberNodeButtonTabContext) => ReactNode;
+}
+
+export interface FiberNodeButtonRenderActionContext {
+  id: FiberNodeButtonActionId;
+  defaultProps: FiberNodeButtonActionDefaultProps;
+  fiber: UseFiberNodeResult;
+  t: FiberNodeButtonI18n;
+}
+
+export type FiberNodeButtonRenderAction = (
+  context: FiberNodeButtonRenderActionContext,
+) => ReactNode | undefined;
 
 export interface FiberNodeButtonExternalFundingResolved {
   signFundingTx: (txForSigner: unknown) => Promise<unknown>;
@@ -70,6 +161,13 @@ export interface FiberNodeButtonProps {
   initialFundingAmountCkb?: string;
   externalFunding?: FiberNodeButtonExternalFundingConfig;
   renderConnectorSection?: (context: FiberNodeButtonConnectorSectionContext) => ReactNode;
+  tabs?: ReadonlyArray<FiberNodeButtonTabConfig>;
+  renderTabContent?: (
+    tabId: FiberNodeButtonTabId,
+    context: FiberNodeButtonTabContext,
+  ) => ReactNode | undefined;
+  renderAction?: FiberNodeButtonRenderAction;
+  t?: FiberNodeButtonI18n;
 }
 
 export interface FiberNodeButtonPanelProps {
@@ -83,12 +181,25 @@ export interface FiberNodeButtonPanelProps {
   initialFundingAmountCkb: string;
   externalFunding?: FiberNodeButtonExternalFundingConfig;
   renderConnectorSection?: (context: FiberNodeButtonConnectorSectionContext) => ReactNode;
+  tabs?: ReadonlyArray<FiberNodeButtonTabConfig>;
+  renderTabContent?: (
+    tabId: FiberNodeButtonTabId,
+    context: FiberNodeButtonTabContext,
+  ) => ReactNode | undefined;
+  renderAction?: FiberNodeButtonRenderAction;
+  t?: FiberNodeButtonI18n;
 }
 
-export const TAB_ITEMS: ReadonlyArray<{ id: PanelTab; label: string }> = [
+export const TAB_ITEMS: ReadonlyArray<{ id: DefaultPanelTab; label: string }> = [
   { id: 'workbench', label: 'Workbench' },
   { id: 'channels', label: 'Channels' },
   { id: 'diagnostics', label: 'Diagnostics' },
+];
+
+export const DEFAULT_TAB_IDS: ReadonlyArray<DefaultPanelTab> = [
+  'workbench',
+  'channels',
+  'diagnostics',
 ];
 
 export const FILTER_ITEMS: ReadonlyArray<ChannelFilter> = ['active', 'pending', 'closed', 'all'];

--- a/packages/react/src/fiber-node-button/types.ts
+++ b/packages/react/src/fiber-node-button/types.ts
@@ -105,6 +105,7 @@ export interface FiberNodeButtonRenderActionContext {
   id: FiberNodeButtonActionId;
   defaultProps: FiberNodeButtonActionDefaultProps;
   fiber: UseFiberNodeResult;
+  state: FiberNodeButtonPanelState;
   t: FiberNodeButtonI18n;
 }
 

--- a/packages/react/src/fiber-node-button/workbench-tab.tsx
+++ b/packages/react/src/fiber-node-button/workbench-tab.tsx
@@ -1,13 +1,21 @@
+import { renderPanelAction } from './render-action.js';
 import { styles } from './styles.js';
-import type { FiberNodeButtonPanelProps } from './types.js';
+import type {
+  FiberNodeButtonActionDefaultProps,
+  FiberNodeButtonPanelProps,
+  FiberNodeButtonRenderAction,
+  FiberNodeButtonTabContext,
+} from './types.js';
 import type { FiberNodeButtonPanelState } from './use-panel-state.js';
-import { shorten, withDisabledStyle } from './utils.js';
+import { shorten } from './utils.js';
 
 export interface WorkbenchTabProps {
   state: FiberNodeButtonPanelState;
   fiber: FiberNodeButtonPanelProps['fiber'];
   externalFunding: FiberNodeButtonPanelProps['externalFunding'];
   renderConnectorSection: FiberNodeButtonPanelProps['renderConnectorSection'];
+  renderAction?: FiberNodeButtonRenderAction;
+  t: FiberNodeButtonTabContext['t'];
 }
 
 export function WorkbenchTab({
@@ -15,6 +23,8 @@ export function WorkbenchTab({
   fiber,
   externalFunding,
   renderConnectorSection,
+  renderAction,
+  t,
 }: WorkbenchTabProps) {
   const {
     isNodeReady,
@@ -41,14 +51,24 @@ export function WorkbenchTab({
     <>
       <section style={styles.section}>
         <div style={styles.rowBetween}>
-          <h4 style={styles.sectionTitle}>Connection Prep</h4>
-          <span style={styles.badge}>{isNodeReady ? 'Connected' : 'Disconnected'}</span>
+          <h4 style={styles.sectionTitle}>
+            {t('workbench.connectionPrep.title', 'Connection Prep')}
+          </h4>
+          <span style={styles.badge}>
+            {isNodeReady
+              ? t('workbench.connectionPrep.connected', 'Connected')
+              : t('workbench.connectionPrep.disconnected', 'Disconnected')}
+          </span>
         </div>
         <p style={styles.compactText}>
-          Node: {fiber.nodeInfo?.pubkey ? shorten(fiber.nodeInfo.pubkey, 18, 12) : 'N/A'}
+          {t('workbench.connectionPrep.node', 'Node')}:{' '}
+          {fiber.nodeInfo?.pubkey ? shorten(fiber.nodeInfo.pubkey, 18, 12) : t('meta.na', 'N/A')}
         </p>
         <p style={styles.compactText}>
-          External wallet: {externalFunding?.enabled ? 'Enabled' : 'Disabled'}
+          {t('workbench.connectionPrep.externalWallet', 'External wallet')}:{' '}
+          {externalFunding?.enabled
+            ? t('workbench.connectionPrep.enabled', 'Enabled')
+            : t('workbench.connectionPrep.disabled', 'Disabled')}
         </p>
 
         {renderConnectorSection ? (
@@ -60,12 +80,16 @@ export function WorkbenchTab({
 
       <section style={styles.section}>
         <div style={styles.rowBetween}>
-          <h4 style={styles.sectionTitle}>Open Channel</h4>
-          {channelOpenFlow.lastResult ? <span style={styles.badge}>Recent Success</span> : null}
+          <h4 style={styles.sectionTitle}>{t('workbench.openChannel.title', 'Open Channel')}</h4>
+          {channelOpenFlow.lastResult ? (
+            <span style={styles.badge}>
+              {t('workbench.openChannel.recentSuccess', 'Recent Success')}
+            </span>
+          ) : null}
         </div>
 
         <label style={styles.fieldLabel}>
-          Target Peer Pubkey
+          {t('workbench.openChannel.targetPeerPubkey', 'Target Peer Pubkey')}
           <input
             style={styles.input}
             list={peerListId}
@@ -81,7 +105,7 @@ export function WorkbenchTab({
         </label>
 
         <label style={styles.fieldLabel}>
-          Funding Amount (CKB)
+          {t('workbench.openChannel.fundingAmount', 'Funding Amount (CKB)')}
           <input
             style={styles.input}
             value={fundingAmountCkb}
@@ -91,79 +115,92 @@ export function WorkbenchTab({
         </label>
 
         <div style={styles.row}>
-          <button
-            type="button"
-            style={withDisabledStyle(
-              styles.primaryButton,
-              !isNodeReady || channelOpenFlow.isOpening || !peerPubkey.trim(),
-            )}
-            disabled={!isNodeReady || channelOpenFlow.isOpening || !peerPubkey.trim()}
-            onClick={() => {
-              void openChannel();
-            }}
-          >
-            {channelOpenFlow.isOpening ? 'Opening...' : 'Open Channel'}
-          </button>
+          {renderPanelAction({
+            id: 'open-channel',
+            fiber,
+            renderAction,
+            t,
+            buttonStyle: styles.primaryButton,
+            defaultProps: {
+              id: 'open-channel',
+              label: t('actions.openChannel', 'Open Channel'),
+              loadingLabel: t('actions.openChannel.loading', 'Opening...'),
+              disabled: !isNodeReady || channelOpenFlow.isOpening || !peerPubkey.trim(),
+              loading: channelOpenFlow.isOpening,
+              onTrigger: openChannel,
+            } satisfies FiberNodeButtonActionDefaultProps,
+          })}
         </div>
 
         {channelOpenFlow.lastResult ? (
           <p style={styles.compactText}>
-            Last channel: {shorten(channelOpenFlow.lastResult.channelId, 14, 8)}
+            {t('workbench.openChannel.lastChannel', 'Last channel')}:{' '}
+            {shorten(channelOpenFlow.lastResult.channelId, 14, 8)}
           </p>
         ) : null}
 
         {channelOpenFlow.suggestedFundingAmountCkb ? (
           <p style={styles.compactText}>
-            Suggested amount: {channelOpenFlow.suggestedFundingAmountCkb} CKB
+            {t('workbench.openChannel.suggestedAmount', 'Suggested amount')}:{' '}
+            {channelOpenFlow.suggestedFundingAmountCkb} CKB
           </p>
         ) : null}
       </section>
 
       <section style={styles.section}>
-        <h4 style={styles.sectionTitle}>Payments</h4>
+        <h4 style={styles.sectionTitle}>{t('workbench.payments.title', 'Payments')}</h4>
 
         <div style={styles.row}>
-          <button
-            type="button"
-            style={withDisabledStyle(styles.actionButton, isCreatingInvoice || !isNodeReady)}
-            disabled={isCreatingInvoice || !isNodeReady}
-            onClick={() => {
-              void createInvoice();
-            }}
-          >
-            {isCreatingInvoice ? 'Creating...' : 'Create Invoice (1 CKB)'}
-          </button>
+          {renderPanelAction({
+            id: 'create-invoice',
+            fiber,
+            renderAction,
+            t,
+            defaultProps: {
+              id: 'create-invoice',
+              label: t('actions.createInvoice', 'Create Invoice (1 CKB)'),
+              loadingLabel: t('actions.createInvoice.loading', 'Creating...'),
+              disabled: isCreatingInvoice || !isNodeReady,
+              loading: isCreatingInvoice,
+              onTrigger: createInvoice,
+            } satisfies FiberNodeButtonActionDefaultProps,
+          })}
           {createdInvoice ? (
             <span style={styles.compactText}>{shorten(createdInvoice, 20, 10)}</span>
           ) : null}
         </div>
 
         <label style={styles.fieldLabel}>
-          Invoice
+          {t('workbench.payments.invoice', 'Invoice')}
           <input
             style={styles.input}
             value={invoiceInput}
             onChange={(event) => setInvoiceInput(event.target.value)}
-            placeholder="Paste invoice to pay"
+            placeholder={t('workbench.payments.invoicePlaceholder', 'Paste invoice to pay')}
           />
         </label>
 
         <div style={styles.rowBetween}>
-          <button
-            type="button"
-            style={withDisabledStyle(
-              styles.primaryButton,
-              isPaying || !isNodeReady || !invoiceInput.trim(),
-            )}
-            disabled={isPaying || !isNodeReady || !invoiceInput.trim()}
-            onClick={() => {
-              void submitPayment();
-            }}
-          >
-            {isPaying ? 'Paying...' : 'Pay Invoice'}
-          </button>
+          {renderPanelAction({
+            id: 'pay-invoice',
+            fiber,
+            renderAction,
+            t,
+            buttonStyle: styles.primaryButton,
+            defaultProps: {
+              id: 'pay-invoice',
+              label: t('actions.payInvoice', 'Pay Invoice'),
+              loadingLabel: t('actions.payInvoice.loading', 'Paying...'),
+              disabled: isPaying || !isNodeReady || !invoiceInput.trim(),
+              loading: isPaying,
+              onTrigger: submitPayment,
+            } satisfies FiberNodeButtonActionDefaultProps,
+          })}
 
-          <span style={styles.compactText}>Status: {paymentResult?.status ?? 'Idle'}</span>
+          <span style={styles.compactText}>
+            {t('workbench.payments.status', 'Status')}:{' '}
+            {paymentResult?.status ?? t('workbench.payments.idle', 'Idle')}
+          </span>
         </div>
       </section>
     </>

--- a/packages/react/src/fiber-node-button/workbench-tab.tsx
+++ b/packages/react/src/fiber-node-button/workbench-tab.tsx
@@ -118,6 +118,7 @@ export function WorkbenchTab({
           {renderPanelAction({
             id: 'open-channel',
             fiber,
+            state,
             renderAction,
             t,
             buttonStyle: styles.primaryButton,
@@ -154,6 +155,7 @@ export function WorkbenchTab({
           {renderPanelAction({
             id: 'create-invoice',
             fiber,
+            state,
             renderAction,
             t,
             defaultProps: {
@@ -184,6 +186,7 @@ export function WorkbenchTab({
           {renderPanelAction({
             id: 'pay-invoice',
             fiber,
+            state,
             renderAction,
             t,
             buttonStyle: styles.primaryButton,

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -30,11 +30,20 @@ export type {
 } from './connect-button.js';
 export { ConnectButton } from './connect-button.js';
 export type {
+  FiberNodeButtonActionDefaultProps,
+  FiberNodeButtonActionId,
   FiberNodeButtonConnectorSectionContext,
   FiberNodeButtonExternalFundingConfig,
   FiberNodeButtonExternalFundingResolved,
   FiberNodeButtonExternalFundingResolverContext,
+  FiberNodeButtonI18n,
   FiberNodeButtonProps,
+  FiberNodeButtonRenderAction,
+  FiberNodeButtonRenderActionContext,
+  FiberNodeButtonTabActions,
+  FiberNodeButtonTabConfig,
+  FiberNodeButtonTabContext,
+  FiberNodeButtonTabId,
 } from './fiber-node-button.js';
 export { FiberNodeButton } from './fiber-node-button.js';
 export type { FiberPayQuickCardProps } from './fiber-pay-quick-card.js';

--- a/packages/react/tests/fiber-node-button-extensibility.test.tsx
+++ b/packages/react/tests/fiber-node-button-extensibility.test.tsx
@@ -84,6 +84,8 @@ describe('FiberNodeButton extensibility', () => {
       return dictionary[key] ?? fallback;
     };
 
+    let sawRenderActionState = false;
+
     render(
       <FiberNodeButton
         fiber={fiber}
@@ -105,7 +107,11 @@ describe('FiberNodeButton extensibility', () => {
           }
           return <div>Custom Channels Content</div>;
         }}
-        renderAction={({ id, defaultProps }) => {
+        renderAction={({ id, defaultProps, state }) => {
+          if (state.activeTab !== undefined && state.paymentResult !== undefined) {
+            sawRenderActionState = true;
+          }
+
           if (id !== 'pay-invoice') {
             return undefined;
           }
@@ -141,6 +147,7 @@ describe('FiberNodeButton extensibility', () => {
     fireEvent.click(screen.getByRole('tab', { name: '操作台' }));
     expect(screen.getByRole('button', { name: 'Pay Invoice Custom' })).toBeTruthy();
     expect(screen.queryByRole('button', { name: 'Pay Invoice' })).toBeNull();
+    expect(sawRenderActionState).toBe(true);
   });
 
   it('allows tabs.render to override built-in tab content', async () => {

--- a/packages/react/tests/fiber-node-button-extensibility.test.tsx
+++ b/packages/react/tests/fiber-node-button-extensibility.test.tsx
@@ -1,0 +1,145 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { FiberNodeButton } from '../src/fiber-node-button.js';
+import type { UseFiberNodeResult } from '../src/use-fiber-node.js';
+
+afterEach(() => {
+  cleanup();
+});
+
+function createNodeMock() {
+  return {
+    listPeers: vi.fn(async () => ({ peers: [{ pubkey: '0xabc' }] })),
+    listChannels: vi.fn(async () => ({ channels: [] })),
+    graphNodes: vi.fn(async () => ({ nodes: [], last_cursor: '0x0' })),
+    graphChannels: vi.fn(async () => ({ channels: [], last_cursor: '0x0' })),
+    connectPeer: vi.fn(async () => ({})),
+    shutdownChannel: vi.fn(async () => ({})),
+    abandonChannel: vi.fn(async () => ({})),
+    newInvoice: vi.fn(async () => ({ invoice_address: 'ln-fake-invoice' })),
+    parseInvoice: vi.fn(async () => ({ invoice: { data: { payment_hash: '0x1' } } })),
+    sendPayment: vi.fn(async () => ({})),
+    waitForPayment: vi.fn(async () => ({ status: 'Succeeded' })),
+  };
+}
+
+function createFiberMock(overrides: Partial<UseFiberNodeResult> = {}): UseFiberNodeResult {
+  return {
+    state: 'idle',
+    node: null,
+    nodeInfo: null,
+    error: null,
+    isStarting: false,
+    isRunning: false,
+    isPasskeySupported: true,
+    passkeySupportReason: 'supported',
+    passkeyUnavailableReason: null,
+    hasPasskeyConfigured: true,
+    startWithPassword: vi.fn(async () => {}),
+    createPasskeyAndStart: vi.fn(async () => {}),
+    startWithPasskey: vi.fn(async () => {}),
+    startWithRawKey: vi.fn(async () => {}),
+    stop: vi.fn(async () => {}),
+    ...overrides,
+  };
+}
+
+describe('FiberNodeButton extensibility', () => {
+  it('keeps default tab behavior when no extension props are passed', async () => {
+    const node = createNodeMock();
+    const fiber = createFiberMock({
+      state: 'running',
+      isRunning: true,
+      node: node as unknown as UseFiberNodeResult['node'],
+      nodeInfo: { pubkey: '0x0123456789abcdef0123456789abcdef' } as UseFiberNodeResult['nodeInfo'],
+    });
+
+    render(<FiberNodeButton fiber={fiber} strategy="passkey" />);
+
+    fireEvent.click(screen.getByRole('button', { name: /0x012345/i }));
+
+    expect(screen.getByRole('tab', { name: 'Workbench' })).toBeTruthy();
+    expect(screen.getByRole('tab', { name: 'Channels' })).toBeTruthy();
+    expect(screen.getByRole('tab', { name: 'Diagnostics' })).toBeTruthy();
+
+    await waitFor(() => {
+      expect(node.listPeers).toHaveBeenCalled();
+    });
+  });
+
+  it('supports tabs config, renderTabContent, renderAction and i18n t', async () => {
+    const node = createNodeMock();
+    const fiber = createFiberMock({
+      state: 'running',
+      isRunning: true,
+      node: node as unknown as UseFiberNodeResult['node'],
+      nodeInfo: { pubkey: '0x0123456789abcdef0123456789abcdef' } as UseFiberNodeResult['nodeInfo'],
+    });
+
+    const t = (key: string, fallback: string) => {
+      const dictionary: Record<string, string> = {
+        'tabs.workbench': '操作台',
+        'tabs.channels': '通道',
+      };
+      return dictionary[key] ?? fallback;
+    };
+
+    render(
+      <FiberNodeButton
+        fiber={fiber}
+        strategy="passkey"
+        t={t}
+        tabs={[
+          { id: 'channels' },
+          {
+            id: 'my-stats',
+            label: 'My Stats',
+            render: () => <div>Stats Tab Body</div>,
+          },
+          { id: 'diagnostics', hidden: true },
+          { id: 'workbench' },
+        ]}
+        renderTabContent={(tabId) => {
+          if (tabId !== 'channels') {
+            return undefined;
+          }
+          return <div>Custom Channels Content</div>;
+        }}
+        renderAction={({ id, defaultProps }) => {
+          if (id !== 'pay-invoice') {
+            return undefined;
+          }
+
+          return (
+            <button
+              type="button"
+              disabled={defaultProps.disabled}
+              onClick={() => {
+                void defaultProps.onTrigger();
+              }}
+            >
+              {defaultProps.loading ? 'Paying Custom...' : 'Pay Invoice Custom'}
+            </button>
+          );
+        }}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /0x012345/i }));
+
+    expect(screen.getByRole('tab', { name: '通道' })).toBeTruthy();
+    expect(screen.getByRole('tab', { name: 'My Stats' })).toBeTruthy();
+    expect(screen.getByRole('tab', { name: '操作台' })).toBeTruthy();
+    expect(screen.queryByRole('tab', { name: 'Diagnostics' })).toBeNull();
+
+    fireEvent.click(screen.getByRole('tab', { name: '通道' }));
+    expect(screen.getByText('Custom Channels Content')).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('tab', { name: 'My Stats' }));
+    expect(screen.getByText('Stats Tab Body')).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('tab', { name: '操作台' }));
+    expect(screen.getByRole('button', { name: 'Pay Invoice Custom' })).toBeTruthy();
+    expect(screen.queryByRole('button', { name: 'Pay Invoice' })).toBeNull();
+  });
+});

--- a/packages/react/tests/fiber-node-button-extensibility.test.tsx
+++ b/packages/react/tests/fiber-node-button-extensibility.test.tsx
@@ -142,4 +142,58 @@ describe('FiberNodeButton extensibility', () => {
     expect(screen.getByRole('button', { name: 'Pay Invoice Custom' })).toBeTruthy();
     expect(screen.queryByRole('button', { name: 'Pay Invoice' })).toBeNull();
   });
+
+  it('allows tabs.render to override built-in tab content', async () => {
+    const node = createNodeMock();
+    const fiber = createFiberMock({
+      state: 'running',
+      isRunning: true,
+      node: node as unknown as UseFiberNodeResult['node'],
+      nodeInfo: { pubkey: '0x0123456789abcdef0123456789abcdef' } as UseFiberNodeResult['nodeInfo'],
+    });
+
+    render(
+      <FiberNodeButton
+        fiber={fiber}
+        strategy="passkey"
+        tabs={[
+          { id: 'workbench' },
+          { id: 'channels', render: () => <div>Channels Overridden By tabs.render</div> },
+          { id: 'diagnostics' },
+        ]}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /0x012345/i }));
+    fireEvent.click(screen.getByRole('tab', { name: 'Channels' }));
+
+    expect(screen.getByText('Channels Overridden By tabs.render')).toBeTruthy();
+  });
+
+  it('shows empty-tab notice when all configured tabs are hidden', async () => {
+    const node = createNodeMock();
+    const fiber = createFiberMock({
+      state: 'running',
+      isRunning: true,
+      node: node as unknown as UseFiberNodeResult['node'],
+      nodeInfo: { pubkey: '0x0123456789abcdef0123456789abcdef' } as UseFiberNodeResult['nodeInfo'],
+    });
+
+    render(
+      <FiberNodeButton
+        fiber={fiber}
+        strategy="passkey"
+        tabs={[
+          { id: 'workbench', hidden: true },
+          { id: 'channels', hidden: true },
+          { id: 'diagnostics', hidden: true },
+        ]}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /0x012345/i }));
+
+    expect(screen.getByText('No visible tabs are configured.')).toBeTruthy();
+    expect(screen.queryByRole('tab')).toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary
- add extensibility APIs to FiberNodeButton: tabs, renderTabContent, renderAction, and t i18n function
- refactor panel rendering to support tab reorder/hide/custom tabs with active-tab fallback
- add action rendering abstraction so open/pay/create/close/force-close can be overridden without forking
- add react-quick-card Custom Tab Mode demo and README customization docs
- add extensibility test suite for default compatibility and new extension paths

## Validation
- pnpm -w lint
- cd packages/react && pnpm test -- --run && pnpm build
- full pre-commit checks passed (build/typecheck/test across workspace)

Closes #144