### PR TITLE
chore(react): move @nervosnetwork/fiber-js to peerDependencies

### DIFF
--- a/.changeset/move-fiber-js-peerdeps.md
+++ b/.changeset/move-fiber-js-peerdeps.md
@@ -1,0 +1,8 @@
+---
+"@fiber-pay/react": patch
+---
+
+Move `@nervosnetwork/fiber-js` from `dependencies` to optional `peerDependencies`, aligning with the pattern already used in `@fiber-pay/sdk`.
+
+- `@fiber-pay/react/package.json`: remove `@nervosnetwork/fiber-js` from `dependencies`, add to `peerDependencies` and `peerDependenciesMeta.optional`, and add to `devDependencies` for isolated build/test support.
+- `@fiber-pay/react/README.md`: update install command to explicitly include `@nervosnetwork/fiber-js`.

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -5,7 +5,7 @@ React hooks and components for browser payment flows on Fiber.
 ## Install
 
 ```bash
-pnpm add @fiber-pay/react react
+pnpm add @fiber-pay/react @nervosnetwork/fiber-js react
 ```
 
 ## One-line import

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -54,6 +54,7 @@
     }
   },
   "devDependencies": {
+    "@nervosnetwork/fiber-js": "~0.8.1",
     "@testing-library/react": "^16.3.0",
     "@types/react": "^18.0.0 || ^19.0.0",
     "jsdom": "^26.1.0"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -38,15 +38,18 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@fiber-pay/sdk": "workspace:*",
-    "@nervosnetwork/fiber-js": "~0.8.1"
+    "@fiber-pay/sdk": "workspace:*"
   },
   "peerDependencies": {
     "react": "^18.0.0 || ^19.0.0",
-    "qrcode.react": "^4.0.0"
+    "qrcode.react": "^4.0.0",
+    "@nervosnetwork/fiber-js": "~0.8.1"
   },
   "peerDependenciesMeta": {
     "qrcode.react": {
+      "optional": true
+    },
+    "@nervosnetwork/fiber-js": {
       "optional": true
     }
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -247,9 +247,6 @@ importers:
       '@fiber-pay/sdk':
         specifier: workspace:*
         version: link:../sdk
-      '@nervosnetwork/fiber-js':
-        specifier: ~0.8.1
-        version: 0.8.1
       qrcode.react:
         specifier: ^4.0.0
         version: 4.2.0(react@19.2.4)
@@ -257,6 +254,9 @@ importers:
         specifier: ^18.0.0 || ^19.0.0
         version: 19.2.4
     devDependencies:
+      '@nervosnetwork/fiber-js':
+        specifier: ~0.8.1
+        version: 0.8.1
       '@testing-library/react':
         specifier: ^16.3.0
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)


### PR DESCRIPTION
## Summary

Move `@nervosnetwork/fiber-js` from `dependencies` to optional `peerDependencies` in `@fiber-pay/react`, aligning with the pattern already used in `@fiber-pay/sdk`.

Closes #140

## Changes

- `packages/react/package.json`
  - Removed `@nervosnetwork/fiber-js` from `dependencies`
  - Added `@nervosnetwork/fiber-js` to `peerDependencies` (`~0.8.1`)
  - Added `@nervosnetwork/fiber-js` to `peerDependenciesMeta` as `optional: true`

- `packages/react/README.md`
  - Updated install command to include the new peer dependency explicitly:
    ```bash
    pnpm add @fiber-pay/react @nervosnetwork/fiber-js react
    ```

## Rationale

- `@fiber-pay/react` does not directly import `@nervosnetwork/fiber-js` in its source; all types are re-exported through `@fiber-pay/sdk/browser`.
- The package's `tsup.config.ts` already marks `@nervosnetwork/fiber-js` as `external`, so it is not bundled regardless.
- Keeping it in `dependencies` risks npm installing a duplicate copy under `@fiber-pay/react/node_modules`, causing version drift and conflicting with the app's intended WASM version.
- Moving it to `peerDependencies` makes the app the single owner of the Fiber WASM version, consistent with `@fiber-pay/sdk`.

## Test Plan

- [x] `pnpm --filter @fiber-pay/react build` passes
- [x] `pnpm --filter @fiber-pay/react test` passes (11/11)
- [x] `pnpm --filter @fiber-pay/sdk build` passes