### PR TITLE
fix(react): address issue #150 DX feedback

### DIFF
--- a/.changeset/green-buses-learn.md
+++ b/.changeset/green-buses-learn.md
@@ -1,0 +1,9 @@
+---
+"@fiber-pay/react": patch
+---
+
+Improve React SDK developer experience with staged payment hook APIs and clearer browser integration docs.
+
+- Add `parseInvoice`, `sendPayment`, and `waitForPayment` to `useFiberPayment` while keeping `payInvoice` compatibility.
+- Document COOP/COEP requirements, expected WASM bundle impact, and retry guidance for startup failures.
+- Clarify React/browser install guidance for `@nervosnetwork/fiber-js` and optional `qrcode.react`.

--- a/docs/wasm-passkey-payment-component-quickstart.md
+++ b/docs/wasm-passkey-payment-component-quickstart.md
@@ -24,13 +24,44 @@ import { FiberPayQuickCard } from '@fiber-pay/react';
 ## 1) Install
 
 ```bash
-pnpm add @fiber-pay/react react
+pnpm add @fiber-pay/react react @nervosnetwork/fiber-js
+# optional, for QR codes in NodeInfoPanel
+pnpm add qrcode.react
 ```
 
 If you prefer lower-level control without React abstractions:
 
 ```bash
 pnpm add @fiber-pay/sdk @nervosnetwork/fiber-js
+```
+
+## Browser Requirements (Must Read)
+
+For browser multithreaded WASM runtime (`SharedArrayBuffer`), your app must serve:
+
+- `Cross-Origin-Opener-Policy: same-origin`
+- `Cross-Origin-Embedder-Policy: require-corp`
+
+Without these headers, `FiberBrowserNode.start()` can fail at runtime.
+
+Vite example plugin:
+
+```ts
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import { type Plugin } from 'vite';
+
+function crossOriginIsolation(): Plugin {
+  return {
+    name: 'cross-origin-isolation',
+    configureServer(server) {
+      server.middlewares.use((_req: IncomingMessage, res: ServerResponse, next: () => void) => {
+        res.setHeader('Cross-Origin-Opener-Policy', 'same-origin');
+        res.setHeader('Cross-Origin-Embedder-Policy', 'require-corp');
+        next();
+      });
+    },
+  };
+}
 ```
 
 ## 2) Smallest Passkey Startup (No UI)
@@ -296,6 +327,8 @@ Use this path when you want to ship a functional payment panel quickly, then pro
 - Treat browser XSS hardening as top priority (CSP, script hygiene, strict dependency review).
 - Avoid exposing privileged backend tokens in browser bundles.
 - For browser multithreaded WASM runtime, keep COOP/COEP settings correctly configured.
+- Expect a large WASM-related bundle chunk (roughly ~14 MB raw, ~6.5 MB gzip in current demos);
+  use route-level split/lazy mounting for payment-heavy UI.
 
 ## 8) Reference Paths
 

--- a/docs/wasm-passkey-payment-component-quickstart.md
+++ b/docs/wasm-passkey-payment-component-quickstart.md
@@ -64,6 +64,9 @@ function crossOriginIsolation(): Plugin {
 }
 ```
 
+Note: this `configureServer` middleware only affects local Vite dev server.
+In production, configure COOP/COEP headers on your web server or CDN.
+
 ## 2) Smallest Passkey Startup (No UI)
 
 ```ts

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -47,6 +47,9 @@ export default defineConfig({
 });
 ```
 
+Note: `configureServer` only applies to Vite dev server. For production builds,
+set these headers on your web server or CDN (for example Nginx, Cloudflare, Vercel).
+
 ## Bundle Size Notes
 
 Browser Fiber WASM artifacts are large by nature. In the current examples, a production build includes

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -6,7 +6,58 @@ React hooks and components for browser payment flows on Fiber.
 
 ```bash
 pnpm add @fiber-pay/react @nervosnetwork/fiber-js react
+# optional, for QR codes in NodeInfoPanel
+pnpm add qrcode.react
 ```
+
+`@nervosnetwork/fiber-js` is a peer dependency used by the browser WASM runtime.
+If you provide a custom `wasmFactory`, you can manage that dependency yourself.
+
+## Browser Requirements (WASM + Passkey)
+
+For multithreaded WASM runtime (`SharedArrayBuffer`) in modern browsers, serve your app with:
+
+- `Cross-Origin-Opener-Policy: same-origin`
+- `Cross-Origin-Embedder-Policy: require-corp`
+
+Without these headers, Fiber WASM startup may fail with browser/runtime errors.
+
+Vite example:
+
+```ts
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import { defineConfig, type Plugin } from 'vite';
+import react from '@vitejs/plugin-react';
+
+function crossOriginIsolation(): Plugin {
+  return {
+    name: 'cross-origin-isolation',
+    configureServer(server) {
+      server.middlewares.use((_req: IncomingMessage, res: ServerResponse, next: () => void) => {
+        res.setHeader('Cross-Origin-Opener-Policy', 'same-origin');
+        res.setHeader('Cross-Origin-Embedder-Policy', 'require-corp');
+        next();
+      });
+    },
+  };
+}
+
+export default defineConfig({
+  plugins: [react(), crossOriginIsolation()],
+});
+```
+
+## Bundle Size Notes
+
+Browser Fiber WASM artifacts are large by nature. In the current examples, a production build includes
+an additional ~14 MB JS chunk (~6.5 MB gzip) for WASM/runtime assets.
+
+Recommended integration strategy:
+
+- Lazy-mount payment-heavy UI (for example route-level split).
+- Keep WASM-dependent flows behind user intent (open panel, start node, pay flow).
+- Accept a separate large chunk for WASM and tune warnings with `build.chunkSizeWarningLimit` when needed.
+- Document expected bundle budgets in your downstream app so this chunk is intentional, not surprising.
 
 ## One-line import
 
@@ -194,3 +245,48 @@ For custom connected-state panels (for example peer/channel controls), use `rend
 - `useFiberPayment(node)`
 
 `useFiberNode` exposes passkey/password startup, node lifecycle methods, and passkey diagnostics (`passkeySupportReason`, `passkeyUnavailableReason`).
+
+`useFiberPayment` supports both convenience and staged flows:
+
+- `payInvoice(invoice)` (parse + send + wait in one call)
+- `parseInvoice(invoice)`
+- `sendPayment(invoice)`
+- `waitForPayment(paymentHash)`
+
+Staged flow example:
+
+```tsx
+const { parseInvoice, sendPayment, waitForPayment, error } = useFiberPayment(node);
+
+const confirmAndPay = async (invoice: string) => {
+  const parsed = await parseInvoice(invoice);
+  // Render your own confirmation UI before actually sending
+  console.log('Will pay hash:', parsed.invoice.data.payment_hash);
+
+  await sendPayment(invoice);
+  const result = await waitForPayment(parsed.invoice.data.payment_hash);
+  console.log('Payment status:', result.status);
+};
+```
+
+## Error Recovery Pattern
+
+If `useFiberNode` startup fails, `state` may enter `error` and `error` will contain the raw failure message.
+You can retry with the same hook instance (no unmount/remount required):
+
+```tsx
+const { state, error, startWithPasskey, startWithPassword } = useFiberNode({
+  network: 'testnet',
+  walletId: 'demo-wallet',
+});
+
+const retry = async () => {
+  if (state === 'error') {
+    await startWithPasskey();
+    // or: await startWithPassword('your-password');
+  }
+};
+```
+
+For production UIs, map `error` to actionable guidance (for example: COOP/COEP missing, invalid password,
+passkey canceled, secure-context requirement).

--- a/packages/react/src/use-fiber-payment.ts
+++ b/packages/react/src/use-fiber-payment.ts
@@ -1,7 +1,16 @@
-import type { FiberBrowserNode, GetPaymentResult } from '@fiber-pay/sdk/browser';
+import type {
+  FiberBrowserNode,
+  GetPaymentResult,
+  ParseInvoiceResult,
+  PaymentHash,
+  SendPaymentResult,
+} from '@fiber-pay/sdk/browser';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
 export interface UseFiberPaymentResult {
+  parseInvoice: (invoice: string) => Promise<ParseInvoiceResult>;
+  sendPayment: (invoice: string) => Promise<SendPaymentResult>;
+  waitForPayment: (paymentHash: PaymentHash) => Promise<GetPaymentResult>;
   payInvoice: (invoice: string) => Promise<void>;
   isPaying: boolean;
   paymentResult: GetPaymentResult | null;
@@ -28,15 +37,108 @@ export function useFiberPayment(node: FiberBrowserNode | null): UseFiberPaymentR
     [],
   );
 
-  const payInvoice = useCallback(
+  const ensureNode = useCallback(() => {
+    if (!node) {
+      throw new Error('Node is not initialized');
+    }
+
+    return node;
+  }, [node]);
+
+  const parseInvoiceInternal = useCallback(
     async (invoice: string) => {
-      if (!node) {
-        if (isMountedRef.current) {
-          setError('Node is not initialized');
-        }
-        return;
+      const activeNode = ensureNode();
+      return activeNode.parseInvoice({ invoice });
+    },
+    [ensureNode],
+  );
+
+  const sendPaymentInternal = useCallback(
+    async (invoice: string) => {
+      const activeNode = ensureNode();
+      return activeNode.sendPayment({ invoice });
+    },
+    [ensureNode],
+  );
+
+  const waitForPaymentInternal = useCallback(
+    async (paymentHash: PaymentHash) => {
+      const activeNode = ensureNode();
+      return activeNode.waitForPayment(paymentHash);
+    },
+    [ensureNode],
+  );
+
+  const parseInvoice = useCallback(
+    async (invoice: string) => {
+      if (isMountedRef.current) {
+        setError(null);
       }
 
+      try {
+        return await parseInvoiceInternal(invoice);
+      } catch (parseError) {
+        if (isMountedRef.current) {
+          setError(asErrorMessage(parseError));
+        }
+        throw parseError;
+      }
+    },
+    [parseInvoiceInternal],
+  );
+
+  const sendPayment = useCallback(
+    async (invoice: string) => {
+      if (isMountedRef.current) {
+        setIsPaying(true);
+        setError(null);
+      }
+
+      try {
+        return await sendPaymentInternal(invoice);
+      } catch (sendError) {
+        if (isMountedRef.current) {
+          setError(asErrorMessage(sendError));
+        }
+        throw sendError;
+      } finally {
+        if (isMountedRef.current) {
+          setIsPaying(false);
+        }
+      }
+    },
+    [sendPaymentInternal],
+  );
+
+  const waitForPayment = useCallback(
+    async (paymentHash: PaymentHash) => {
+      if (isMountedRef.current) {
+        setIsPaying(true);
+        setError(null);
+      }
+
+      try {
+        const result = await waitForPaymentInternal(paymentHash);
+        if (isMountedRef.current) {
+          setPaymentResult(result);
+        }
+        return result;
+      } catch (waitError) {
+        if (isMountedRef.current) {
+          setError(asErrorMessage(waitError));
+        }
+        throw waitError;
+      } finally {
+        if (isMountedRef.current) {
+          setIsPaying(false);
+        }
+      }
+    },
+    [waitForPaymentInternal],
+  );
+
+  const payInvoice = useCallback(
+    async (invoice: string) => {
       if (isMountedRef.current) {
         setIsPaying(true);
         setError(null);
@@ -44,11 +146,11 @@ export function useFiberPayment(node: FiberBrowserNode | null): UseFiberPaymentR
       }
 
       try {
-        const parsed = await node.parseInvoice({ invoice });
-        await node.sendPayment({ invoice });
+        const parsed = await parseInvoiceInternal(invoice);
+        await sendPaymentInternal(invoice);
 
         const paymentHash = parsed.invoice.data.payment_hash;
-        const result = await node.waitForPayment(paymentHash);
+        const result = await waitForPaymentInternal(paymentHash);
 
         if (result.status === 'Failed') {
           throw new Error(result.failed_error ?? 'Payment failed during routing/execution');
@@ -67,10 +169,13 @@ export function useFiberPayment(node: FiberBrowserNode | null): UseFiberPaymentR
         }
       }
     },
-    [node],
+    [parseInvoiceInternal, sendPaymentInternal, waitForPaymentInternal],
   );
 
   return {
+    parseInvoice,
+    sendPayment,
+    waitForPayment,
     payInvoice,
     isPaying,
     paymentResult,

--- a/packages/react/src/use-fiber-payment.ts
+++ b/packages/react/src/use-fiber-payment.ts
@@ -92,6 +92,7 @@ export function useFiberPayment(node: FiberBrowserNode | null): UseFiberPaymentR
       if (isMountedRef.current) {
         setIsPaying(true);
         setError(null);
+        setPaymentResult(null);
       }
 
       try {
@@ -115,6 +116,7 @@ export function useFiberPayment(node: FiberBrowserNode | null): UseFiberPaymentR
       if (isMountedRef.current) {
         setIsPaying(true);
         setError(null);
+        setPaymentResult(null);
       }
 
       try {

--- a/packages/react/tests/use-fiber-payment.test.ts
+++ b/packages/react/tests/use-fiber-payment.test.ts
@@ -16,6 +16,16 @@ function createNodeMock(overrides: Partial<FiberBrowserNode> = {}): FiberBrowser
   } as unknown as FiberBrowserNode;
 }
 
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
 describe('useFiberPayment', () => {
   it('supports staged parse/send/wait APIs', async () => {
     const node = createNodeMock();
@@ -77,6 +87,57 @@ describe('useFiberPayment', () => {
     expect(node.waitForPayment).toHaveBeenCalledWith('0xabc');
     expect(result.current.paymentResult?.status).toBe('Succeeded');
     expect(result.current.error).toBeNull();
+  });
+
+  it('clears stale paymentResult when staged sendPayment starts', async () => {
+    const node = createNodeMock();
+    const { result } = renderHook(() => useFiberPayment(node));
+
+    await act(async () => {
+      await result.current.waitForPayment('0xabc');
+    });
+    expect(result.current.paymentResult?.status).toBe('Succeeded');
+
+    await act(async () => {
+      await result.current.sendPayment('ln-next');
+    });
+
+    expect(result.current.paymentResult).toBeNull();
+  });
+
+  it('clears stale paymentResult while staged waitForPayment is pending', async () => {
+    const deferred = createDeferred<{ status: 'Succeeded' }>();
+    const waitForPaymentMock = vi
+      .fn()
+      .mockResolvedValueOnce({ status: 'Succeeded' })
+      .mockImplementationOnce(() => deferred.promise);
+
+    const node = createNodeMock({
+      waitForPayment: waitForPaymentMock,
+    });
+    const { result } = renderHook(() => useFiberPayment(node));
+
+    await act(async () => {
+      await result.current.waitForPayment('0xfirst');
+    });
+    expect(result.current.paymentResult?.status).toBe('Succeeded');
+
+    let pendingWait: Promise<unknown> | undefined;
+    await act(async () => {
+      pendingWait = result.current.waitForPayment('0xsecond');
+      await Promise.resolve();
+    });
+
+    expect(result.current.paymentResult).toBeNull();
+    expect(result.current.isPaying).toBe(true);
+
+    await act(async () => {
+      deferred.resolve({ status: 'Succeeded' });
+      await pendingWait;
+    });
+
+    expect(result.current.paymentResult?.status).toBe('Succeeded');
+    expect(result.current.isPaying).toBe(false);
   });
 
   it('captures failed payment message from payInvoice', async () => {

--- a/packages/react/tests/use-fiber-payment.test.ts
+++ b/packages/react/tests/use-fiber-payment.test.ts
@@ -1,0 +1,96 @@
+import { act, cleanup, renderHook } from '@testing-library/react';
+import type { FiberBrowserNode } from '@fiber-pay/sdk/browser';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { useFiberPayment } from '../src/use-fiber-payment.js';
+
+afterEach(() => {
+  cleanup();
+});
+
+function createNodeMock(overrides: Partial<FiberBrowserNode> = {}): FiberBrowserNode {
+  return {
+    parseInvoice: vi.fn(async () => ({ invoice: { data: { payment_hash: '0xabc' } } })),
+    sendPayment: vi.fn(async () => ({ payment_hash: '0xabc' })),
+    waitForPayment: vi.fn(async () => ({ status: 'Succeeded' })),
+    ...overrides,
+  } as unknown as FiberBrowserNode;
+}
+
+describe('useFiberPayment', () => {
+  it('supports staged parse/send/wait APIs', async () => {
+    const node = createNodeMock();
+    const { result } = renderHook(() => useFiberPayment(node));
+
+    let parsed: Awaited<ReturnType<FiberBrowserNode['parseInvoice']>> | undefined;
+    await act(async () => {
+      parsed = await result.current.parseInvoice('ln-invoice');
+    });
+
+    expect(node.parseInvoice).toHaveBeenCalledWith({ invoice: 'ln-invoice' });
+    expect(parsed?.invoice.data.payment_hash).toBe('0xabc');
+
+    await act(async () => {
+      await result.current.sendPayment('ln-invoice');
+    });
+
+    expect(node.sendPayment).toHaveBeenCalledWith({ invoice: 'ln-invoice' });
+    expect(result.current.isPaying).toBe(false);
+
+    let payment: Awaited<ReturnType<FiberBrowserNode['waitForPayment']>> | undefined;
+    await act(async () => {
+      payment = await result.current.waitForPayment('0xabc');
+    });
+
+    expect(node.waitForPayment).toHaveBeenCalledWith('0xabc');
+    expect(payment?.status).toBe('Succeeded');
+    expect(result.current.paymentResult?.status).toBe('Succeeded');
+    expect(result.current.error).toBeNull();
+  });
+
+  it('sets error when staged methods are called without an initialized node', async () => {
+    const { result } = renderHook(() => useFiberPayment(null));
+
+    let thrown: unknown;
+    await act(async () => {
+      try {
+        await result.current.sendPayment('ln-invoice');
+      } catch (error) {
+        thrown = error;
+      }
+    });
+
+    expect((thrown as Error).message).toBe('Node is not initialized');
+    expect(result.current.error).toBe('Node is not initialized');
+    expect(result.current.isPaying).toBe(false);
+  });
+
+  it('keeps payInvoice convenience flow working', async () => {
+    const node = createNodeMock();
+    const { result } = renderHook(() => useFiberPayment(node));
+
+    await act(async () => {
+      await result.current.payInvoice('ln-convenience');
+    });
+
+    expect(node.parseInvoice).toHaveBeenCalledWith({ invoice: 'ln-convenience' });
+    expect(node.sendPayment).toHaveBeenCalledWith({ invoice: 'ln-convenience' });
+    expect(node.waitForPayment).toHaveBeenCalledWith('0xabc');
+    expect(result.current.paymentResult?.status).toBe('Succeeded');
+    expect(result.current.error).toBeNull();
+  });
+
+  it('captures failed payment message from payInvoice', async () => {
+    const node = createNodeMock({
+      waitForPayment: vi.fn(async () => ({ status: 'Failed', failed_error: 'route not found' })),
+    });
+    const { result } = renderHook(() => useFiberPayment(node));
+
+    await act(async () => {
+      await result.current.payInvoice('ln-failed');
+    });
+
+    expect(result.current.paymentResult).toBeNull();
+    expect(result.current.error).toBe('route not found');
+    expect(result.current.isPaying).toBe(false);
+  });
+});

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -58,6 +58,9 @@ For multithreaded WASM runtime support (`SharedArrayBuffer`), serve the app with
 
 Without these headers, browser node startup can fail at runtime.
 
+In production deployments, configure these headers at your hosting layer (for example
+Nginx, Cloudflare, or Vercel), not only in local dev tooling.
+
 ### Bundle Size Expectations
 
 The Fiber browser runtime is intentionally heavy. Expect a large WASM-related chunk in production builds

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -30,6 +30,12 @@ console.log(info.pubkey);
 
 ## Browser Usage
 
+Browser integrations also need the Fiber WASM runtime peer dependency:
+
+```bash
+pnpm add @fiber-pay/sdk @nervosnetwork/fiber-js
+```
+
 Use the browser subpath in frontend apps to avoid pulling Node-only modules:
 
 ```ts
@@ -42,6 +48,21 @@ const client = new BrowserRpcClient({
 const info = await client.nodeInfo();
 console.log(info.pubkey);
 ```
+
+### Browser Runtime Requirements
+
+For multithreaded WASM runtime support (`SharedArrayBuffer`), serve the app with:
+
+- `Cross-Origin-Opener-Policy: same-origin`
+- `Cross-Origin-Embedder-Policy: require-corp`
+
+Without these headers, browser node startup can fail at runtime.
+
+### Bundle Size Expectations
+
+The Fiber browser runtime is intentionally heavy. Expect a large WASM-related chunk in production builds
+(roughly ~14 MB raw and ~6.5 MB gzip in current examples). Prefer route-level code splitting and lazy
+mounting so the chunk loads only when payment/node features are needed.
 
 `@fiber-pay/sdk/browser` also exports `FiberRpcClient` for migration compatibility.
 


### PR DESCRIPTION
## Summary

This PR addresses the valid DX gaps from issue #150 and documents which reported points were already fixed on current `master`.

### Issue validity check on current `master`

- Already fixed / not reproducible now:
  - **#1 Type declaration gap**: `packages/sdk/dist/browser/index.d.ts` exists.
  - **#5 `strategy="auto"` docs mismatch**: `ConnectButton` now only supports `passkey | password`.
- Still valid (fully or partially):
  - **#2 Bundle size clarity**: builds still include a large WASM-related chunk (~14MB raw / ~6.5MB gzip in examples).
  - **#3 COOP/COEP visibility**: requirement existed but was too easy to miss in docs.
  - **#4 Install guidance completeness**: quickstart install command was missing `@nervosnetwork/fiber-js`.
  - **#6 `useFiberPayment` staged flow**: only `payInvoice` was exposed.
  - **#7 Recovery guidance**: runtime retry pattern existed in code but was undocumented.

## Changes

- `@fiber-pay/react`: add staged payment methods to `useFiberPayment`:
  - `parseInvoice(invoice)`
  - `sendPayment(invoice)`
  - `waitForPayment(paymentHash)`
  - keep `payInvoice(invoice)` unchanged for backward compatibility
- Add tests for new `useFiberPayment` staged methods and compatibility path.
- Docs updates:
  - React README: browser requirements (COOP/COEP), bundle-size expectations, staged payment usage, retry pattern.
  - SDK README: browser peer dependency install note, browser requirements, bundle-size expectations.
  - Quickstart doc: install command now includes `@nervosnetwork/fiber-js`, plus explicit browser requirements.
- Add changeset for `@fiber-pay/react` patch release.

## Validation

- `cd packages/react && pnpm test && pnpm typecheck && pnpm build`
- `pnpm format:check`
- `pnpm lint`
- Commit hook also ran full repo `build/typecheck/test` successfully.

Closes #150
