### PR TITLE
fix(example): gate CCC wallet connector section by external funding toggle

### DIFF
--- a/.changeset/bright-schools-jump.md
+++ b/.changeset/bright-schools-jump.md
@@ -1,0 +1,7 @@
+---
+"@fiber-pay/react": patch
+---
+
+Update the `react-fiber-node-button-lab` example so the custom CCC wallet connector section is only rendered when external funding mode is enabled.
+
+This aligns the demo UI with the actual channel-open funding flow and avoids showing external wallet controls while internal funding mode is active.

--- a/examples/react-fiber-node-button-lab/src/App.tsx
+++ b/examples/react-fiber-node-button-lab/src/App.tsx
@@ -621,7 +621,9 @@ export function App() {
                       <div style={{ display: 'grid', gap: 6 }}>
                         <div style={{ fontSize: 12, color: '#475569' }}>
                           CCC wallet: <strong>{connectedExternalWallet?.name ?? 'Not connected'}</strong>
-                          {externalWalletAddress ? ` | address: ${shorten(externalWalletAddress, 20, 10)}` : ''}
+                          {connectedExternalWallet && externalWalletAddress
+                            ? ` | address: ${shorten(externalWalletAddress, 20, 10)}`
+                            : ''}
                         </div>
                         <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
                           <button

--- a/examples/react-fiber-node-button-lab/src/App.tsx
+++ b/examples/react-fiber-node-button-lab/src/App.tsx
@@ -615,52 +615,56 @@ export function App() {
               tabs={customTabMode ? customTabs : undefined}
               t={customTabMode ? customI18n : undefined}
               renderAction={customTabMode ? customRenderAction : undefined}
-              renderConnectorSection={() => (
-                <div style={{ display: 'grid', gap: 6 }}>
-                  <div style={{ fontSize: 12, color: '#475569' }}>
-                    CCC wallet: <strong>{connectedExternalWallet?.name ?? 'Not connected'}</strong>
-                    {externalWalletAddress ? ` | address: ${shorten(externalWalletAddress, 20, 10)}` : ''}
-                  </div>
-                  <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
-                    <button
-                      type="button"
-                      onClick={() => {
-                        void openExternalWalletConnectModal();
-                      }}
-                      style={{
-                        border: '1px solid #1d4ed8',
-                        borderRadius: 8,
-                        padding: '6px 10px',
-                        background: '#2563eb',
-                        color: '#fff',
-                        cursor: 'pointer',
-                        fontWeight: 700,
-                      }}
-                    >
-                      {connectedExternalWallet ? 'Switch External Wallet' : 'Connect External Wallet'}
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => {
-                        void disconnectExternalWallet();
-                      }}
-                      disabled={!connectedExternalWallet}
-                      style={{
-                        border: '1px solid #cbd5e1',
-                        borderRadius: 8,
-                        padding: '6px 10px',
-                        background: '#fff',
-                        color: '#111827',
-                        cursor: connectedExternalWallet ? 'pointer' : 'not-allowed',
-                        opacity: connectedExternalWallet ? 1 : 0.65,
-                        fontWeight: 700,
-                      }}
-                    >
-                      Disconnect External Wallet
-                    </button>
-                  </div>
-                </div>
-              )}
+              renderConnectorSection={
+                externalWallet
+                  ? () => (
+                      <div style={{ display: 'grid', gap: 6 }}>
+                        <div style={{ fontSize: 12, color: '#475569' }}>
+                          CCC wallet: <strong>{connectedExternalWallet?.name ?? 'Not connected'}</strong>
+                          {externalWalletAddress ? ` | address: ${shorten(externalWalletAddress, 20, 10)}` : ''}
+                        </div>
+                        <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+                          <button
+                            type="button"
+                            onClick={() => {
+                              void openExternalWalletConnectModal();
+                            }}
+                            style={{
+                              border: '1px solid #1d4ed8',
+                              borderRadius: 8,
+                              padding: '6px 10px',
+                              background: '#2563eb',
+                              color: '#fff',
+                              cursor: 'pointer',
+                              fontWeight: 700,
+                            }}
+                          >
+                            {connectedExternalWallet ? 'Switch External Wallet' : 'Connect External Wallet'}
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => {
+                              void disconnectExternalWallet();
+                            }}
+                            disabled={!connectedExternalWallet}
+                            style={{
+                              border: '1px solid #cbd5e1',
+                              borderRadius: 8,
+                              padding: '6px 10px',
+                              background: '#fff',
+                              color: '#111827',
+                              cursor: connectedExternalWallet ? 'pointer' : 'not-allowed',
+                              opacity: connectedExternalWallet ? 1 : 0.65,
+                              fontWeight: 700,
+                            }}
+                          >
+                            Disconnect External Wallet
+                          </button>
+                        </div>
+                      </div>
+                    )
+                  : undefined
+              }
             />
 
             <div style={styles.fundingCard}>


### PR DESCRIPTION
## Summary
- gate custom connector section rendering in the lab example
- show CCC wallet connect/disconnect UI only when external funding mode is enabled
- keep internal funding mode UI clean to match actual runtime behavior

## Validation
- example-react-fiber-node-button-lab build passed (tsc -b && vite build)
- repository hooks completed successfully during commit (format/lint/build/typecheck/test)
