### PR TITLE
docs: refresh skills/readmes and mark agent package experimental

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ Fiber target: `v0.8.0`
 - `@fiber-pay/runtime`: orchestration runtime for jobs, monitoring, retries, and proxy-facing automation loops
 - `@fiber-pay/node`: easy handling for the local `fnn` binary lifecycle
 
+Package maturity note:
+`@fiber-pay/agent` is currently experimental and not recommended for production use yet (limited validation coverage and ongoing hardening).
+
 ## Why this repo is AI-friendly
 
 - Canonical skill guide for agents: `skills/fiber-pay/SKILL.md`

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -2,6 +2,10 @@
 
 AI-agent orchestration layer for Fiber Network (targeting Fiber `v0.8.0`).
 
+> Status: Experimental. This package is currently **not recommended** for production use.
+> It has not been fully validated by end-to-end tests yet, and implementation quality is still rough.
+> Prefer `@fiber-pay/cli` and `@fiber-pay/sdk` for stable integrations.
+
 This package provides:
 
 - `FiberPay`: high-level, agent-friendly API on top of `@fiber-pay/sdk` + `@fiber-pay/node`
@@ -143,3 +147,4 @@ See `src/mcp-tools.ts` for complete tool names and JSON schemas.
 
 - No dedicated `@fiber-pay/agent` test suite yet
 - MCP runtime execution adapter is not bundled in this package
+- API behavior may still change while the package is being hardened

--- a/skills/fiber-pay/SKILL.md
+++ b/skills/fiber-pay/SKILL.md
@@ -7,7 +7,7 @@ description: Operate CKB Lightning payments through fiber-pay CLI. Use when task
 
 fiber-pay is an AI payment layer over Fiber Network for CKB Lightning. It provides an AI-friendly CLI to manage node lifecycle, channels, invoices, payments, and more.
 
-- Last updated: 2026-02-19
+- Last updated: 2026-05-26
 - Fiber node target: v0.8.0
 - Fiber RPC reference: https://github.com/nervosnetwork/fiber/blob/v0.8.0/crates/fiber-lib/src/rpc/README.md
 
@@ -76,4 +76,4 @@ Read [references/rebalance.md](references/rebalance.md) for channel liquidity re
 - **Runtime API**: Read [references/runtime-api.md](references/runtime-api.md) for `/jobs/*` and `/monitor/*` endpoints and state model.
 - **Password Management**: Read [references/password-management.md](references/password-management.md) for CLI keystore encryption, security best practices, and the novel WebAuthn Passkey integration for browser environments.
 - **Browser WASM Integration**: Read [references/wasm-browser.md](references/wasm-browser.md) for building browser-based native Fiber nodes using SDK, Vite COOP/COEP isolation, and WebAuthn credential pipelines.
-- **L402 & Agent Service**: Read [references/l402-agent.md](references/l402-agent.md) for L402 payment-gated APIs, `l402 proxy`, `agent serve`, and `agent call` commands. Covers per-session Linux namespace isolation (PID + mount + user namespaces via `unshare`), BoxLite Alpine setup (`scripts/boxlite-setup.sh`), session workspace layout, and the `--no-isolation` debug flag.
+- **L402 & Agent Service**: Read [references/l402-agent.md](references/l402-agent.md) for L402 payment-gated APIs, `l402 proxy`, `agent serve`, and `agent call` commands. Covers per-session Linux namespace isolation (PID + mount + user namespaces via `unshare`), BoxLite Alpine setup (`scripts/boxlite-setup.sh`), and session workspace layout. Isolation is mandatory and no bypass debug flag is supported.

--- a/skills/fiber-pay/references/auth.md
+++ b/skills/fiber-pay/references/auth.md
@@ -23,7 +23,7 @@ rpc:
   biscuit_public_key: "ed25519/<public-key>"
 ```
 
-Related config key reference: see `references/config.md` (`rpc.biscuit_public_key`).
+Related config key reference: see [config.md](config.md) (`rpc.biscuit_public_key`).
 
 ## 2) CLI usage
 

--- a/skills/fiber-pay/references/config.md
+++ b/skills/fiber-pay/references/config.md
@@ -2,7 +2,7 @@
 
 - Structured reference for `config.yml` used by the Fiber Network Node (`fnn`). 
 - All values are set via `fiber-pay config set <path> <value>`.
-- Full commented fnn config.yml artifact: [references/fnn.reference.yml](references/fnn.reference.yml)
+- Full commented fnn config.yml artifact: [fnn.reference.yml](fnn.reference.yml)
 
 ## Top-level
 
@@ -148,8 +148,10 @@ Requires `cch` in `services`.
 
 ## Config priority
 
-1. CLI flags (`--fiber-listening-addr ...`)
-2. Environment variables (`FIBER_LISTENING_ADDR=...`)
+For `fnn` runtime resolution (not fiber-pay CLI global flags), effective value priority is:
+
+1. `fnn` CLI flags (for example `--fiber-listening-addr ...`)
+2. Environment variables (for example `FIBER_LISTENING_ADDR=...`)
 3. `config.yml` (lowest priority)
 
 ## CLI config operations

--- a/skills/fiber-pay/references/configuration.md
+++ b/skills/fiber-pay/references/configuration.md
@@ -55,4 +55,4 @@ The reference file includes useful operational notes:
 
 Use `skills/fiber-pay/references/fnn.reference.yml` when exploring advanced keys that are not yet exposed as first-class CLI flags.
 
-For RPC Biscuit authentication setup and token usage, see `skills/fiber-pay/references/auth.md`.
+For RPC Biscuit authentication setup and token usage, see [auth.md](auth.md).

--- a/skills/fiber-pay/references/l402-agent.md
+++ b/skills/fiber-pay/references/l402-agent.md
@@ -42,11 +42,15 @@ fiber-pay agent serve --agent opencode --price 0.1 --root-key <hex> --approve-al
 
 - Endpoint: `POST /` with `{"prompt": "..."}` for a new session, or
    `{"prompt": "...", "sessionId": "...", "sessionToken": "..."}` to resume.
-- Requires: `npm install -g acpx` and the target agent installed
+- Requires: a reachable BoxLite sandbox (`--boxlite-url`, `--boxlite-box-id`) with `acpx` and the target agent CLI installed in the Box.
 - Agents: any acpx-compatible — `codex`, `claude`, `opencode`, `gemini`, `pi`, etc.
 - Session mode: server issues `sessionId` + `sessionToken`; clients must send both to resume.
 
-Key flags: `--port`, `--cwd`, `--timeout`, `--approve-all`, `--format`.
+Common key flags: `--port`, `--host`, `--cwd`, `--timeout`, `--approve-all`, `--format`, `--boxlite-url`, `--boxlite-box-id`, `--proxy-port`, `--proxy-host-addr`.
+
+Security note:
+
+- `--no-proxy` is local debug only and guarded by `FIBER_PAY_ALLOW_INSECURE_NO_PROXY=1` plus loopback `--host`.
 
 ### Per-session Linux namespace isolation
 


### PR DESCRIPTION
## Summary
- refresh skill/readme wording to remove stale `--no-isolation` references
- mark `@fiber-pay/agent` as experimental and currently not recommended for production use
- add root README maturity note so users see package status early

## Changes
- update `skills/fiber-pay/SKILL.md`
  - bump `Last updated` date
  - replace stale wording about `--no-isolation` with mandatory-isolation statement
- update `packages/agent/README.md`
  - add explicit warning that package is experimental / not recommended yet
  - note limited validation and rough implementation state
  - extend known gaps with API-stability caveat
- update `README.md`
  - add package maturity note for `@fiber-pay/agent`

## Validation
- repository hooks ran successfully during commit:
  - format check
  - lint
  - build
  - typecheck
  - test

