### PR TITLE
chore: upgrade wasm smoke to Fiber 0.8.1 and sync docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 AI-friendly toolchain for CKB Lightning on Fiber Network.
 
-Fiber target: `v0.8.0`
+Fiber target: `v0.8.1`
 
 ## Start Here: CLI + SDK
 

--- a/e2e/wasm-smoke/package.json
+++ b/e2e/wasm-smoke/package.json
@@ -8,7 +8,7 @@
     "smoke:ci": "node ./ci-smoke.mjs"
   },
   "dependencies": {
-    "@nervosnetwork/fiber-js": "0.7.1"
+    "@nervosnetwork/fiber-js": "0.8.1"
   },
   "devDependencies": {
     "playwright": "^1.55.0",

--- a/e2e/wasm-smoke/src/main.ts
+++ b/e2e/wasm-smoke/src/main.ts
@@ -134,9 +134,11 @@ async function runSmokeTests() {
   // --- Test 5: node_info ---
   try {
     const info = await adapter!.nodeInfo();
-    if (!info.node_id) throw new Error('node_id missing');
+    const nodeIdentity = (info as { pubkey?: string; node_id?: string }).pubkey
+      ?? (info as { pubkey?: string; node_id?: string }).node_id;
+    if (!nodeIdentity) throw new Error('pubkey/node_id missing');
     pass('node_info');
-    log(`  Node ID: ${info.node_id}`, 'info');
+    log(`  Node Pubkey: ${nodeIdentity}`, 'info');
     log(`  Version: ${info.version}`, 'info');
     log(`  Chain:   ${info.chain_hash}`, 'info');
     totalPass++;

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -1,6 +1,6 @@
 # @fiber-pay/agent
 
-AI-agent orchestration layer for Fiber Network (targeting Fiber `v0.8.0`).
+AI-agent orchestration layer for Fiber Network (targeting Fiber `v0.8.1`).
 
 > Status: Experimental. This package is currently **not recommended** for production use.
 > It has not been fully validated by end-to-end tests yet, and implementation quality is still rough.
@@ -141,7 +141,7 @@ See `src/mcp-tools.ts` for complete tool names and JSON schemas.
 ## Compatibility
 
 - Node.js: `>=20`
-- Fiber RPC semantics: aligned with Fiber `v0.8.0`
+- Fiber RPC semantics: aligned with Fiber `v0.8.1`
 
 ## Known gaps
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -23,5 +23,5 @@ See [docs/l402-agent-guide.md](./docs/l402-agent-guide.md) for L402 and agent de
 ## Compatibility
 
 - Node.js `>=20`
-- Fiber target: `v0.8.0`
+- Fiber target: `v0.8.1`
 

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -17,4 +17,4 @@ import { createFiberNodeManager } from '@fiber-pay/node';
 ## Compatibility
 
 - Node.js `>=20`
-- Fiber target: `v0.8.0`
+- Fiber target: `v0.8.1`

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -1,6 +1,6 @@
 # @fiber-pay/runtime
 
-Runtime monitor + job orchestration for Fiber (`fnn v0.8.0`).
+Runtime monitor + job orchestration for Fiber (`fnn v0.8.1`).
 
 ## Quick start
 

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -129,4 +129,4 @@ See [packages/cli/docs/l402-agent-guide.md](../cli/docs/l402-agent-guide.md) for
 ## Compatibility
 
 - Node.js `>=20`
-- Fiber target: `v0.8.0`
+- Fiber target: `v0.8.1`

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,8 +36,8 @@ importers:
   e2e/wasm-smoke:
     dependencies:
       '@nervosnetwork/fiber-js':
-        specifier: 0.7.1
-        version: 0.7.1
+        specifier: 0.8.1
+        version: 0.8.1
     devDependencies:
       playwright:
         specifier: ^1.55.0
@@ -1043,9 +1043,6 @@ packages:
 
   '@nervosnetwork/ckb-types@0.109.5':
     resolution: {integrity: sha512-5jQNjFw76YCd+Ppl+0RvBWzxwvWaKfWC5wjVFFdNAieX7xksCHfZFIeow8je7AF8uVypwe56WlLBlblxw9NBBQ==}
-
-  '@nervosnetwork/fiber-js@0.7.1':
-    resolution: {integrity: sha512-58LHLTirWUvqlWGj0F0xQJNjx60hIol0rHrPmC68L01I5muH5QQF14Tm5UQ3q9qX+yEvV1esWGowtlnLUh6U0A==}
 
   '@nervosnetwork/fiber-js@0.8.1':
     resolution: {integrity: sha512-T37qCsvrcVGeX1fjv6FrgwhfwiWPqvVmJfil5tirdYevvoZCcfigqrknMdl1lDar4l1HypDswD4szbD0b3Nz/w==}
@@ -4206,11 +4203,6 @@ snapshots:
       tslib: 2.3.1
 
   '@nervosnetwork/ckb-types@0.109.5': {}
-
-  '@nervosnetwork/fiber-js@0.7.1':
-    dependencies:
-      async-mutex: 0.5.0
-      stream-browserify: 3.0.0
 
   '@nervosnetwork/fiber-js@0.8.1':
     dependencies:

--- a/skills/fiber-pay/references/fnn.reference.yml
+++ b/skills/fiber-pay/references/fnn.reference.yml
@@ -1,7 +1,7 @@
 # =============================================================================
 # Fiber Network Node (fnn) - Full Configuration Reference
 # =============================================================================
-# Version: v0.7.1
+# Version: v0.8.1
 #
 # Usage:
 #   fnn --config /path/to/config.yml


### PR DESCRIPTION
## Summary
- upgrade `e2e/wasm-smoke` dependency `@nervosnetwork/fiber-js` from `0.7.1` to `0.8.1`
- sync skill reference header version in `skills/fiber-pay/references/fnn.reference.yml` from `v0.7.1` to `v0.8.1`
- update wasm smoke `node_info` assertion to support Fiber v0.8.x field naming (`pubkey`) while keeping fallback compatibility with legacy `node_id`
- refresh lockfile to remove the remaining `@nervosnetwork/fiber-js@0.7.1` entry

## Why
Main code paths are already on Fiber v0.8.1, but `e2e/wasm-smoke` was still pinned to 0.7.1 and the smoke assertion still expected pre-v0.8 field naming.

## Validation
- `cd e2e/wasm-smoke && pnpm build`
- `cd e2e/wasm-smoke && pnpm smoke:ci` (title result: `PASS: 8 passed, 0 failed`)
- pre-commit hooks also ran full repo checks (format/lint/build/typecheck/test) and passed
