### PR TITLE
feat(sdk): add CCC external funding resolver helper

### DIFF
--- a/.changeset/khaki-donkeys-tickle.md
+++ b/.changeset/khaki-donkeys-tickle.md
@@ -1,0 +1,5 @@
+---
+"@fiber-pay/sdk": patch
+---
+
+Add `createCccExternalFundingResolver` runtime validation for signer capabilities and recommended address shape, and improve docs/examples for copy-pasteable known script configuration.

--- a/examples/react-fiber-node-button-lab/src/App.tsx
+++ b/examples/react-fiber-node-button-lab/src/App.tsx
@@ -6,10 +6,8 @@ import {
   useFiberNode,
 } from '@fiber-pay/react';
 import {
-  cccScriptToFiberScript,
-  createCccSignFundingTx,
-  resolveFundingLockCellDepsByKnownScript,
-  type Script,
+  createCccExternalFundingResolver,
+  type CccRecommendedAddressObjLike,
 } from '@fiber-pay/sdk/browser';
 import { type CSSProperties, useCallback, useEffect, useMemo, useState } from 'react';
 
@@ -363,36 +361,25 @@ export function App() {
     };
   }, [addLog, cccSigner, externalWallet]);
 
-  const resolveExternalFunding = useCallback(
-    async () => {
-      if (!cccSigner) {
+  const resolveExternalFunding = useMemo(() => {
+    if (!cccSigner) {
+      return async () => {
         throw new Error('External wallet mode requires a connected CCC wallet signer.');
-      }
-
-      const addressObj = await cccSigner.getRecommendedAddressObj();
-      const walletScript: Script = cccScriptToFiberScript(addressObj.script);
-      const resolvedDeps = await resolveFundingLockCellDepsByKnownScript(
-        cccSigner,
-        walletScript,
-        Object.values(ccc.KnownScript),
-      );
-
-      setExternalWalletAddress(addressObj.toString());
-
-      if (resolvedDeps?.knownScript) {
-        addLog(`Using CCC known script deps: ${resolvedDeps.knownScript}.`);
-      }
-
-      return {
-        signFundingTx: createCccSignFundingTx(cccSigner),
-        shutdownScript: walletScript,
-        fundingLockScript: walletScript,
-        fundingLockScriptCellDeps: resolvedDeps?.cellDeps,
-        ckbRpcUrl: TESTNET_CKB_RPC_URL,
       };
-    },
-    [addLog, cccSigner],
-  );
+    }
+
+    return createCccExternalFundingResolver({
+      signer: cccSigner,
+      knownScripts: Object.values(ccc.KnownScript),
+      ckbRpcUrl: TESTNET_CKB_RPC_URL,
+      onKnownScriptResolved: (knownScript: string) => {
+        addLog(`Using CCC known script deps: ${knownScript}.`);
+      },
+      onAddressResolved: (addressObj: CccRecommendedAddressObjLike) => {
+        setExternalWalletAddress(addressObj.toString?.() ?? null);
+      },
+    });
+  }, [addLog, cccSigner]);
 
   const externalWalletToggleLocked = fiber.isRunning || fiber.isStarting;
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -154,11 +154,12 @@ If you use CCC wallets, `@fiber-pay/sdk/browser` provides
 `createCccExternalFundingResolver(...)` so you do not need to handwrite resolve logic:
 
 ```tsx
+import { ccc } from '@ckb-ccc/connector-react';
 import { createCccExternalFundingResolver } from '@fiber-pay/sdk/browser';
 
 const resolveExternalFunding = createCccExternalFundingResolver({
   signer: cccSigner,
-  knownScripts: ['SECP256K1_BLAKE160'],
+  knownScripts: Object.values(ccc.KnownScript),
   ckbRpcUrl: 'https://testnet.ckbapp.dev/',
 });
 ```

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -158,7 +158,7 @@ import { createCccExternalFundingResolver } from '@fiber-pay/sdk/browser';
 
 const resolveExternalFunding = createCccExternalFundingResolver({
   signer: cccSigner,
-  knownScripts: Object.values(ccc.KnownScript),
+  knownScripts: ['SECP256K1_BLAKE160'],
   ckbRpcUrl: 'https://testnet.ckbapp.dev/',
 });
 ```

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -150,6 +150,19 @@ export function WalletEntry() {
 For external funding, pass `externalFunding` with an async `resolve` callback that returns
 `signFundingTx` and optional script / dep overrides.
 
+If you use CCC wallets, `@fiber-pay/sdk/browser` provides
+`createCccExternalFundingResolver(...)` so you do not need to handwrite resolve logic:
+
+```tsx
+import { createCccExternalFundingResolver } from '@fiber-pay/sdk/browser';
+
+const resolveExternalFunding = createCccExternalFundingResolver({
+  signer: cccSigner,
+  knownScripts: Object.values(ccc.KnownScript),
+  ckbRpcUrl: 'https://testnet.ckbapp.dev/',
+});
+```
+
 ### Customizing The Panel
 
 `FiberNodeButton` now supports additive panel customization without forking the component:

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -34,11 +34,12 @@ For external wallet channel funding in React UIs (for example `FiberNodeButton`)
 you can use a prebuilt CCC resolver factory instead of wiring scripts/deps manually.
 
 ```ts
+import { ccc } from '@ckb-ccc/connector-react';
 import { createCccExternalFundingResolver } from '@fiber-pay/sdk/browser';
 
 const resolveExternalFunding = createCccExternalFundingResolver({
   signer: cccSigner,
-  knownScripts: ['SECP256K1_BLAKE160'],
+  knownScripts: Object.values(ccc.KnownScript),
   ckbRpcUrl: 'https://testnet.ckbapp.dev/',
 });
 

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -38,7 +38,7 @@ import { createCccExternalFundingResolver } from '@fiber-pay/sdk/browser';
 
 const resolveExternalFunding = createCccExternalFundingResolver({
   signer: cccSigner,
-  knownScripts: Object.values(ccc.KnownScript),
+  knownScripts: ['SECP256K1_BLAKE160'],
   ckbRpcUrl: 'https://testnet.ckbapp.dev/',
 });
 

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -28,6 +28,27 @@ const info = await client.nodeInfo();
 console.log(info.pubkey);
 ```
 
+### CCC External Funding Resolver (React-Friendly)
+
+For external wallet channel funding in React UIs (for example `FiberNodeButton`),
+you can use a prebuilt CCC resolver factory instead of wiring scripts/deps manually.
+
+```ts
+import { createCccExternalFundingResolver } from '@fiber-pay/sdk/browser';
+
+const resolveExternalFunding = createCccExternalFundingResolver({
+  signer: cccSigner,
+  knownScripts: Object.values(ccc.KnownScript),
+  ckbRpcUrl: 'https://testnet.ckbapp.dev/',
+});
+
+// FiberNodeButton externalFunding usage
+const externalFunding = {
+  enabled: true,
+  resolve: resolveExternalFunding,
+};
+```
+
 ## Browser Usage
 
 Browser integrations also need the Fiber WASM runtime peer dependency:

--- a/packages/sdk/src/browser/ccc-external-funding.ts
+++ b/packages/sdk/src/browser/ccc-external-funding.ts
@@ -166,7 +166,33 @@ export function createCccExternalFundingResolver<TContext = unknown>(
   } = options;
 
   return async (_context: TContext): Promise<CccExternalFundingResolved> => {
+    if (typeof signer.signTransaction !== 'function') {
+      throw new Error(
+        'The provided signer does not support "signTransaction". Please ensure you are passing a compatible CCC signer.',
+      );
+    }
+
+    if (typeof signer.getRecommendedAddressObj !== 'function') {
+      throw new Error(
+        'The provided signer does not support "getRecommendedAddressObj". Please ensure you are passing a compatible CCC signer.',
+      );
+    }
+
+    if (knownScripts.length > 0 && typeof signer.client?.getKnownScript !== 'function') {
+      throw new Error(
+        'The provided signer does not support "client.getKnownScript", which is required when knownScripts are configured.',
+      );
+    }
+
     const addressObj = await signer.getRecommendedAddressObj();
+    if (!addressObj) {
+      throw new Error('Failed to retrieve the recommended address from the signer.');
+    }
+
+    if (!addressObj.script) {
+      throw new Error('The recommended address object is missing the script property.');
+    }
+
     onAddressResolved?.(addressObj);
 
     const walletScript = cccScriptToFiberScript(addressObj.script);

--- a/packages/sdk/src/browser/ccc-external-funding.ts
+++ b/packages/sdk/src/browser/ccc-external-funding.ts
@@ -38,8 +38,34 @@ export interface CccSignerLike {
   };
 }
 
+export interface CccRecommendedAddressObjLike {
+  script: CccScriptLike;
+  toString?: () => string;
+}
+
+export interface CccFundingSignerLike extends CccSignerLike {
+  getRecommendedAddressObj: () => Promise<CccRecommendedAddressObjLike>;
+}
+
 export interface CreateCccSignFundingTxOptions {
   toRpcTransaction?: (signedTx: unknown) => Record<string, unknown>;
+}
+
+export interface CccExternalFundingResolved {
+  signFundingTx: (txForSigner: unknown) => Promise<unknown>;
+  shutdownScript: Script;
+  fundingLockScript: Script;
+  fundingLockScriptCellDeps?: CellDep[];
+  ckbRpcUrl?: string;
+}
+
+export interface CreateCccExternalFundingResolverOptions {
+  signer: CccFundingSignerLike;
+  knownScripts?: readonly string[];
+  ckbRpcUrl?: string;
+  signFundingTxOptions?: CreateCccSignFundingTxOptions;
+  onKnownScriptResolved?: (knownScript: string) => void;
+  onAddressResolved?: (address: CccRecommendedAddressObjLike) => void;
 }
 
 function toHexPrefixed(value: string): HexString {
@@ -124,5 +150,41 @@ export function createCccSignFundingTx(
   return async (txForSigner: unknown): Promise<Record<string, unknown>> => {
     const signedTx = await signer.signTransaction(txForSigner);
     return toRpcTransaction(signedTx);
+  };
+}
+
+export function createCccExternalFundingResolver<TContext = unknown>(
+  options: CreateCccExternalFundingResolverOptions,
+) {
+  const {
+    signer,
+    knownScripts = [],
+    ckbRpcUrl,
+    signFundingTxOptions,
+    onKnownScriptResolved,
+    onAddressResolved,
+  } = options;
+
+  return async (_context: TContext): Promise<CccExternalFundingResolved> => {
+    const addressObj = await signer.getRecommendedAddressObj();
+    onAddressResolved?.(addressObj);
+
+    const walletScript = cccScriptToFiberScript(addressObj.script);
+    const resolvedDeps =
+      knownScripts.length > 0
+        ? await resolveFundingLockCellDepsByKnownScript(signer, walletScript, knownScripts)
+        : null;
+
+    if (resolvedDeps?.knownScript) {
+      onKnownScriptResolved?.(resolvedDeps.knownScript);
+    }
+
+    return {
+      signFundingTx: createCccSignFundingTx(signer, signFundingTxOptions),
+      shutdownScript: walletScript,
+      fundingLockScript: walletScript,
+      fundingLockScriptCellDeps: resolvedDeps?.cellDeps,
+      ckbRpcUrl,
+    };
   };
 }

--- a/packages/sdk/src/browser/index.ts
+++ b/packages/sdk/src/browser/index.ts
@@ -125,12 +125,17 @@ export type {
 export { ChannelState } from '../types/rpc.js';
 export { ckbToShannons, fromHex, shannonsToCkb, toHex } from '../utils.js';
 export {
+  type CccExternalFundingResolved,
+  type CccFundingSignerLike,
   type CccKnownScriptCellDepLike,
   type CccKnownScriptInfoLike,
+  type CccRecommendedAddressObjLike,
   type CccScriptLike,
   type CccSignerLike,
+  type CreateCccExternalFundingResolverOptions,
   type CreateCccSignFundingTxOptions,
   cccScriptToFiberScript,
+  createCccExternalFundingResolver,
   createCccSignFundingTx,
   resolveFundingLockCellDepsByKnownScript,
 } from './ccc-external-funding.js';

--- a/packages/sdk/tests/ccc-external-funding.test.ts
+++ b/packages/sdk/tests/ccc-external-funding.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
 	cccScriptToFiberScript,
+	createCccExternalFundingResolver,
 	createCccSignFundingTx,
 	resolveFundingLockCellDepsByKnownScript,
 } from '../src/browser/ccc-external-funding.js';
@@ -86,5 +87,90 @@ describe('ccc external funding helpers', () => {
 		const signFundingTx = createCccSignFundingTx(signer);
 		const result = await signFundingTx({ inputs: [] });
 		expect(result.cell_deps?.[0]?.dep_type).toBe('dep_group');
+	});
+
+	it('creates a CCC external funding resolver for FiberNodeButton-style flows', async () => {
+		const onKnownScriptResolved = vi.fn();
+		const onAddressResolved = vi.fn();
+		const signer = {
+			signTransaction: vi.fn(async (tx: unknown) => tx),
+			getRecommendedAddressObj: vi.fn(async () => ({
+				script: {
+					codeHash: '0x1234',
+					hashType: 'type' as const,
+					args: '0xabcd',
+				},
+				toString: () => 'ckt1qyqv9...',
+			})),
+			client: {
+				getKnownScript: vi.fn(async () => ({
+					codeHash: '0x1234',
+					hashType: 'type' as const,
+					cellDeps: [
+						{
+							cellDep: {
+								outPoint: {
+									txHash: '0xbeef',
+									index: 1,
+								},
+								depType: 'code' as const,
+							},
+						},
+					],
+				})),
+			},
+		};
+
+		const resolve = createCccExternalFundingResolver({
+			signer,
+			knownScripts: ['SECP256K1_BLAKE160'],
+			ckbRpcUrl: 'https://testnet.ckbapp.dev/',
+			onKnownScriptResolved,
+			onAddressResolved,
+		});
+
+		const result = await resolve({});
+
+		expect(result.shutdownScript).toEqual({
+			code_hash: '0x1234',
+			hash_type: 'type',
+			args: '0xabcd',
+		});
+		expect(result.fundingLockScript).toEqual(result.shutdownScript);
+		expect(result.fundingLockScriptCellDeps).toEqual([
+			{
+				out_point: {
+					tx_hash: '0xbeef',
+					index: '0x1',
+				},
+				dep_type: 'code',
+			},
+		]);
+		expect(result.ckbRpcUrl).toBe('https://testnet.ckbapp.dev/');
+		expect(typeof result.signFundingTx).toBe('function');
+		expect(onKnownScriptResolved).toHaveBeenCalledWith('SECP256K1_BLAKE160');
+		expect(onAddressResolved).toHaveBeenCalledTimes(1);
+	});
+
+	it('skips known script lookup when no knownScripts are provided', async () => {
+		const signer = {
+			signTransaction: vi.fn(async (tx: unknown) => tx),
+			getRecommendedAddressObj: vi.fn(async () => ({
+				script: {
+					codeHash: '0x1234',
+					hashType: 'type' as const,
+					args: '0xabcd',
+				},
+			})),
+			client: {
+				getKnownScript: vi.fn(),
+			},
+		};
+
+		const resolve = createCccExternalFundingResolver({ signer });
+		const result = await resolve({});
+
+		expect(result.fundingLockScriptCellDeps).toBeUndefined();
+		expect(signer.client.getKnownScript).not.toHaveBeenCalled();
 	});
 });

--- a/packages/sdk/tests/ccc-external-funding.test.ts
+++ b/packages/sdk/tests/ccc-external-funding.test.ts
@@ -173,4 +173,35 @@ describe('ccc external funding helpers', () => {
 		expect(result.fundingLockScriptCellDeps).toBeUndefined();
 		expect(signer.client.getKnownScript).not.toHaveBeenCalled();
 	});
+
+	it('throws a clear error when signer does not support getRecommendedAddressObj', async () => {
+		const resolve = createCccExternalFundingResolver({
+			signer: {
+				signTransaction: vi.fn(async (tx: unknown) => tx),
+				client: {
+					getKnownScript: vi.fn(),
+				},
+			} as unknown as Parameters<typeof createCccExternalFundingResolver>[0]['signer'],
+		});
+
+		await expect(resolve({})).rejects.toThrow(
+			'The provided signer does not support "getRecommendedAddressObj".',
+		);
+	});
+
+	it('throws a clear error when recommended address is missing script', async () => {
+		const resolve = createCccExternalFundingResolver({
+			signer: {
+				signTransaction: vi.fn(async (tx: unknown) => tx),
+				getRecommendedAddressObj: vi.fn(async () => ({})),
+				client: {
+					getKnownScript: vi.fn(),
+				},
+			} as unknown as Parameters<typeof createCccExternalFundingResolver>[0]['signer'],
+		});
+
+		await expect(resolve({})).rejects.toThrow(
+			'The recommended address object is missing the script property.',
+		);
+	});
 });


### PR DESCRIPTION
## Summary
- add createCccExternalFundingResolver in @fiber-pay/sdk/browser to reduce app-side external funding boilerplate
- export new CCC resolver types and helper from browser entrypoint
- migrate react-fiber-node-button-lab to use createCccExternalFundingResolver instead of handwritten resolveExternalFunding internals
- add SDK tests for resolver behavior (normal path + no-knownScripts path)
- document CCC resolver usage in both packages/sdk/README.md and packages/react/README.md

## Validation
- cd packages/sdk && pnpm test -- ccc-external-funding.test.ts
- cd packages/sdk && pnpm typecheck
- cd packages/sdk && pnpm build
- cd examples/react-fiber-node-button-lab && pnpm build
- pre-commit hooks also passed full repo checks (format/lint/build/typecheck/test)

## Notes
- externalFunding.resolve remains app-provided by API design, but CCC integration now has a built-in resolver factory for one-line wiring
