### PR TITLE
fix: remove non-functional Pages enablement from deploy workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -29,9 +29,12 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Pages
+        # Note: GitHub Pages must be enabled manually in the repository settings
+        # (Settings -> Pages -> Build and deployment -> Source: GitHub Actions).
+        # The default GITHUB_TOKEN cannot enable Pages automatically, so we do
+        # not use `enablement: true` here; it fails with
+        # "Resource not accessible by integration".
         uses: actions/configure-pages@v5
-        with:
-          enablement: true
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
## Root cause

The GitHub Pages deploy workflow is failing because GitHub Pages is not enabled for this repository, and the default `GITHUB_TOKEN` cannot enable it automatically.

- PR #163 added `enablement: true` to `actions/configure-pages` to auto-provision Pages.
- However, enabling a Pages site requires `administration:write` permission, which the default `GITHUB_TOKEN` issued to Actions workflows cannot be granted (see [actions/configure-pages docs/issues](https://github.com/actions/configure-pages/issues/188)).
- The resulting error is: `Create Pages site failed. Error: Resource not accessible by integration`.

I verified via the GitHub API that no Pages site exists for this repo yet (`GET /repos/RetricSu/fiber-pay/pages` returns 404).

## Fix

Remove `enablement: true` and add a comment documenting that Pages must be enabled manually in the repository settings before the workflow can succeed.

## Required manual step

After merging this PR, a repository owner still needs to enable GitHub Pages once:

1. Go to **Settings → Pages → Build and deployment**
2. Set **Source** to **GitHub Actions**
3. Click **Save**

Once Pages is enabled, the workflow will be able to upload and deploy the `website` directory on subsequent pushes.