### PR TITLE
docs: add NodeInfoPanel component docs with composition examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Package maturity note:
 | --- | --- |
 | `@fiber-pay/cli` | Stable operator interface and automation-first command surface |
 | `@fiber-pay/sdk` | Typed protocol/client primitives for app integration |
-| `@fiber-pay/react` | React hooks/components for browser WASM + passkey payment flows |
+| `@fiber-pay/react` | React hooks/components for browser WASM + passkey payment flows (`ConnectButton`, `FiberNodeButton`, `FiberPayQuickCard`, `NodeInfoPanel`, `useFiberNode`, `useFiberPayment`) |
 | `@fiber-pay/runtime` | Runtime orchestration (jobs, monitoring, retry loops) |
 | `@fiber-pay/node` | Local `fnn` binary lifecycle management |
 | `@fiber-pay/agent` | Experimental package, not recommended for production yet |

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -65,7 +65,7 @@ Recommended integration strategy:
 ## One-line import
 
 ```tsx
-import { ConnectButton, FiberPayQuickCard, useFiberNode, useFiberPayment } from '@fiber-pay/react';
+import { ConnectButton, FiberNodeButton, FiberPayQuickCard, NodeInfoPanel, useFiberNode, useFiberPayment } from '@fiber-pay/react';
 ```
 
 ## Quick start
@@ -118,6 +118,113 @@ import { Fiber } from '@nervosnetwork/fiber-js';
 export function HeaderWallet() {
   const fiber = useFiberNode({ network: 'testnet', wasmFactory: () => new Fiber() });
   return <ConnectButton fiber={fiber} strategy="passkey" />;
+}
+```
+
+## NodeInfoPanel
+
+`NodeInfoPanel` is a **display-only** component that shows Fiber browser node metadata, real-time stats, and an optional QR code for deposits. It is the complement to `ConnectButton`/`FiberNodeButton` — while those handle connection management and operations, `NodeInfoPanel` provides the dashboard view.
+
+```tsx
+import { NodeInfoPanel, useFiberNode } from '@fiber-pay/react';
+
+export function NodeDashboard() {
+  const fiber = useFiberNode({ network: 'testnet', walletId: 'dashboard' });
+
+  return (
+    <NodeInfoPanel node={fiber.node} network="testnet" showQrCode />
+  );
+}
+```
+
+> **Note:** `NodeInfoPanel` does **not** manage the node lifecycle. It expects a running `FiberBrowserNode` instance passed via the `node` prop — use `useFiberNode` or `ConnectButton`/`FiberNodeButton` for connection management.
+
+### What it shows
+
+| Info | Detail |
+|------|--------|
+| **Node state badge** | Visual status indicator (idle, starting, running, error, etc.) |
+| **Pubkey** | Full display with **copy-to-clipboard button** |
+| **CKB Address** | Derived from the node's lock script, displayed with **copy button** |
+| **Peers / Channels count** | Compact stat cards |
+| **CKB Balance** | Queried from chain via RPC (updated every 15s) |
+| **QR Code** | Optional — shows CKB address for "Scan to deposit CKB" (`showQrCode` prop) |
+
+### Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `node` | `FiberBrowserNode \| null` | — | The running node instance. Pass `null` for idle state. |
+| `network` | `"testnet" \| "mainnet"` | — | Network for address derivation and RPC URL. |
+| `pollInterval` | `number` | `15000` | Stats refresh interval in milliseconds. |
+| `showQrCode` | `boolean` | `false` | Show a QR code of the CKB address (requires `qrcode.react`). |
+| `renderQrCode` | `(value: string) => ReactNode` | — | Override QR rendering with your own library. |
+| `className` | `string` | — | Additional CSS class name(s). |
+| `style` | `CSSProperties` | — | Inline styles. |
+
+### Role comparison
+
+| Capability | ConnectButton | FiberNodeButton | NodeInfoPanel |
+|------------|:---:|:---:|:---:|
+| Connect / Disconnect | ✅ | ✅ | ❌ |
+| Create invoices / Pay | ❌ | ✅ | ❌ |
+| Channel management | ❌ | ✅ | ❌ |
+| Diagnostics (graph/peers) | ❌ | ✅ | ❌ |
+| **Pubkey with copy** | ❌ | ❌ | ✅ |
+| **CKB Address + copy** | ❌ | ❌ | ✅ |
+| **QR code for deposit** | ❌ | ❌ | ✅ |
+| **CKB balance** | ❌ | ❌ | ✅ |
+
+### Combining with other components
+
+`NodeInfoPanel` is designed to compose with `ConnectButton` and `FiberNodeButton` through the shared `useFiberNode` hook:
+
+**Standalone layout** — ConnectButton in the header, NodeInfoPanel in a sidebar:
+```tsx
+import { ConnectButton, NodeInfoPanel, useFiberNode } from '@fiber-pay/react';
+
+export function WalletLayout() {
+  const fiber = useFiberNode({ network: 'testnet', walletId: 'main-wallet' });
+
+  return (
+    <div style={{ display: 'flex', gap: 16 }}>
+      <header>
+        <ConnectButton fiber={fiber} strategy="passkey" />
+      </header>
+      <aside>
+        <NodeInfoPanel node={fiber.node} network="testnet" showQrCode />
+      </aside>
+    </div>
+  );
+}
+```
+
+**As a custom tab in FiberNodeButton** — add a "Deposit" tab inside the existing dropdown (see [Tab customization](#tab-customization) below for more options):
+
+```tsx
+import { FiberNodeButton, NodeInfoPanel, useFiberNode } from '@fiber-pay/react';
+
+export function WalletWithDeposit() {
+  const fiber = useFiberNode({ network: 'testnet', walletId: 'wallet-deposit' });
+
+  return (
+    <FiberNodeButton
+      fiber={fiber}
+      strategy="passkey"
+      tabs={[
+        { id: 'workbench' },
+        { id: 'channels' },
+        {
+          id: 'deposit',
+          label: 'Deposit',
+          render: ({ fiber: { node } }) => (
+            <NodeInfoPanel node={node} network="testnet" showQrCode />
+          ),
+        },
+        { id: 'diagnostics' },
+      ]}
+    />
+  );
 }
 ```
 
@@ -222,6 +329,8 @@ export function WalletEntry() {
 - `renderTabContent(tabId, context)`: override tab body rendering
 - `renderAction(context)`: replace default action button UI/behavior for selected actions (context includes `state`)
 - `t(key, fallback, vars?)`: localize labels and copy
+
+> **Tip:** Use a custom tab to embed `NodeInfoPanel` (see [its section](#nodeinfopanel) above) for a deposit/recharge UI inside `FiberNodeButton`'s dropdown — no extra layout needed.
 
 Render precedence for a tab body is:
 1. `renderTabContent(tabId, context)` when it returns a value other than `undefined`

--- a/packages/react/docs/wasm-passkey-payment-component-quickstart.md
+++ b/packages/react/docs/wasm-passkey-payment-component-quickstart.md
@@ -18,7 +18,7 @@ import { FiberPayQuickCard } from '@fiber-pay/react';
 
 ## What You Get Today
 
-- `@fiber-pay/react`: official React hooks and starter component (`useFiberNode`, `useFiberPayment`, `FiberPayQuickCard`)
+- `@fiber-pay/react`: official React hooks and starter components (`useFiberNode`, `useFiberPayment`, `ConnectButton`, `FiberNodeButton`, `FiberPayQuickCard`, `NodeInfoPanel`)
 - `@fiber-pay/sdk/browser`: low-level browser API when you need deeper control
 
 ## 1) Install


### PR DESCRIPTION
## Summary

The NodeInfoPanel component was already exported from `@fiber-pay/react`, but it had **no documentation** in the README — users had to dig through source code or discover it by accident. This PR adds a comprehensive documentation section for NodeInfoPanel, including the composition example discussed in RET-76.

## Changes

### `packages/react/README.md`

- **New NodeInfoPanel section** with:
  - Description and usage example
  - "What it shows" feature table (pubkey, CKB address, balance, QR code, stats)
  - Full props table
  - **Role comparison table** (ConnectButton vs FiberNodeButton vs NodeInfoPanel) — helps developers choose the right component
  - **Composition examples**:
    - Standalone: ConnectButton + NodeInfoPanel side-by-side
    - **As a custom tab in FiberNodeButton**: adds a "Deposit" tab with NodeInfoPanel QR code and balance
- Updated one-line import to include all major components
- Added cross-reference tip in FiberNodeButton tab customization section

### Other files

- `packages/react/docs/wasm-passkey-payment-component-quickstart.md`: Updated component list
- Root `README.md`: Package description now lists all exported React components

## Why

The documentation didn't clearly explain how NodeInfoPanel relates to FiberNodeButton and ConnectButton. These changes make the component relationship explicit and show developers exactly how to compose them together.
