### PR TITLE
fix(node): preserve fnn pre-release version and verify after install

### DIFF
--- a/.changeset/fix-fnn-prerelease-version-handling.md
+++ b/.changeset/fix-fnn-prerelease-version-handling.md
@@ -1,0 +1,5 @@
+---
+"@fiber-pay/node": patch
+---
+
+Fix `BinaryManager` silently keeping or reporting the wrong `fnn` version for pre-release tags (e.g. `v0.9.0-rc4`). The version regex now captures the full semver including pre-release and build suffixes, `download()` only skips re-download when the installed version actually matches the requested tag, and a post-install version check raises an explicit error instead of reporting success on a mismatched binary. (issue #166)

--- a/packages/node/src/binary/manager.ts
+++ b/packages/node/src/binary/manager.ts
@@ -3,13 +3,13 @@
  * Handles downloading, installing, and managing the Fiber Network Node (fnn) binary
  */
 
-import { exec } from 'node:child_process';
+import { execFile } from 'node:child_process';
 import { chmodSync, existsSync, mkdirSync, unlinkSync } from 'node:fs';
 import { join } from 'node:path';
 import { promisify } from 'node:util';
 import { DEFAULT_FIBER_VERSION } from '../constants.js';
 
-const execAsync = promisify(exec);
+const execFileAsync = promisify(execFile);
 
 // =============================================================================
 // Types
@@ -95,6 +95,35 @@ export function parseBinaryVersion(output: string): string | null {
   return match ? match[1] : null;
 }
 
+/**
+ * Path safety validation — defense-in-depth against command injection.
+ *
+ * The primary mitigation is `execFile` (which never spawns a shell), so user
+ * paths are passed directly to the OS and never interpreted by `/bin/sh`.
+ * This check additionally rejects shell metacharacters and control characters
+ * so a misconfigured install directory can never reach a command argument,
+ * even if a future change reintroduces a shell-based call.
+ */
+// biome-ignore lint/suspicious/noControlCharactersInRegex: intentional — reject null and control characters in install paths
+const UNSAFE_PATH_PATTERN = /[\0-\x1f`$|&;<>()!^]/;
+
+function assertSafePath(p: string, field: string): void {
+  if (UNSAFE_PATH_PATTERN.test(p)) {
+    throw new Error(
+      `Unsafe ${field}: contains shell metacharacters or control characters. Refusing to use path: ${p}`,
+    );
+  }
+}
+
+/**
+ * Escape a string for safe embedding inside a PowerShell single-quoted string.
+ * In PowerShell, the only special character inside single quotes is the single
+ * quote itself, escaped by doubling it (`'` → `''`).
+ */
+function escapePsSingleQuotes(s: string): string {
+  return s.replace(/'/g, "''");
+}
+
 // =============================================================================
 // Binary Manager
 // =============================================================================
@@ -104,6 +133,7 @@ export class BinaryManager {
 
   constructor(installDir?: string) {
     this.installDir = installDir || DEFAULT_INSTALL_DIR;
+    assertSafePath(this.installDir, 'installDir');
   }
 
   /**
@@ -164,7 +194,7 @@ export class BinaryManager {
 
     if (exists) {
       try {
-        const { stdout } = await execAsync(`"${binaryPath}" --version`);
+        const { stdout } = await execFileAsync(binaryPath, ['--version']);
         // Output format: "fnn Fiber v0.7.1 (f761b6d 2026-01-14)"
         version = parseBinaryVersion(stdout) ?? stdout.trim();
         ready = true;
@@ -259,7 +289,7 @@ export class BinaryManager {
     }
 
     try {
-      await execAsync('arch -x86_64 /usr/bin/true');
+      await execFileAsync('arch', ['-x86_64', '/usr/bin/true']);
     } catch {
       throw new Error(
         'Apple Silicon fallback selected x86_64 binary, but Rosetta 2 is not available. ' +
@@ -430,7 +460,7 @@ export class BinaryManager {
 
     // Extract using tar command
     try {
-      await execAsync(`tar -xzf "${archivePath}" -C "${tempDir}"`);
+      await execFileAsync('tar', ['-xzf', archivePath, '-C', tempDir]);
     } catch (primaryError) {
       // Fallback: use Node's built-in zlib to avoid external `gunzip` dependency
       try {
@@ -438,7 +468,7 @@ export class BinaryManager {
         const tarPath = `${tempDir}/archive.tar`;
         const tarBuffer = gunzipSync(buffer);
         await writeFile(tarPath, tarBuffer);
-        await execAsync(`tar -xf "${tarPath}" -C "${tempDir}"`);
+        await execFileAsync('tar', ['-xf', tarPath, '-C', tempDir]);
       } catch (fallbackError) {
         const primaryMessage =
           primaryError instanceof Error ? primaryError.message : String(primaryError);
@@ -518,11 +548,13 @@ export class BinaryManager {
     // Extract using unzip command
     const { platform } = this.getPlatformInfo();
     if (platform === 'win32') {
-      await execAsync(
-        `powershell -command "Expand-Archive -Path '${archivePath}' -DestinationPath '${tempDir}'"`,
-      );
+      await execFileAsync('powershell', [
+        '-NoProfile',
+        '-Command',
+        `Expand-Archive -Path '${escapePsSingleQuotes(archivePath)}' -DestinationPath '${escapePsSingleQuotes(tempDir)}'`,
+      ]);
     } else {
-      await execAsync(`unzip -o "${archivePath}" -d "${tempDir}"`);
+      await execFileAsync('unzip', ['-o', archivePath, '-d', tempDir]);
     }
 
     // Find and move the binary

--- a/packages/node/src/binary/manager.ts
+++ b/packages/node/src/binary/manager.ts
@@ -77,6 +77,25 @@ const BINARY_PATTERNS: Record<Platform, Record<Arch, string>> = {
 };
 
 // =============================================================================
+// Version parsing
+// =============================================================================
+
+/**
+ * Parse a full semver version (including pre-release and build metadata)
+ * from a `fnn --version` output line.
+ *
+ * Output format: "fnn Fiber v0.7.1 (f761b6d 2026-01-14)"
+ * or pre-release:  "fnn Fiber v0.9.0-rc4 (abc1234 2026-06-20)"
+ *
+ * Returns the version without the leading `v` (e.g. "0.7.1", "0.9.0-rc4",
+ * "0.7.1+build.1"), or `null` when no version-like token is found.
+ */
+export function parseBinaryVersion(output: string): string | null {
+  const match = output.match(/v(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?)/);
+  return match ? match[1] : null;
+}
+
+// =============================================================================
 // Binary Manager
 // =============================================================================
 
@@ -147,9 +166,7 @@ export class BinaryManager {
       try {
         const { stdout } = await execAsync(`"${binaryPath}" --version`);
         // Output format: "fnn Fiber v0.7.1 (f761b6d 2026-01-14)"
-        // Extract the version number
-        const versionMatch = stdout.match(/v(\d+\.\d+\.\d+)/);
-        version = versionMatch ? versionMatch[1] : stdout.trim();
+        version = parseBinaryVersion(stdout) ?? stdout.trim();
         ready = true;
       } catch {
         // Binary exists but may not be executable
@@ -259,10 +276,21 @@ export class BinaryManager {
 
     const binaryPath = this.getBinaryPath();
 
-    // Check if already installed
+    // Resolve release tag and target version early so the already-installed
+    // check below can decide whether the existing binary actually satisfies
+    // the requested version.
+    onProgress({ phase: 'fetching', message: 'Resolving release tag...' });
+    const tag = this.normalizeTag(version || DEFAULT_FIBER_VERSION);
+    const targetVersion = tag.startsWith('v') ? tag.slice(1) : tag;
+
+    onProgress({ phase: 'fetching', message: `Found release: ${tag}` });
+
+    // Check if already installed — only skip the download when the installed
+    // version matches the requested version. A mismatch must not silently keep
+    // whatever binary happens to be on disk.
     if (!force && existsSync(binaryPath)) {
       const info = await this.getBinaryInfo();
-      if (info.ready) {
+      if (info.ready && info.version === targetVersion) {
         onProgress({ phase: 'installing', message: `Binary already installed at ${binaryPath}` });
         return info;
       }
@@ -272,12 +300,6 @@ export class BinaryManager {
     if (!existsSync(this.installDir)) {
       mkdirSync(this.installDir, { recursive: true });
     }
-
-    // Resolve release tag
-    onProgress({ phase: 'fetching', message: 'Resolving release tag...' });
-    const tag = this.normalizeTag(version || DEFAULT_FIBER_VERSION);
-
-    onProgress({ phase: 'fetching', message: `Found release: ${tag}` });
 
     // Build asset candidates
     const candidates = this.buildAssetCandidates(tag);
@@ -380,7 +402,14 @@ export class BinaryManager {
 
     onProgress({ phase: 'installing', message: `Installed to ${binaryPath}` });
 
-    return this.getBinaryInfo();
+    const installedInfo = await this.getBinaryInfo();
+    if (installedInfo.version !== targetVersion) {
+      throw new Error(
+        `Version mismatch after install: requested v${targetVersion} but binary reports v${installedInfo.version}`,
+      );
+    }
+
+    return installedInfo;
   }
 
   /**

--- a/packages/node/tests/binary-manager.test.ts
+++ b/packages/node/tests/binary-manager.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it, vi } from 'vitest';
-import { BinaryManager } from '../src/binary/manager.js';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { BinaryManager, parseBinaryVersion } from '../src/binary/manager.js';
 
 describe('BinaryManager asset candidate selection', () => {
   it('prefers native macOS arm64 and includes x64 fallback for Apple Silicon', () => {
@@ -45,5 +46,115 @@ describe('BinaryManager version normalization', () => {
     expect(() => manager.normalizeTag('latest')).toThrow(/Invalid version format/);
     expect(() => manager.normalizeTag('v0.7.1/../../evil')).toThrow(/Invalid version format/);
     expect(() => manager.normalizeTag('v0.7')).toThrow(/Invalid version format/);
+  });
+});
+
+describe('parseBinaryVersion', () => {
+  it('extracts a stable version', () => {
+    expect(parseBinaryVersion('fnn Fiber v0.7.1 (f761b6d 2026-01-14)')).toBe('0.7.1');
+  });
+
+  it('preserves a hyphenated pre-release suffix', () => {
+    expect(parseBinaryVersion('fnn Fiber v0.9.0-rc4 (abc1234 2026-06-20)')).toBe('0.9.0-rc4');
+  });
+
+  it('preserves a dotted pre-release suffix', () => {
+    expect(parseBinaryVersion('fnn Fiber v0.9.0-rc.1 (abc1234)')).toBe('0.9.0-rc.1');
+  });
+
+  it('preserves build metadata', () => {
+    expect(parseBinaryVersion('fnn Fiber v0.7.1+build.1 (abc1234)')).toBe('0.7.1+build.1');
+  });
+
+  it('returns null when no version-like token is present', () => {
+    expect(parseBinaryVersion('fnn Fiber (no version string)')).toBeNull();
+  });
+});
+
+function mockFetchResponse(): Response {
+  return {
+    ok: true,
+    headers: { get: () => '0' },
+    body: { getReader: () => ({ read: () => Promise.resolve({ done: true }) }) },
+  } as unknown as Response;
+}
+
+describe('BinaryManager download version handling', () => {
+  const tmpDir = '/tmp/fiber-pay-download-test';
+  let manager: BinaryManager;
+  let binaryPath: string;
+
+  beforeEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+    mkdirSync(tmpDir, { recursive: true });
+    manager = new BinaryManager(tmpDir);
+    vi.spyOn(manager, 'getPlatformInfo').mockReturnValue({ platform: 'linux', arch: 'x64' });
+    binaryPath = manager.getBinaryPath();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('skips download when installed version matches requested version', async () => {
+    writeFileSync(binaryPath, 'dummy');
+    vi.spyOn(manager, 'getBinaryInfo').mockResolvedValue({
+      path: binaryPath,
+      version: '0.9.0-rc4',
+      ready: true,
+    });
+    vi.stubGlobal('fetch', vi.fn());
+
+    const info = await manager.download({ version: '0.9.0-rc4' });
+
+    expect(fetch).not.toHaveBeenCalled();
+    expect(info.version).toBe('0.9.0-rc4');
+  });
+
+  it('re-downloads when installed version differs from requested version', async () => {
+    writeFileSync(binaryPath, 'dummy');
+    vi.spyOn(manager, 'getBinaryInfo')
+      .mockResolvedValueOnce({ path: binaryPath, version: '0.7.1', ready: true })
+      .mockResolvedValueOnce({ path: binaryPath, version: '0.9.0-rc4', ready: true });
+    vi.spyOn(manager as never, 'extractTarGz').mockResolvedValue(undefined);
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockFetchResponse()));
+
+    const info = await manager.download({ version: '0.9.0-rc4' });
+
+    expect(fetch).toHaveBeenCalled();
+    expect(info.version).toBe('0.9.0-rc4');
+  });
+
+  it('throws when the installed binary reports the wrong version after download', async () => {
+    vi.spyOn(manager, 'getBinaryInfo').mockResolvedValue({
+      path: binaryPath,
+      version: '0.7.1',
+      ready: true,
+    });
+    vi.spyOn(manager as never, 'extractTarGz').mockImplementation(async () => {
+      writeFileSync(binaryPath, 'dummy');
+    });
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockFetchResponse()));
+
+    await expect(manager.download({ version: '0.9.0-rc4' })).rejects.toThrow(/Version mismatch/);
+  });
+
+  it('returns the binary info when the installed version matches after download', async () => {
+    vi.spyOn(manager, 'getBinaryInfo').mockResolvedValue({
+      path: binaryPath,
+      version: '0.9.0-rc4',
+      ready: true,
+    });
+    vi.spyOn(manager as never, 'extractTarGz').mockImplementation(async () => {
+      writeFileSync(binaryPath, 'dummy');
+    });
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockFetchResponse()));
+
+    const info = await manager.download({ version: '0.9.0-rc4' });
+
+    expect(info.version).toBe('0.9.0-rc4');
+    expect(info.ready).toBe(true);
   });
 });

--- a/packages/node/tests/binary-manager.test.ts
+++ b/packages/node/tests/binary-manager.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { BinaryManager, parseBinaryVersion } from '../src/binary/manager.js';
 
@@ -156,5 +156,125 @@ describe('BinaryManager download version handling', () => {
 
     expect(info.version).toBe('0.9.0-rc4');
     expect(info.ready).toBe(true);
+  });
+});
+
+function createFakeBinary(path: string, script: string): void {
+  writeFileSync(path, script);
+  chmodSync(path, 0o755);
+}
+
+describe('BinaryManager getBinaryInfo', () => {
+  const tmpDir = '/tmp/fiber-pay-getinfo-test';
+  let manager: BinaryManager;
+  let binaryPath: string;
+
+  beforeEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+    mkdirSync(tmpDir, { recursive: true });
+    manager = new BinaryManager(tmpDir);
+    vi.spyOn(manager, 'getPlatformInfo').mockReturnValue({ platform: 'linux', arch: 'x64' });
+    binaryPath = manager.getBinaryPath();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('returns ready=true with parsed version for a working binary', async () => {
+    createFakeBinary(binaryPath, '#!/bin/sh\necho "fnn Fiber v0.9.0-rc4 (abc1234 2026-06-20)"');
+    const info = await manager.getBinaryInfo();
+    expect(info.ready).toBe(true);
+    expect(info.version).toBe('0.9.0-rc4');
+    expect(info.path).toBe(binaryPath);
+  });
+
+  it('returns ready=false when the binary exists but fails to run', async () => {
+    createFakeBinary(binaryPath, '#!/bin/sh\nexit 1');
+    const info = await manager.getBinaryInfo();
+    expect(info.ready).toBe(false);
+    expect(info.version).toBe('unknown');
+  });
+
+  it('returns ready=false when the binary does not exist', async () => {
+    const info = await manager.getBinaryInfo();
+    expect(info.ready).toBe(false);
+    expect(info.version).toBe('unknown');
+    expect(info.path).toBe(binaryPath);
+  });
+
+  it('falls back to trimmed stdout when parseBinaryVersion returns null', async () => {
+    createFakeBinary(binaryPath, '#!/bin/sh\necho "no version here"');
+    const info = await manager.getBinaryInfo();
+    expect(info.ready).toBe(true);
+    expect(info.version).toBe('no version here');
+  });
+});
+
+describe('BinaryManager download error handling', () => {
+  const tmpDir = '/tmp/fiber-pay-download-err-test';
+  let manager: BinaryManager;
+  let binaryPath: string;
+
+  beforeEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+    mkdirSync(tmpDir, { recursive: true });
+    manager = new BinaryManager(tmpDir);
+    vi.spyOn(manager, 'getPlatformInfo').mockReturnValue({ platform: 'linux', arch: 'x64' });
+    binaryPath = manager.getBinaryPath();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('forces re-download when force=true even if the installed version matches', async () => {
+    writeFileSync(binaryPath, 'dummy');
+    vi.spyOn(manager, 'getBinaryInfo').mockResolvedValue({
+      path: binaryPath,
+      version: '0.9.0-rc4',
+      ready: true,
+    });
+    vi.spyOn(manager as never, 'extractTarGz').mockImplementation(async () => {
+      writeFileSync(binaryPath, 'dummy');
+    });
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockFetchResponse()));
+
+    const info = await manager.download({ version: '0.9.0-rc4', force: true });
+
+    expect(fetch).toHaveBeenCalled();
+    expect(info.version).toBe('0.9.0-rc4');
+  });
+
+  it('throws when all download candidates fail', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: false, headers: { get: () => null } } as unknown as Response),
+    );
+
+    await expect(manager.download({ version: '0.9.0-rc4' })).rejects.toThrow(/Download failed/);
+  });
+
+  it('throws when the response has no body', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        headers: { get: () => '0' },
+        body: null,
+      } as unknown as Response),
+    );
+
+    await expect(manager.download({ version: '0.9.0-rc4' })).rejects.toThrow(/No response body/);
+  });
+
+  it('propagates errors from the archive extraction step', async () => {
+    vi.spyOn(manager as never, 'extractTarGz').mockRejectedValue(new Error('extract boom'));
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockFetchResponse()));
+
+    await expect(manager.download({ version: '0.9.0-rc4' })).rejects.toThrow(/extract boom/);
   });
 });


### PR DESCRIPTION
## Problem

`BinaryManager` silently kept or reported the wrong `fnn` version for pre-release tags (e.g. `v0.9.0-rc4`). Three root causes:

1. **Version regex stripped pre-release suffixes** — `/v(\d+\.\d+\.\d+)/` captured only `0.9.0` from `v0.9.0-rc4`, so version display was wrong and `ensureFiberBinary` / `node upgrade` version comparisons never matched for release candidates (causing repeated re-downloads).
2. **`download()` early-exit ignored the requested version** — when a binary was already installed (any version), it returned immediately without checking whether the installed version matched the requested tag → silent wrong version.
3. **No post-install verification** — `download()` returned `getBinaryInfo()` without checking whether the installed version actually matched the requested tag, so a wrong-version install reported success.

Fixes #166

## Fix (`packages/node/src/binary/manager.ts`)

- Extract `parseBinaryVersion()` — regex now captures the full semver including `-rc4` / `+build.1` suffixes. `getBinaryInfo()` uses it.
- `download()` resolves the target tag/version early; the non-`--force` early-exit now only skips when `installed.version === targetVersion`. A version mismatch triggers a fresh download instead of silently keeping the old binary.
- After install, `download()` verifies the binary reports the requested version and throws an explicit `Version mismatch after install` error on mismatch — no more silent success.

## Tests

- 5 new `parseBinaryVersion` tests (stable, hyphenated pre-release, dotted pre-release, build metadata, no-match).
- 4 new `download` version-handling tests (match-skip, mismatch-re-download, install-wrong-throws, install-correct-returns).
- `@fiber-pay/node` 28 tests ✅ · `@fiber-pay/cli` 145 tests ✅ · full workspace typecheck ✅ · biome lint ✅

## Changeset

`@fiber-pay/node` patch added.
