### PR TITLE
feat(website): add umami analytics tracking to landing page

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -15,6 +15,11 @@
     />
     <meta property="og:type" content="website" />
     <link rel="stylesheet" href="./styles.css" />
+    <script
+      defer
+      src="https://umami.retric.uk/script.js"
+      data-website-id="7cf7aaab-e5ff-45c4-af34-80aa188bfd32"
+    ></script>
   </head>
   <body>
     <header class="site-header">

--- a/website/index.html
+++ b/website/index.html
@@ -19,6 +19,7 @@
       defer
       src="https://umami.retric.uk/script.js"
       data-website-id="7cf7aaab-e5ff-45c4-af34-80aa188bfd32"
+      data-domains="retricsu.github.io"
     ></script>
   </head>
   <body>


### PR DESCRIPTION
Adds the umami tracking script to the landing page \<head> section to enable website stats collection.