### PR TITLE
feat(cli): support opening UDT channels

### DIFF
--- a/.changeset/fiber-version-rc7.md
+++ b/.changeset/fiber-version-rc7.md
@@ -1,0 +1,5 @@
+---
+'@fiber-pay/node': patch
+---
+
+Bump default Fiber binary version from `v0.9.0-rc4` to `v0.9.0-rc7`. The `v0.9.0-rc4` GitHub release assets are no longer available, which caused fresh installs and CI smoke tests to fail during binary download.

--- a/.changeset/udt-channel-open.md
+++ b/.changeset/udt-channel-open.md
@@ -1,0 +1,5 @@
+---
+'@fiber-pay/cli': minor
+---
+
+Add UDT channel support to `fiber-pay channel open`. The new `--funding-udt-type-script` option accepts a JSON CKB script (`code_hash`, `hash_type`, `args`) and routes the funding amount as raw UDT units instead of CKB.

--- a/.changeset/udt-channel-open.md
+++ b/.changeset/udt-channel-open.md
@@ -3,3 +3,5 @@
 ---
 
 Add UDT channel support to `fiber-pay channel open`. The new `--funding-udt-type-script` option accepts a JSON CKB script (`code_hash`, `hash_type`, `args`) and routes the funding amount as raw UDT units instead of CKB.
+
+BREAKING CHANGE: The JSON and human-readable output of `fiber-pay channel open` and `fiber-pay channel accept` now uses `fundingAmount` (in shannons for CKB, or raw UDT units) plus `fundingLabel` (`CKB` or `UDT`) instead of the previous `fundingCkb` field. The `--funding` option semantics are unchanged.

--- a/packages/cli/docs/human-quickstart.md
+++ b/packages/cli/docs/human-quickstart.md
@@ -49,6 +49,16 @@ fiber-pay channel watch --until CHANNEL_READY --json
 fiber-pay channel list --state CHANNEL_READY --json
 ```
 
+To open a UDT channel, add `--funding-udt-type-script` with the CKB type script JSON and provide the funding amount as raw UDT units:
+
+```bash
+fiber-pay channel open \
+  --peer <peer-address> \
+  --funding <UDT-amount> \
+  --funding-udt-type-script '{"code_hash":"0x...","hash_type":"type","args":"0x..."}' \
+  --json
+```
+
 ## 4) Receive then send payment
 
 Create an invoice (receiver side):

--- a/packages/cli/src/commands/channel.ts
+++ b/packages/cli/src/commands/channel.ts
@@ -1,7 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import {
   type ChannelState,
-  ckbToShannons,
   ensureHexPrefix,
   type HexString,
   nodeIdToPeerId,
@@ -422,7 +421,25 @@ export function createChannelCommand(config: CliConfig): Command {
     .action(async (temporaryChannelId, options) => {
       const rpc = await createReadyRpcClient(config);
       const json = Boolean(options.json);
-      const fundingCkb = parseFloat(options.funding);
+      const fundingLabel = 'CKB';
+
+      let fundingAmount: bigint;
+      try {
+        fundingAmount = parseFundingAmount(options.funding as string, false);
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
+        if (json) {
+          printJsonError({
+            code: 'CHANNEL_ACCEPT_INPUT_INVALID',
+            message: msg,
+            recoverable: true,
+            suggestion: 'Provide the CKB amount as a non-negative number.',
+          });
+        } else {
+          console.error(`Error: ${msg}`);
+        }
+        process.exit(1);
+      }
 
       const endpoint = resolveRpcEndpoint(config);
       if (endpoint.target === 'runtime-proxy') {
@@ -431,7 +448,7 @@ export function createChannelCommand(config: CliConfig): Command {
             action: 'accept',
             acceptChannelParams: {
               temporary_channel_id: temporaryChannelId as HexString,
-              funding_amount: ckbToShannons(fundingCkb),
+              funding_amount: toHex(fundingAmount),
             },
           },
           options: {
@@ -444,7 +461,8 @@ export function createChannelCommand(config: CliConfig): Command {
             jobId: created.id,
             jobState: created.state,
             temporaryChannelId,
-            fundingCkb,
+            fundingAmount: fundingAmount.toString(),
+            fundingLabel,
           };
 
           if (json) {
@@ -454,7 +472,7 @@ export function createChannelCommand(config: CliConfig): Command {
             console.log(`  Job:                  ${payload.jobId}`);
             console.log(`  Job State:            ${payload.jobState}`);
             console.log(`  Temporary Channel ID: ${payload.temporaryChannelId}`);
-            console.log(`  Funding:              ${payload.fundingCkb} CKB`);
+            console.log(`  Funding:              ${payload.fundingAmount} ${payload.fundingLabel}`);
           }
           return;
         }
@@ -462,17 +480,22 @@ export function createChannelCommand(config: CliConfig): Command {
 
       const result = await rpc.acceptChannel({
         temporary_channel_id: temporaryChannelId as HexString,
-        funding_amount: ckbToShannons(fundingCkb),
+        funding_amount: toHex(fundingAmount),
       });
 
-      const payload = { channelId: result.channel_id, temporaryChannelId, fundingCkb };
+      const payload = {
+        channelId: result.channel_id,
+        temporaryChannelId,
+        fundingAmount: fundingAmount.toString(),
+        fundingLabel,
+      };
       if (json) {
         printJsonSuccess(payload);
       } else {
         console.log('Channel accepted');
         console.log(`  Channel ID:           ${payload.channelId}`);
         console.log(`  Temporary Channel ID: ${payload.temporaryChannelId}`);
-        console.log(`  Funding:              ${payload.fundingCkb} CKB`);
+        console.log(`  Funding:              ${payload.fundingAmount} ${payload.fundingLabel}`);
       }
     });
 

--- a/packages/cli/src/commands/channel.ts
+++ b/packages/cli/src/commands/channel.ts
@@ -5,6 +5,7 @@ import {
   ensureHexPrefix,
   type HexString,
   nodeIdToPeerId,
+  toHex,
 } from '@fiber-pay/sdk';
 import { Command } from 'commander';
 import { sleep } from '../lib/async.js';
@@ -20,6 +21,11 @@ import {
   printJsonSuccess,
   truncateMiddle,
 } from '../lib/format.js';
+import {
+  parseFundingAmount,
+  parseUdtTypeScript,
+  type UdtTypeScript,
+} from '../lib/parse-options.js';
 import { createReadyRpcClient, resolveRpcEndpoint } from '../lib/rpc.js';
 import { tryCreateRuntimeChannelJob } from '../lib/runtime-jobs.js';
 import { registerChannelRebalanceCommand } from './rebalance.js';
@@ -262,8 +268,12 @@ export function createChannelCommand(config: CliConfig): Command {
   channel
     .command('open')
     .requiredOption('--peer <pubkeyOrMultiaddr>')
-    .requiredOption('--funding <ckb>')
+    .requiredOption('--funding <amount>')
     .option('--private')
+    .option(
+      '--funding-udt-type-script <json>',
+      'JSON object with code_hash, hash_type, and args to open a UDT channel',
+    )
     .option(
       '--idempotency-key <key>',
       'Reuse this key only when retrying the exact same open intent',
@@ -273,7 +283,51 @@ export function createChannelCommand(config: CliConfig): Command {
       const rpc = await createReadyRpcClient(config);
       const json = Boolean(options.json);
       const peerInput = options.peer as string;
-      const fundingCkb = parseFloat(options.funding);
+
+      let fundingUdtTypeScript: UdtTypeScript | undefined;
+      try {
+        fundingUdtTypeScript = parseUdtTypeScript(
+          options.fundingUdtTypeScript as string | undefined,
+          '--funding-udt-type-script',
+        );
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
+        if (json) {
+          printJsonError({
+            code: 'CHANNEL_OPEN_INPUT_INVALID',
+            message: msg,
+            recoverable: true,
+            suggestion:
+              'Provide a valid JSON script, e.g. {"code_hash":"0x...","hash_type":"type","args":"0x..."}',
+          });
+        } else {
+          console.error(`Error: ${msg}`);
+        }
+        process.exit(1);
+      }
+
+      const isUdt = fundingUdtTypeScript !== undefined;
+      const fundingLabel = isUdt ? 'UDT' : 'CKB';
+
+      let fundingAmount: bigint;
+      try {
+        fundingAmount = parseFundingAmount(options.funding as string, isUdt);
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
+        if (json) {
+          printJsonError({
+            code: 'CHANNEL_OPEN_INPUT_INVALID',
+            message: msg,
+            recoverable: true,
+            suggestion: isUdt
+              ? 'Provide the UDT amount as an integer in the smallest unit.'
+              : 'Provide the CKB amount as a non-negative number.',
+          });
+        } else {
+          console.error(`Error: ${msg}`);
+        }
+        process.exit(1);
+      }
 
       let peerPubkey = peerInput;
       if (peerInput.includes('/')) {
@@ -288,17 +342,20 @@ export function createChannelCommand(config: CliConfig): Command {
           ? options.idempotencyKey.trim()
           : `open:${peerPubkey}:${randomUUID()}`;
 
+      const openChannelParams = {
+        pubkey: peerPubkey as HexString,
+        funding_amount: toHex(fundingAmount),
+        public: !options.private,
+        ...(fundingUdtTypeScript ? { funding_udt_type_script: fundingUdtTypeScript } : {}),
+      };
+
       const endpoint = resolveRpcEndpoint(config);
       if (endpoint.target === 'runtime-proxy') {
         const created = await tryCreateRuntimeChannelJob(endpoint.url, {
           params: {
             action: 'open',
             peerId: peerPubkey,
-            openChannelParams: {
-              pubkey: peerPubkey,
-              funding_amount: ckbToShannons(fundingCkb),
-              public: !options.private,
-            },
+            openChannelParams,
             waitForReady: false,
           },
           options: {
@@ -312,7 +369,9 @@ export function createChannelCommand(config: CliConfig): Command {
             jobId: created.id,
             jobState: created.state,
             peer: peerPubkey,
-            fundingCkb,
+            fundingAmount: fundingAmount.toString(),
+            fundingLabel,
+            ...(fundingUdtTypeScript ? { fundingUdtTypeScript } : {}),
             idempotencyKey,
           };
 
@@ -323,23 +382,24 @@ export function createChannelCommand(config: CliConfig): Command {
             console.log(`  Job:                  ${payload.jobId}`);
             console.log(`  Job State:            ${payload.jobState}`);
             console.log(`  Peer:                 ${payload.peer}`);
-            console.log(`  Funding:              ${payload.fundingCkb} CKB`);
+            console.log(`  Funding:              ${payload.fundingAmount} ${payload.fundingLabel}`);
+            if (fundingUdtTypeScript) {
+              console.log(`  UDT Type Script:      ${JSON.stringify(fundingUdtTypeScript)}`);
+            }
             console.log(`  Idempotency Key:      ${payload.idempotencyKey}`);
           }
           return;
         }
       }
 
-      const result = await rpc.openChannel({
-        pubkey: peerPubkey as HexString,
-        funding_amount: ckbToShannons(fundingCkb),
-        public: !options.private,
-      });
+      const result = await rpc.openChannel(openChannelParams);
 
       const payload = {
         temporaryChannelId: result.temporary_channel_id,
         peer: peerPubkey,
-        fundingCkb,
+        fundingAmount: fundingAmount.toString(),
+        fundingLabel,
+        ...(fundingUdtTypeScript ? { fundingUdtTypeScript } : {}),
       };
       if (json) {
         printJsonSuccess(payload);
@@ -347,7 +407,10 @@ export function createChannelCommand(config: CliConfig): Command {
         console.log('Channel open initiated');
         console.log(`  Temporary Channel ID: ${payload.temporaryChannelId}`);
         console.log(`  Peer:                 ${payload.peer}`);
-        console.log(`  Funding:              ${payload.fundingCkb} CKB`);
+        console.log(`  Funding:              ${payload.fundingAmount} ${payload.fundingLabel}`);
+        if (fundingUdtTypeScript) {
+          console.log(`  UDT Type Script:      ${JSON.stringify(fundingUdtTypeScript)}`);
+        }
       }
     });
 

--- a/packages/cli/src/lib/parse-options.ts
+++ b/packages/cli/src/lib/parse-options.ts
@@ -72,10 +72,14 @@ export function parseUdtTypeScript(
 export function parseFundingAmount(value: string, isUdt: boolean): bigint {
   if (isUdt) {
     try {
-      return BigInt(value);
+      const amount = BigInt(value);
+      if (amount < 0n) {
+        throw new Error();
+      }
+      return amount;
     } catch {
       throw new Error(
-        `Invalid UDT funding amount: ${value}. Expected an integer in the smallest UDT unit.`,
+        `Invalid UDT funding amount: ${value}. Expected a non-negative integer in the smallest UDT unit.`,
       );
     }
   }

--- a/packages/cli/src/lib/parse-options.ts
+++ b/packages/cli/src/lib/parse-options.ts
@@ -1,3 +1,5 @@
+import type { HexString } from '@fiber-pay/sdk';
+
 export function parseIntegerOption(value: string | undefined, name: string): number | undefined {
   if (value === undefined) {
     return undefined;
@@ -17,4 +19,70 @@ export function parseBoolOption(value: string | undefined, name: string): boolea
   if (normalized === 'true') return true;
   if (normalized === 'false') return false;
   throw new Error(`Invalid ${name}: ${value}. Expected true|false.`);
+}
+
+const VALID_HASH_TYPES = new Set(['type', 'data', 'data1', 'data2']);
+
+export interface UdtTypeScript {
+  code_hash: HexString;
+  hash_type: 'type' | 'data' | 'data1' | 'data2';
+  args: HexString;
+}
+
+export function parseUdtTypeScript(
+  value: string | undefined,
+  name: string,
+): UdtTypeScript | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch {
+    throw new Error(`Invalid ${name}: must be a valid JSON object`);
+  }
+
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error(`Invalid ${name}: must be a JSON object with code_hash, hash_type, and args`);
+  }
+
+  const script = parsed as Record<string, unknown>;
+
+  if (typeof script.code_hash !== 'string' || !/^0x[0-9a-fA-F]+$/.test(script.code_hash)) {
+    throw new Error(`Invalid ${name}: code_hash must be a hex string starting with 0x`);
+  }
+
+  if (typeof script.hash_type !== 'string' || !VALID_HASH_TYPES.has(script.hash_type)) {
+    throw new Error(`Invalid ${name}: hash_type must be one of type, data, data1, data2`);
+  }
+
+  if (typeof script.args !== 'string' || !/^0x[0-9a-fA-F]*$/.test(script.args)) {
+    throw new Error(`Invalid ${name}: args must be a hex string starting with 0x`);
+  }
+
+  return {
+    code_hash: script.code_hash as HexString,
+    hash_type: script.hash_type as UdtTypeScript['hash_type'],
+    args: script.args as HexString,
+  };
+}
+
+export function parseFundingAmount(value: string, isUdt: boolean): bigint {
+  if (isUdt) {
+    try {
+      return BigInt(value);
+    } catch {
+      throw new Error(
+        `Invalid UDT funding amount: ${value}. Expected an integer in the smallest UDT unit.`,
+      );
+    }
+  }
+
+  const parsed = parseFloat(value);
+  if (Number.isNaN(parsed) || parsed < 0) {
+    throw new Error(`Invalid CKB funding amount: ${value}. Expected a non-negative number.`);
+  }
+  return BigInt(Math.floor(parsed * 1e8));
 }

--- a/packages/cli/src/lib/parse-options.ts
+++ b/packages/cli/src/lib/parse-options.ts
@@ -70,23 +70,32 @@ export function parseUdtTypeScript(
 }
 
 export function parseFundingAmount(value: string, isUdt: boolean): bigint {
+  if (value.trim() !== value || value.trim().length === 0) {
+    throw new Error(
+      `Invalid ${isUdt ? 'UDT' : 'CKB'} funding amount: ${value}. Expected a non-negative ${isUdt ? 'integer' : 'number'}.`,
+    );
+  }
+
   if (isUdt) {
-    try {
-      const amount = BigInt(value);
-      if (amount < 0n) {
-        throw new Error();
-      }
-      return amount;
-    } catch {
+    if (!/^-?\d+$/.test(value)) {
       throw new Error(
         `Invalid UDT funding amount: ${value}. Expected a non-negative integer in the smallest UDT unit.`,
       );
     }
+    const amount = BigInt(value);
+    if (amount < 0n) {
+      throw new Error(
+        `Invalid UDT funding amount: ${value}. Expected a non-negative integer in the smallest UDT unit.`,
+      );
+    }
+    return amount;
   }
 
-  const parsed = parseFloat(value);
-  if (Number.isNaN(parsed) || parsed < 0) {
+  // CKB is parsed as a fixed-point decimal with at most 8 decimal places (shannons).
+  if (!/^\d+(\.\d{1,8})?$/.test(value)) {
     throw new Error(`Invalid CKB funding amount: ${value}. Expected a non-negative number.`);
   }
-  return BigInt(Math.floor(parsed * 1e8));
+  const [integerPart, fractionalPart = ''] = value.split('.');
+  const shannonsPerCkb = 10n ** 8n;
+  return BigInt(integerPart) * shannonsPerCkb + BigInt(fractionalPart.padEnd(8, '0'));
 }

--- a/packages/cli/tests/node-version-policy.test.ts
+++ b/packages/cli/tests/node-version-policy.test.ts
@@ -43,8 +43,8 @@ describe('node version policy', () => {
 
     const decision = resolveManagedUpgradeVersion(manager);
 
-    expect(decision.targetTag).toBe('v0.9.0-rc4');
-    expect(decision.targetVersion).toBe('0.9.0-rc4');
+    expect(decision.targetTag).toBe('v0.9.0-rc7');
+    expect(decision.targetVersion).toBe('0.9.0-rc7');
     expect(decision.source).toBe('default');
   });
 });

--- a/packages/cli/tests/parse-options.test.ts
+++ b/packages/cli/tests/parse-options.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+import { parseFundingAmount, parseUdtTypeScript } from '../src/lib/parse-options.js';
+
+describe('parseUdtTypeScript', () => {
+  it('returns undefined when value is undefined', () => {
+    expect(parseUdtTypeScript(undefined, '--funding-udt-type-script')).toBeUndefined();
+  });
+
+  it('parses a valid type script', () => {
+    const raw = JSON.stringify({
+      code_hash: '0x1234abcd',
+      hash_type: 'type',
+      args: '0x',
+    });
+    expect(parseUdtTypeScript(raw, '--funding-udt-type-script')).toEqual({
+      code_hash: '0x1234abcd',
+      hash_type: 'type',
+      args: '0x',
+    });
+  });
+
+  it('accepts all valid hash types', () => {
+    for (const hashType of ['type', 'data', 'data1', 'data2']) {
+      const raw = JSON.stringify({
+        code_hash: '0x1234',
+        hash_type: hashType,
+        args: '0x5678',
+      });
+      expect(parseUdtTypeScript(raw, '--funding-udt-type-script')).toEqual({
+        code_hash: '0x1234',
+        hash_type: hashType,
+        args: '0x5678',
+      });
+    }
+  });
+
+  it('throws when input is not valid JSON', () => {
+    expect(() => parseUdtTypeScript('not-json', '--funding-udt-type-script')).toThrow(
+      'must be a valid JSON object',
+    );
+  });
+
+  it('throws when input is not an object', () => {
+    expect(() => parseUdtTypeScript('[]', '--funding-udt-type-script')).toThrow(
+      'must be a JSON object',
+    );
+  });
+
+  it('throws when code_hash is missing', () => {
+    const raw = JSON.stringify({ hash_type: 'type', args: '0x' });
+    expect(() => parseUdtTypeScript(raw, '--funding-udt-type-script')).toThrow('code_hash');
+  });
+
+  it('throws when code_hash is not a hex string', () => {
+    const raw = JSON.stringify({ code_hash: '1234', hash_type: 'type', args: '0x' });
+    expect(() => parseUdtTypeScript(raw, '--funding-udt-type-script')).toThrow('code_hash');
+  });
+
+  it('throws when hash_type is invalid', () => {
+    const raw = JSON.stringify({ code_hash: '0x1234', hash_type: 'invalid', args: '0x' });
+    expect(() => parseUdtTypeScript(raw, '--funding-udt-type-script')).toThrow('hash_type');
+  });
+
+  it('throws when args is missing', () => {
+    const raw = JSON.stringify({ code_hash: '0x1234', hash_type: 'type' });
+    expect(() => parseUdtTypeScript(raw, '--funding-udt-type-script')).toThrow('args');
+  });
+
+  it('throws when args is not a hex string', () => {
+    const raw = JSON.stringify({ code_hash: '0x1234', hash_type: 'type', args: 'abcd' });
+    expect(() => parseUdtTypeScript(raw, '--funding-udt-type-script')).toThrow('args');
+  });
+});
+
+describe('parseFundingAmount', () => {
+  it('converts CKB amount to shannons', () => {
+    expect(parseFundingAmount('1.5', false)).toBe(150_000_000n);
+    expect(parseFundingAmount('0', false)).toBe(0n);
+    expect(parseFundingAmount('100', false)).toBe(10_000_000_000n);
+  });
+
+  it('parses UDT amount as raw integer', () => {
+    expect(parseFundingAmount('1000', true)).toBe(1000n);
+    expect(parseFundingAmount('0', true)).toBe(0n);
+    expect(parseFundingAmount('12345678901234567890', true)).toBe(12345678901234567890n);
+  });
+
+  it('throws on negative CKB amount', () => {
+    expect(() => parseFundingAmount('-1', false)).toThrow('CKB funding amount');
+  });
+
+  it('throws on non-numeric CKB amount', () => {
+    expect(() => parseFundingAmount('abc', false)).toThrow('CKB funding amount');
+  });
+
+  it('throws on non-integer UDT amount', () => {
+    expect(() => parseFundingAmount('1.5', true)).toThrow('UDT funding amount');
+  });
+
+  it('throws on non-numeric UDT amount', () => {
+    expect(() => parseFundingAmount('abc', true)).toThrow('UDT funding amount');
+  });
+});

--- a/packages/cli/tests/parse-options.test.ts
+++ b/packages/cli/tests/parse-options.test.ts
@@ -97,6 +97,11 @@ describe('parseFundingAmount', () => {
     expect(() => parseFundingAmount('1.5', true)).toThrow('UDT funding amount');
   });
 
+  it('throws on negative UDT amount', () => {
+    expect(() => parseFundingAmount('-1', true)).toThrow('UDT funding amount');
+    expect(() => parseFundingAmount('-100', true)).toThrow('UDT funding amount');
+  });
+
   it('throws on non-numeric UDT amount', () => {
     expect(() => parseFundingAmount('abc', true)).toThrow('UDT funding amount');
   });

--- a/packages/cli/tests/parse-options.test.ts
+++ b/packages/cli/tests/parse-options.test.ts
@@ -105,4 +105,36 @@ describe('parseFundingAmount', () => {
   it('throws on non-numeric UDT amount', () => {
     expect(() => parseFundingAmount('abc', true)).toThrow('UDT funding amount');
   });
+
+  it('rejects empty or whitespace-only UDT amounts', () => {
+    expect(() => parseFundingAmount('', true)).toThrow('UDT funding amount');
+    expect(() => parseFundingAmount('   ', true)).toThrow('UDT funding amount');
+  });
+
+  it('rejects UDT amounts with surrounding whitespace, scientific notation, or illegal suffixes', () => {
+    expect(() => parseFundingAmount(' 100', true)).toThrow('UDT funding amount');
+    expect(() => parseFundingAmount('100 ', true)).toThrow('UDT funding amount');
+    expect(() => parseFundingAmount(' 100 ', true)).toThrow('UDT funding amount');
+    expect(() => parseFundingAmount('1e2', true)).toThrow('UDT funding amount');
+    expect(() => parseFundingAmount('100abc', true)).toThrow('UDT funding amount');
+    expect(() => parseFundingAmount('+100', true)).toThrow('UDT funding amount');
+  });
+
+  it('parses CKB amounts with up to 8 decimal places exactly', () => {
+    expect(parseFundingAmount('0.00000001', false)).toBe(1n);
+    expect(parseFundingAmount('123.45678901', false)).toBe(12_345_678_901n);
+  });
+
+  it('throws on malformed or over-precise CKB amounts', () => {
+    expect(() => parseFundingAmount('', false)).toThrow('CKB funding amount');
+    expect(() => parseFundingAmount('   ', false)).toThrow('CKB funding amount');
+    expect(() => parseFundingAmount(' 1.5', false)).toThrow('CKB funding amount');
+    expect(() => parseFundingAmount('1.5 ', false)).toThrow('CKB funding amount');
+    expect(() => parseFundingAmount('Infinity', false)).toThrow('CKB funding amount');
+    expect(() => parseFundingAmount('NaN', false)).toThrow('CKB funding amount');
+    expect(() => parseFundingAmount('1abc', false)).toThrow('CKB funding amount');
+    expect(() => parseFundingAmount('1.2.3', false)).toThrow('CKB funding amount');
+    expect(() => parseFundingAmount('1e2', false)).toThrow('CKB funding amount');
+    expect(() => parseFundingAmount('0.123456789', false)).toThrow('CKB funding amount');
+  });
 });

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -17,4 +17,4 @@ import { createFiberNodeManager } from '@fiber-pay/node';
 ## Compatibility
 
 - Node.js `>=20`
-- Fiber target: `v0.9.0-rc4`
+- Fiber target: `v0.9.0-rc7`

--- a/packages/node/src/constants.ts
+++ b/packages/node/src/constants.ts
@@ -3,4 +3,4 @@
  */
 
 /** Default Fiber Network Node binary version used for downloads when no version is specified. */
-export const DEFAULT_FIBER_VERSION = 'v0.9.0-rc4';
+export const DEFAULT_FIBER_VERSION = 'v0.9.0-rc7';


### PR DESCRIPTION
Closes #179

This PR adds UDT channel support to `fiber-pay channel open`:

- New `--funding-udt-type-script` option accepts a JSON CKB script with `code_hash`, `hash_type`, and `args`.
- When a UDT type script is provided, `--funding` is treated as raw UDT units instead of CKB.
- The script and amount are forwarded through both the direct RPC path and the runtime job path.
- Added validation helpers and unit tests in `packages/cli/tests/parse-options.test.ts`.
- Updated the human quickstart docs with a UDT channel example.

## Scope

This PR is intentionally **CLI-only**. It adds UDT support to the `fiber-pay channel open` command and hardens funding amount parsing. Agent/MCP layer UDT support is out of scope and will be handled separately.

## Breaking change

The JSON and human-readable output of `channel open` and `channel accept` now uses `fundingAmount` + `fundingLabel` instead of `fundingCkb`. `fundingAmount` is in shannons for CKB channels and in raw UDT units for UDT channels. The `--funding` option semantics are unchanged.

## rc7 binary bump

The default Fiber node binary version is bumped from `v0.9.0-rc4` to `v0.9.0-rc7`. This is included because the rc4 GitHub release assets were removed, causing fresh installs and CI smoke tests to fail during binary download. This is an orthogonal infrastructure fix required to keep CI green; rollback to rc4 is not possible until GitHub re-publishes the rc4 assets.

## Testing

- `pnpm test`, `pnpm typecheck`, `pnpm format:check`, `pnpm lint`
- Real UDT end-to-end channel open reaching `CHANNEL_READY`
