### PR TITLE
feat(cli): extend UDT support across invoices, routes, rebalances and channel formatting

### DIFF
--- a/.changeset/udt-channel-formatting.md
+++ b/.changeset/udt-channel-formatting.md
@@ -1,0 +1,5 @@
+---
+'@fiber-pay/cli': minor
+---
+
+Make channel list/detail formatting UDT-aware, showing raw UDT units and the channel's `funding_udt_type_script`.

--- a/.changeset/udt-invoice-create.md
+++ b/.changeset/udt-invoice-create.md
@@ -1,0 +1,5 @@
+---
+'@fiber-pay/cli': minor
+---
+
+Add UDT support to `invoice create` via `--udt-type-script` and `--udt-name`.

--- a/.changeset/udt-payment-route.md
+++ b/.changeset/udt-payment-route.md
@@ -1,0 +1,5 @@
+---
+'@fiber-pay/cli': minor
+---
+
+Add UDT support to `payment route` via `--udt-type-script` and `--udt-name`.

--- a/.changeset/udt-payment-send.md
+++ b/.changeset/udt-payment-send.md
@@ -1,0 +1,5 @@
+---
+'@fiber-pay/cli': minor
+---
+
+Add UDT support to `payment send` via `--udt-type-script` and `--udt-name`.

--- a/.changeset/udt-rebalance.md
+++ b/.changeset/udt-rebalance.md
@@ -1,0 +1,5 @@
+---
+'@fiber-pay/cli': minor
+---
+
+Add UDT support to `payment rebalance` and `channel rebalance` via `--udt-type-script` and `--udt-name`.

--- a/packages/cli/src/commands/channel.ts
+++ b/packages/cli/src/commands/channel.ts
@@ -291,7 +291,7 @@ export function createChannelCommand(config: CliConfig): Command {
           rpc,
         });
         fundingUdtTypeScript = resolved.script;
-        fundingLabel = resolved.unit;
+        fundingLabel = resolved.name ?? resolved.unit;
       } catch (error) {
         const msg = error instanceof Error ? error.message : String(error);
         if (json) {

--- a/packages/cli/src/commands/channel.ts
+++ b/packages/cli/src/commands/channel.ts
@@ -20,13 +20,10 @@ import {
   printJsonSuccess,
   truncateMiddle,
 } from '../lib/format.js';
-import {
-  parseFundingAmount,
-  parseUdtTypeScript,
-  type UdtTypeScript,
-} from '../lib/parse-options.js';
+import { parseFundingAmount, type UdtTypeScript } from '../lib/parse-options.js';
 import { createReadyRpcClient, resolveRpcEndpoint } from '../lib/rpc.js';
 import { tryCreateRuntimeChannelJob } from '../lib/runtime-jobs.js';
+import { resolveUdtTypeScript } from '../lib/udt.js';
 import { registerChannelRebalanceCommand } from './rebalance.js';
 
 function extractPeerIdFromMultiaddr(address: string): string | undefined {
@@ -273,6 +270,7 @@ export function createChannelCommand(config: CliConfig): Command {
       '--funding-udt-type-script <json>',
       'JSON object with code_hash, hash_type, and args to open a UDT channel',
     )
+    .option('--funding-udt-name <name>', 'Name of a UDT from the node config to open a UDT channel')
     .option(
       '--idempotency-key <key>',
       'Reuse this key only when retrying the exact same open intent',
@@ -284,11 +282,15 @@ export function createChannelCommand(config: CliConfig): Command {
       const peerInput = options.peer as string;
 
       let fundingUdtTypeScript: UdtTypeScript | undefined;
+      let fundingLabel = 'CKB';
       try {
-        fundingUdtTypeScript = parseUdtTypeScript(
-          options.fundingUdtTypeScript as string | undefined,
-          '--funding-udt-type-script',
-        );
+        const resolved = await resolveUdtTypeScript({
+          rawScript: options.fundingUdtTypeScript as string | undefined,
+          name: options.fundingUdtName as string | undefined,
+          rpc,
+        });
+        fundingUdtTypeScript = resolved.script;
+        fundingLabel = resolved.unit;
       } catch (error) {
         const msg = error instanceof Error ? error.message : String(error);
         if (json) {
@@ -297,7 +299,7 @@ export function createChannelCommand(config: CliConfig): Command {
             message: msg,
             recoverable: true,
             suggestion:
-              'Provide a valid JSON script, e.g. {"code_hash":"0x...","hash_type":"type","args":"0x..."}',
+              'Provide a valid JSON script or UDT name, e.g. {"code_hash":"0x...","hash_type":"type","args":"0x..."} or --funding-udt-name RUSD',
           });
         } else {
           console.error(`Error: ${msg}`);
@@ -306,7 +308,6 @@ export function createChannelCommand(config: CliConfig): Command {
       }
 
       const isUdt = fundingUdtTypeScript !== undefined;
-      const fundingLabel = isUdt ? 'UDT' : 'CKB';
 
       let fundingAmount: bigint;
       try {

--- a/packages/cli/src/commands/channel.ts
+++ b/packages/cli/src/commands/channel.ts
@@ -287,6 +287,7 @@ export function createChannelCommand(config: CliConfig): Command {
         const resolved = await resolveUdtTypeScript({
           rawScript: options.fundingUdtTypeScript as string | undefined,
           name: options.fundingUdtName as string | undefined,
+          scriptOptionName: '--funding-udt-type-script',
           rpc,
         });
         fundingUdtTypeScript = resolved.script;

--- a/packages/cli/src/commands/invoice.ts
+++ b/packages/cli/src/commands/invoice.ts
@@ -30,6 +30,7 @@ export function createInvoiceCommand(config: CliConfig): Command {
       const json = Boolean(options.json);
 
       let udtTypeScript: UdtTypeScript | undefined;
+      let udtName: string | undefined;
       try {
         const resolved = await resolveUdtTypeScript({
           rawScript: options.udtTypeScript as string | undefined,
@@ -37,6 +38,7 @@ export function createInvoiceCommand(config: CliConfig): Command {
           rpc,
         });
         udtTypeScript = resolved.script;
+        udtName = resolved.name;
       } catch (error) {
         const message = error instanceof Error ? error.message : 'Invalid UDT option';
         if (json) {
@@ -89,10 +91,9 @@ export function createInvoiceCommand(config: CliConfig): Command {
         process.exit(1);
       }
 
-      const amountCkb = isUdt ? undefined : parseFloat(amountInput);
       const expirySeconds = (options.expiry ? parseInt(options.expiry, 10) : 60) * 60;
       const currency = config.network === 'mainnet' ? 'Fibb' : 'Fibt';
-      const unit = isUdt ? 'UDT' : 'CKB';
+      const unit = udtName ?? (isUdt ? 'UDT' : 'CKB');
 
       const endpoint = resolveRpcEndpoint(config);
       if (endpoint.target === 'runtime-proxy') {
@@ -127,7 +128,7 @@ export function createInvoiceCommand(config: CliConfig): Command {
             jobId: job.id,
             invoice: result.invoiceAddress,
             paymentHash: result.paymentHash,
-            amount: isUdt ? amount.toString() : amountCkb,
+            amount: isUdt ? amount.toString() : shannonsToCkb(toHex(amount)),
             unit,
             udtTypeScript,
             expiresAt: new Date(Date.now() + expirySeconds * 1000).toISOString(),
@@ -163,7 +164,7 @@ export function createInvoiceCommand(config: CliConfig): Command {
       const payload = {
         invoice: result.invoice_address,
         paymentHash: result.invoice.data.payment_hash,
-        amount: isUdt ? amount.toString() : amountCkb,
+        amount: isUdt ? amount.toString() : shannonsToCkb(toHex(amount)),
         unit,
         udtTypeScript,
         expiresAt: new Date(Date.now() + expirySeconds * 1000).toISOString(),

--- a/packages/cli/src/commands/invoice.ts
+++ b/packages/cli/src/commands/invoice.ts
@@ -1,4 +1,4 @@
-import { ckbToShannons, type HexString, randomBytes32, shannonsToCkb, toHex } from '@fiber-pay/sdk';
+import { type HexString, randomBytes32, shannonsToCkb, toHex } from '@fiber-pay/sdk';
 import { Command } from 'commander';
 import type { CliConfig } from '../lib/config.js';
 import {
@@ -8,8 +8,10 @@ import {
   printJsonError,
   printJsonSuccess,
 } from '../lib/format.js';
+import { parsePaymentAmount, type UdtTypeScript } from '../lib/parse-options.js';
 import { createReadyRpcClient, resolveRpcEndpoint } from '../lib/rpc.js';
 import { tryCreateRuntimeInvoiceJob, waitForRuntimeJobTerminal } from '../lib/runtime-jobs.js';
+import { resolveUdtTypeScript } from '../lib/udt.js';
 
 export function createInvoiceCommand(config: CliConfig): Command {
   const invoice = new Command('invoice').description('Invoice lifecycle and status commands');
@@ -17,7 +19,9 @@ export function createInvoiceCommand(config: CliConfig): Command {
   invoice
     .command('create')
     .argument('[amount]')
-    .option('--amount <ckb>')
+    .option('--amount <amount>')
+    .option('--udt-type-script <json>', 'UDT type script as JSON CKB Script')
+    .option('--udt-name <name>', 'UDT name from node_info.udt_cfg_infos')
     .option('--description <text>')
     .option('--expiry <minutes>')
     .option('--json')
@@ -25,27 +29,70 @@ export function createInvoiceCommand(config: CliConfig): Command {
       const rpc = await createReadyRpcClient(config);
       const json = Boolean(options.json);
 
-      const amountCkb = options.amount
-        ? parseFloat(options.amount)
-        : amountArg
-          ? parseFloat(amountArg)
-          : 0;
-      if (!amountCkb) {
-        if (options.json) {
+      let udtTypeScript: UdtTypeScript | undefined;
+      try {
+        const resolved = await resolveUdtTypeScript({
+          rawScript: options.udtTypeScript as string | undefined,
+          name: options.udtName as string | undefined,
+          rpc,
+        });
+        udtTypeScript = resolved.script;
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Invalid UDT option';
+        if (json) {
           printJsonError({
             code: 'INVOICE_CREATE_INPUT_INVALID',
-            message: 'Amount required. Usage: invoice create --amount <CKB>',
+            message,
             recoverable: true,
-            suggestion: 'Provide a valid positive amount via `--amount <CKB>`.',
+            suggestion:
+              'Provide a valid JSON script or UDT name, e.g. {"code_hash":"0x...","hash_type":"type","args":"0x..."} or --udt-name RUSD',
           });
         } else {
-          console.error('Error: Amount required. Usage: invoice create --amount <CKB>');
+          console.error(`Error: ${message}`);
         }
         process.exit(1);
       }
 
+      const isUdt = udtTypeScript !== undefined;
+      const amountInput = options.amount ?? amountArg;
+      if (!amountInput) {
+        if (json) {
+          printJsonError({
+            code: 'INVOICE_CREATE_INPUT_INVALID',
+            message: 'Amount required. Usage: invoice create --amount <amount>',
+            recoverable: true,
+            suggestion: 'Provide a valid positive amount via `--amount <amount>`.',
+          });
+        } else {
+          console.error('Error: Amount required. Usage: invoice create --amount <amount>');
+        }
+        process.exit(1);
+      }
+
+      let amount: bigint;
+      try {
+        amount = parsePaymentAmount(amountInput, isUdt);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Invalid amount';
+        if (json) {
+          printJsonError({
+            code: 'INVOICE_CREATE_INPUT_INVALID',
+            message,
+            recoverable: true,
+            suggestion: isUdt
+              ? 'Provide a positive integer UDT amount, e.g. --amount 1000'
+              : 'Provide a positive CKB amount, e.g. --amount 10',
+          });
+        } else {
+          console.error(`Error: ${message}`);
+        }
+        process.exit(1);
+      }
+
+      const amountCkb = isUdt ? undefined : parseFloat(amountInput);
       const expirySeconds = (options.expiry ? parseInt(options.expiry, 10) : 60) * 60;
       const currency = config.network === 'mainnet' ? 'Fibb' : 'Fibt';
+      const unit = isUdt ? 'UDT' : 'CKB';
 
       const endpoint = resolveRpcEndpoint(config);
       if (endpoint.target === 'runtime-proxy') {
@@ -53,11 +100,12 @@ export function createInvoiceCommand(config: CliConfig): Command {
           params: {
             action: 'create',
             newInvoiceParams: {
-              amount: ckbToShannons(amountCkb),
+              amount: toHex(amount),
               currency,
               description: options.description,
               expiry: toHex(expirySeconds),
               payment_preimage: randomBytes32(),
+              ...(udtTypeScript ? { udt_type_script: udtTypeScript } : {}),
             },
             waitForTerminal: false,
           },
@@ -79,7 +127,9 @@ export function createInvoiceCommand(config: CliConfig): Command {
             jobId: job.id,
             invoice: result.invoiceAddress,
             paymentHash: result.paymentHash,
-            amountCkb,
+            amount: isUdt ? amount.toString() : amountCkb,
+            unit,
+            udtTypeScript,
             expiresAt: new Date(Date.now() + expirySeconds * 1000).toISOString(),
             status: (result.status ?? 'Open').toLowerCase(),
           };
@@ -90,7 +140,10 @@ export function createInvoiceCommand(config: CliConfig): Command {
             console.log('Invoice created');
             console.log(`  Job:          ${payload.jobId}`);
             console.log(`  Payment Hash: ${payload.paymentHash ?? 'n/a'}`);
-            console.log(`  Amount:       ${payload.amountCkb} CKB`);
+            console.log(`  Amount:       ${payload.amount} ${payload.unit}`);
+            if (udtTypeScript) {
+              console.log(`  UDT Type Script: ${JSON.stringify(udtTypeScript)}`);
+            }
             console.log(`  Expires At:   ${payload.expiresAt}`);
             console.log(`  Invoice:      ${payload.invoice ?? 'n/a'}`);
           }
@@ -99,17 +152,20 @@ export function createInvoiceCommand(config: CliConfig): Command {
       }
 
       const result = await rpc.newInvoice({
-        amount: ckbToShannons(amountCkb),
+        amount: toHex(amount),
         currency,
         description: options.description,
         expiry: toHex(expirySeconds),
         payment_preimage: randomBytes32(),
+        ...(udtTypeScript ? { udt_type_script: udtTypeScript } : {}),
       });
 
       const payload = {
         invoice: result.invoice_address,
         paymentHash: result.invoice.data.payment_hash,
-        amountCkb,
+        amount: isUdt ? amount.toString() : amountCkb,
+        unit,
+        udtTypeScript,
         expiresAt: new Date(Date.now() + expirySeconds * 1000).toISOString(),
         status: 'open',
       };
@@ -119,7 +175,10 @@ export function createInvoiceCommand(config: CliConfig): Command {
       } else {
         console.log('Invoice created');
         console.log(`  Payment Hash: ${payload.paymentHash}`);
-        console.log(`  Amount:       ${payload.amountCkb} CKB`);
+        console.log(`  Amount:       ${payload.amount} ${payload.unit}`);
+        if (udtTypeScript) {
+          console.log(`  UDT Type Script: ${JSON.stringify(udtTypeScript)}`);
+        }
         console.log(`  Expires At:   ${payload.expiresAt}`);
         console.log(`  Invoice:      ${payload.invoice}`);
       }

--- a/packages/cli/src/commands/payment.ts
+++ b/packages/cli/src/commands/payment.ts
@@ -527,6 +527,8 @@ export function createPaymentCommand(config: CliConfig): Command {
     .option('--keysend', 'Keysend mode')
     .option('--allow-self-payment', 'Allow self-payment for circular route rebalancing')
     .option('--dry-run', 'Simulate—do not actually send')
+    .option('--udt-type-script <json>', 'UDT type script as JSON CKB Script')
+    .option('--udt-name <name>', 'UDT name from node_info.udt_cfg_infos')
     .option('--json')
     .action(async (options) => {
       const rpc = await createReadyRpcClient(config);
@@ -550,6 +552,32 @@ export function createPaymentCommand(config: CliConfig): Command {
         process.exit(1);
       }
 
+      let udtTypeScript: UdtTypeScript | undefined;
+      try {
+        const resolved = await resolveUdtTypeScript({
+          rawScript: options.udtTypeScript as string | undefined,
+          name: options.udtName as string | undefined,
+          rpc,
+        });
+        udtTypeScript = resolved.script;
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Invalid UDT option';
+        if (json) {
+          printJsonError({
+            code: 'PAYMENT_SEND_ROUTE_INPUT_INVALID',
+            message,
+            recoverable: true,
+            suggestion:
+              'Provide a valid JSON script or UDT name, e.g. {"code_hash":"0x...","hash_type":"type","args":"0x..."} or --udt-name RUSD',
+          });
+        } else {
+          console.error(`Error: ${message}`);
+        }
+        process.exit(1);
+      }
+      const isUdt = udtTypeScript !== undefined;
+      const unit = isUdt ? 'UDT' : 'CKB';
+
       const result = await rpc.sendPaymentWithRouter({
         router,
         invoice: options.invoice as string | undefined,
@@ -557,6 +585,7 @@ export function createPaymentCommand(config: CliConfig): Command {
         keysend: options.keysend ? true : undefined,
         allow_self_payment: options.allowSelfPayment ? true : undefined,
         dry_run: options.dryRun ? true : undefined,
+        ...(udtTypeScript ? { udt_type_script: udtTypeScript } : {}),
       });
 
       const payload = {
@@ -568,6 +597,8 @@ export function createPaymentCommand(config: CliConfig): Command {
               ? 'failed'
               : 'pending',
         feeCkb: shannonsToCkb(result.fee),
+        unit,
+        udtTypeScript,
         failureReason: result.failed_error,
         dryRun: Boolean(options.dryRun),
       };
@@ -579,6 +610,10 @@ export function createPaymentCommand(config: CliConfig): Command {
         console.log(`  Hash:   ${payload.paymentHash}`);
         console.log(`  Status: ${payload.status}`);
         console.log(`  Fee:    ${payload.feeCkb} CKB`);
+        console.log(`  Unit:   ${payload.unit}`);
+        if (payload.udtTypeScript) {
+          console.log(`  UDT Type Script: ${JSON.stringify(payload.udtTypeScript)}`);
+        }
         if (payload.failureReason) {
           console.log(`  Error:  ${payload.failureReason}`);
         }

--- a/packages/cli/src/commands/payment.ts
+++ b/packages/cli/src/commands/payment.ts
@@ -1,5 +1,5 @@
 import type { RouterHop } from '@fiber-pay/sdk';
-import { ckbToShannons, type HexString, shannonsToCkb, toHex } from '@fiber-pay/sdk';
+import { type HexString, shannonsToCkb, toHex } from '@fiber-pay/sdk';
 import { Command } from 'commander';
 import { sleep } from '../lib/async.js';
 import type { CliConfig } from '../lib/config.js';
@@ -10,7 +10,11 @@ import {
   printJsonSuccess,
   printPaymentDetailHuman,
 } from '../lib/format.js';
-import { parseFundingAmount, type UdtTypeScript } from '../lib/parse-options.js';
+import {
+  parseFundingAmount,
+  parsePaymentAmount,
+  type UdtTypeScript,
+} from '../lib/parse-options.js';
 import { createReadyRpcClient, resolveRpcEndpoint } from '../lib/rpc.js';
 import {
   type RuntimeJobRecord,
@@ -406,7 +410,9 @@ export function createPaymentCommand(config: CliConfig): Command {
     .command('route')
     .description('Build a payment route through specified hops')
     .requiredOption('--hops <pubkeys>', 'Comma-separated list of node pubkeys forming the route')
-    .option('--amount <ckb>', 'Amount in CKB to route')
+    .option('--amount <amount>', 'Amount to route (CKB or UDT raw units)')
+    .option('--udt-type-script <json>', 'UDT type script as JSON CKB Script')
+    .option('--udt-name <name>', 'UDT name from node_info.udt_cfg_infos')
     .option('--json')
     .action(async (options) => {
       const rpc = await createReadyRpcClient(config);
@@ -428,16 +434,70 @@ export function createPaymentCommand(config: CliConfig): Command {
         process.exit(1);
       }
 
+      let udtTypeScript: UdtTypeScript | undefined;
+      try {
+        const resolved = await resolveUdtTypeScript({
+          rawScript: options.udtTypeScript as string | undefined,
+          name: options.udtName as string | undefined,
+          rpc,
+        });
+        udtTypeScript = resolved.script;
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Invalid UDT option';
+        if (json) {
+          printJsonError({
+            code: 'PAYMENT_ROUTE_INPUT_INVALID',
+            message,
+            recoverable: true,
+            suggestion:
+              'Provide a valid JSON script or UDT name, e.g. {"code_hash":"0x...","hash_type":"type","args":"0x..."} or --udt-name RUSD',
+          });
+        } else {
+          console.error(`Error: ${message}`);
+        }
+        process.exit(1);
+      }
+
+      const isUdt = udtTypeScript !== undefined;
+
+      let amount: bigint | undefined;
+      if (options.amount) {
+        try {
+          amount = parsePaymentAmount(options.amount, isUdt);
+        } catch (error) {
+          const message = error instanceof Error ? error.message : 'Invalid amount';
+          if (json) {
+            printJsonError({
+              code: 'PAYMENT_ROUTE_INPUT_INVALID',
+              message,
+              recoverable: true,
+              suggestion: isUdt
+                ? 'Provide a positive integer UDT amount, e.g. --amount 1000'
+                : 'Provide a positive CKB amount, e.g. --amount 10',
+            });
+          } else {
+            console.error(`Error: ${message}`);
+          }
+          process.exit(1);
+        }
+      }
+
       const hopsInfo = pubkeys.map((pubkey: string) => ({ pubkey: pubkey as HexString }));
-      const amount = options.amount ? ckbToShannons(parseFloat(options.amount)) : undefined;
 
       const result = await rpc.buildRouter({
         hops_info: hopsInfo,
-        amount,
+        amount: amount !== undefined ? toHex(amount) : undefined,
+        ...(udtTypeScript ? { udt_type_script: udtTypeScript } : {}),
       });
 
+      const unit = isUdt ? 'UDT' : 'CKB';
+
       if (json) {
-        printJsonSuccess({ routerHops: result.router_hops });
+        printJsonSuccess({
+          routerHops: result.router_hops,
+          unit,
+          udtTypeScript,
+        });
       } else {
         console.log(`Route built: ${result.router_hops.length} hop(s)`);
         for (let i = 0; i < result.router_hops.length; i++) {
@@ -447,7 +507,9 @@ export function createPaymentCommand(config: CliConfig): Command {
           console.log(
             `    Outpoint:   ${hop.channel_outpoint.tx_hash}:${hop.channel_outpoint.index}`,
           );
-          console.log(`    Amount:     ${shannonsToCkb(hop.amount_received)} CKB`);
+          console.log(
+            `    Amount:     ${isUdt ? BigInt(hop.amount_received).toString() : shannonsToCkb(hop.amount_received)} ${unit}`,
+          );
           console.log(`    Expiry:     ${hop.incoming_tlc_expiry}`);
         }
       }

--- a/packages/cli/src/commands/payment.ts
+++ b/packages/cli/src/commands/payment.ts
@@ -46,7 +46,7 @@ export function createPaymentCommand(config: CliConfig): Command {
       const recipientNodeId = options.to;
 
       let udtTypeScript: UdtTypeScript | undefined;
-      let unit: 'CKB' | 'UDT' = 'CKB';
+      let unit = 'CKB';
       try {
         const resolved = await resolveUdtTypeScript({
           rawScript: options.udtTypeScript as string | undefined,
@@ -54,7 +54,7 @@ export function createPaymentCommand(config: CliConfig): Command {
           rpc,
         });
         udtTypeScript = resolved.script;
-        unit = resolved.unit;
+        unit = resolved.name ?? resolved.unit;
       } catch (error) {
         const msg = error instanceof Error ? error.message : String(error);
         if (json) {
@@ -76,7 +76,7 @@ export function createPaymentCommand(config: CliConfig): Command {
       let amountRaw: bigint | undefined;
       if (options.amount) {
         try {
-          amountRaw = parseFundingAmount(options.amount, isUdt);
+          amountRaw = parsePaymentAmount(options.amount, isUdt);
         } catch (error) {
           const msg = error instanceof Error ? error.message : String(error);
           if (json) {
@@ -85,8 +85,8 @@ export function createPaymentCommand(config: CliConfig): Command {
               message: msg,
               recoverable: true,
               suggestion: isUdt
-                ? 'Provide the UDT amount as an integer in the smallest unit.'
-                : 'Provide the CKB amount as a non-negative number.',
+                ? 'Provide a positive integer UDT amount, e.g. --amount 1000'
+                : 'Provide a positive CKB amount, e.g. --amount 10',
             });
           } else {
             console.error(`Error: ${msg}`);

--- a/packages/cli/src/commands/payment.ts
+++ b/packages/cli/src/commands/payment.ts
@@ -1,5 +1,5 @@
 import type { RouterHop } from '@fiber-pay/sdk';
-import { ckbToShannons, type HexString, shannonsToCkb } from '@fiber-pay/sdk';
+import { ckbToShannons, type HexString, shannonsToCkb, toHex } from '@fiber-pay/sdk';
 import { Command } from 'commander';
 import { sleep } from '../lib/async.js';
 import type { CliConfig } from '../lib/config.js';
@@ -10,12 +10,14 @@ import {
   printJsonSuccess,
   printPaymentDetailHuman,
 } from '../lib/format.js';
+import { parseFundingAmount, type UdtTypeScript } from '../lib/parse-options.js';
 import { createReadyRpcClient, resolveRpcEndpoint } from '../lib/rpc.js';
 import {
   type RuntimeJobRecord,
   tryCreateRuntimePaymentJob,
   waitForRuntimeJobTerminal,
 } from '../lib/runtime-jobs.js';
+import { resolveUdtTypeScript } from '../lib/udt.js';
 import { registerPaymentRebalanceCommand } from './rebalance.js';
 
 export function createPaymentCommand(config: CliConfig): Command {
@@ -26,8 +28,10 @@ export function createPaymentCommand(config: CliConfig): Command {
     .argument('[invoice]')
     .option('--invoice <invoice>')
     .option('--to <nodeId>')
-    .option('--amount <ckb>')
+    .option('--amount <amount>')
     .option('--max-fee <ckb>')
+    .option('--udt-type-script <json>', 'UDT type script for the payment')
+    .option('--udt-name <name>', 'Name of a UDT from the node config for the payment')
     .option('--wait', 'Wait for runtime job terminal status when runtime proxy is active')
     .option('--timeout <seconds>', 'Wait timeout for --wait mode', '120')
     .option('--json')
@@ -36,8 +40,77 @@ export function createPaymentCommand(config: CliConfig): Command {
       const json = Boolean(options.json);
       const invoice = options.invoice || invoiceArg;
       const recipientNodeId = options.to;
-      const amountCkb = options.amount ? parseFloat(options.amount) : undefined;
-      const maxFeeCkb = options.maxFee ? parseFloat(options.maxFee) : undefined;
+
+      let udtTypeScript: UdtTypeScript | undefined;
+      let unit: 'CKB' | 'UDT' = 'CKB';
+      try {
+        const resolved = await resolveUdtTypeScript({
+          rawScript: options.udtTypeScript as string | undefined,
+          name: options.udtName as string | undefined,
+          rpc,
+        });
+        udtTypeScript = resolved.script;
+        unit = resolved.unit;
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
+        if (json) {
+          printJsonError({
+            code: 'PAYMENT_SEND_INPUT_INVALID',
+            message: msg,
+            recoverable: true,
+            suggestion:
+              'Provide a valid JSON script or UDT name, e.g. {"code_hash":"0x...","hash_type":"type","args":"0x..."} or --udt-name RUSD',
+          });
+        } else {
+          console.error(`Error: ${msg}`);
+        }
+        process.exit(1);
+      }
+
+      const isUdt = udtTypeScript !== undefined;
+
+      let amountRaw: bigint | undefined;
+      if (options.amount) {
+        try {
+          amountRaw = parseFundingAmount(options.amount, isUdt);
+        } catch (error) {
+          const msg = error instanceof Error ? error.message : String(error);
+          if (json) {
+            printJsonError({
+              code: 'PAYMENT_SEND_INPUT_INVALID',
+              message: msg,
+              recoverable: true,
+              suggestion: isUdt
+                ? 'Provide the UDT amount as an integer in the smallest unit.'
+                : 'Provide the CKB amount as a non-negative number.',
+            });
+          } else {
+            console.error(`Error: ${msg}`);
+          }
+          process.exit(1);
+        }
+      }
+
+      let maxFeeRaw: bigint | undefined;
+      if (options.maxFee) {
+        try {
+          maxFeeRaw = parseFundingAmount(options.maxFee, false);
+        } catch (error) {
+          const msg = error instanceof Error ? error.message : String(error);
+          if (json) {
+            printJsonError({
+              code: 'PAYMENT_SEND_INPUT_INVALID',
+              message: msg,
+              recoverable: true,
+              suggestion: 'Provide the CKB max fee as a non-negative number.',
+            });
+          } else {
+            console.error(`Error: ${msg}`);
+          }
+          process.exit(1);
+        }
+      }
+
       const shouldWait = Boolean(options.wait);
       const timeoutSeconds = parseInt(String(options.timeout ?? '120'), 10);
 
@@ -54,13 +127,13 @@ export function createPaymentCommand(config: CliConfig): Command {
         }
         process.exit(1);
       }
-      if (recipientNodeId && !amountCkb) {
+      if (recipientNodeId && amountRaw === undefined) {
         if (json) {
           printJsonError({
             code: 'PAYMENT_SEND_INPUT_INVALID',
             message: '--amount required when using --to',
             recoverable: true,
-            suggestion: 'Add `--amount <ckb>` when using keysend mode (`--to`).',
+            suggestion: 'Add `--amount <amount>` when using keysend mode (`--to`).',
           });
         } else {
           console.error('Error: --amount required when using --to');
@@ -71,9 +144,10 @@ export function createPaymentCommand(config: CliConfig): Command {
       const paymentParams = {
         invoice,
         target_pubkey: recipientNodeId as HexString | undefined,
-        amount: amountCkb ? ckbToShannons(amountCkb) : undefined,
+        amount: amountRaw !== undefined ? toHex(amountRaw) : undefined,
         keysend: recipientNodeId ? true : undefined,
-        max_fee_amount: maxFeeCkb ? ckbToShannons(maxFeeCkb) : undefined,
+        max_fee_amount: maxFeeRaw !== undefined ? toHex(maxFeeRaw) : undefined,
+        ...(udtTypeScript ? { udt_type_script: udtTypeScript } : {}),
       };
 
       const endpoint = resolveRpcEndpoint(config);
@@ -106,6 +180,9 @@ export function createPaymentCommand(config: CliConfig): Command {
             failureReason: getJobFailure(job),
             jobId: job.id,
             jobState: job.state,
+            unit,
+            amount: amountRaw?.toString(),
+            ...(udtTypeScript ? { udtTypeScript } : {}),
           };
 
           if (json) {
@@ -116,6 +193,12 @@ export function createPaymentCommand(config: CliConfig): Command {
             console.log(`  Hash:   ${payload.paymentHash}`);
             console.log(`  Status: ${payload.status} (${payload.jobState})`);
             console.log(`  Fee:    ${payload.feeCkb} CKB`);
+            if (payload.amount !== undefined) {
+              console.log(`  Amount: ${payload.amount} ${unit}`);
+            }
+            if (udtTypeScript) {
+              console.log(`  UDT Type Script: ${JSON.stringify(udtTypeScript)}`);
+            }
             if (payload.failureReason) {
               console.log(`  Error:  ${payload.failureReason}`);
             }
@@ -137,6 +220,9 @@ export function createPaymentCommand(config: CliConfig): Command {
               : 'pending',
         feeCkb: shannonsToCkb(result.fee),
         failureReason: result.failed_error,
+        unit,
+        amount: amountRaw?.toString(),
+        ...(udtTypeScript ? { udtTypeScript } : {}),
       };
 
       if (json) {
@@ -146,6 +232,12 @@ export function createPaymentCommand(config: CliConfig): Command {
         console.log(`  Hash:   ${payload.paymentHash}`);
         console.log(`  Status: ${payload.status}`);
         console.log(`  Fee:    ${payload.feeCkb} CKB`);
+        if (payload.amount !== undefined) {
+          console.log(`  Amount: ${payload.amount} ${unit}`);
+        }
+        if (udtTypeScript) {
+          console.log(`  UDT Type Script: ${JSON.stringify(udtTypeScript)}`);
+        }
         if (payload.failureReason) {
           console.log(`  Error:  ${payload.failureReason}`);
         }

--- a/packages/cli/src/commands/rebalance.ts
+++ b/packages/cli/src/commands/rebalance.ts
@@ -14,6 +14,7 @@ interface RebalanceExecutionParams {
   json: boolean;
   errorCode: 'PAYMENT_REBALANCE_INPUT_INVALID' | 'CHANNEL_REBALANCE_INPUT_INVALID';
   udtTypeScript?: UdtTypeScript;
+  udtName?: string;
 }
 
 async function executeRebalance(
@@ -110,7 +111,7 @@ async function executeRebalance(
         ...(params.udtTypeScript ? { udt_type_script: params.udtTypeScript } : {}),
       });
 
-  const unit = isUdt ? 'UDT' : 'CKB';
+  const unit = params.udtName ?? (isUdt ? 'UDT' : 'CKB');
   const payload = {
     mode: isManual ? 'manual' : 'auto',
     selfPubkey,
@@ -194,6 +195,7 @@ export function registerPaymentRebalanceCommand(parent: Command, config: CliConf
 
       const rpc = await createReadyRpcClient(config);
       let udtTypeScript: UdtTypeScript | undefined;
+      let udtName: string | undefined;
       try {
         const resolved = await resolveUdtTypeScript({
           rawScript: options.udtTypeScript as string | undefined,
@@ -201,6 +203,7 @@ export function registerPaymentRebalanceCommand(parent: Command, config: CliConf
           rpc,
         });
         udtTypeScript = resolved.script;
+        udtName = resolved.name;
       } catch (error) {
         const message = error instanceof Error ? error.message : 'Invalid UDT option';
         if (options.json) {
@@ -225,6 +228,7 @@ export function registerPaymentRebalanceCommand(parent: Command, config: CliConf
         json: Boolean(options.json),
         errorCode: 'PAYMENT_REBALANCE_INPUT_INVALID',
         udtTypeScript,
+        udtName,
       });
     });
 }
@@ -337,6 +341,7 @@ export function registerChannelRebalanceCommand(parent: Command, config: CliConf
 
       const rpc = await createReadyRpcClient(config);
       let udtTypeScript: UdtTypeScript | undefined;
+      let udtName: string | undefined;
       try {
         const resolved = await resolveUdtTypeScript({
           rawScript: options.udtTypeScript as string | undefined,
@@ -344,6 +349,7 @@ export function registerChannelRebalanceCommand(parent: Command, config: CliConf
           rpc,
         });
         udtTypeScript = resolved.script;
+        udtName = resolved.name;
       } catch (error) {
         const message = error instanceof Error ? error.message : 'Invalid UDT option';
         if (json) {
@@ -368,6 +374,7 @@ export function registerChannelRebalanceCommand(parent: Command, config: CliConf
         json,
         errorCode: 'CHANNEL_REBALANCE_INPUT_INVALID',
         udtTypeScript,
+        udtName,
       });
     });
 }

--- a/packages/cli/src/commands/rebalance.ts
+++ b/packages/cli/src/commands/rebalance.ts
@@ -1,8 +1,10 @@
-import { ckbToShannons, type HexString, shannonsToCkb } from '@fiber-pay/sdk';
+import { ckbToShannons, type HexString, shannonsToCkb, toHex } from '@fiber-pay/sdk';
 import type { Command } from 'commander';
 import type { CliConfig } from '../lib/config.js';
 import { printJsonError, printJsonSuccess } from '../lib/format.js';
+import { parsePaymentAmount, type UdtTypeScript } from '../lib/parse-options.js';
 import { createReadyRpcClient } from '../lib/rpc.js';
+import { resolveUdtTypeScript } from '../lib/udt.js';
 
 interface RebalanceExecutionParams {
   amountInput: string;
@@ -11,6 +13,7 @@ interface RebalanceExecutionParams {
   dryRun: boolean;
   json: boolean;
   errorCode: 'PAYMENT_REBALANCE_INPUT_INVALID' | 'CHANNEL_REBALANCE_INPUT_INVALID';
+  udtTypeScript?: UdtTypeScript;
 }
 
 async function executeRebalance(
@@ -18,18 +21,21 @@ async function executeRebalance(
   params: RebalanceExecutionParams,
 ): Promise<void> {
   const rpc = await createReadyRpcClient(config);
-  const amountCkb = parseFloat(params.amountInput);
-  const maxFeeCkb = params.maxFeeInput !== undefined ? parseFloat(params.maxFeeInput) : undefined;
-  const manualHops = params.hops ?? [];
+  const isUdt = params.udtTypeScript !== undefined;
 
-  if (!Number.isFinite(amountCkb) || amountCkb <= 0) {
-    const message = 'Invalid --amount value. Expected a positive CKB amount.';
+  let amount: bigint;
+  try {
+    amount = parsePaymentAmount(params.amountInput, isUdt);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Invalid amount';
     if (params.json) {
       printJsonError({
         code: params.errorCode,
         message,
         recoverable: true,
-        suggestion: 'Provide a positive number, e.g. `--amount 10`.',
+        suggestion: isUdt
+          ? 'Provide a positive integer UDT amount, e.g. --amount 1000'
+          : 'Provide a positive CKB amount, e.g. --amount 10',
         details: { amount: params.amountInput },
       });
     } else {
@@ -37,6 +43,9 @@ async function executeRebalance(
     }
     process.exit(1);
   }
+
+  const maxFeeCkb = params.maxFeeInput !== undefined ? parseFloat(params.maxFeeInput) : undefined;
+  const manualHops = params.hops ?? [];
 
   if (
     maxFeeCkb !== undefined &&
@@ -64,7 +73,6 @@ async function executeRebalance(
   }
 
   const selfPubkey = (await rpc.nodeInfo()).pubkey as HexString;
-  const amount = ckbToShannons(amountCkb);
   const isManual = manualHops.length > 0;
   let routeHopCount: number | undefined;
 
@@ -78,8 +86,9 @@ async function executeRebalance(
         ];
 
         const route = await rpc.buildRouter({
-          amount,
+          amount: toHex(amount),
           hops_info: hopsInfo,
+          ...(params.udtTypeScript ? { udt_type_script: params.udtTypeScript } : {}),
         });
         routeHopCount = route.router_hops.length;
 
@@ -88,21 +97,25 @@ async function executeRebalance(
           keysend: true,
           allow_self_payment: true,
           dry_run: params.dryRun ? true : undefined,
+          ...(params.udtTypeScript ? { udt_type_script: params.udtTypeScript } : {}),
         });
       })()
     : await rpc.sendPayment({
         target_pubkey: selfPubkey,
-        amount,
+        amount: toHex(amount),
         keysend: true,
         allow_self_payment: true,
         max_fee_amount: maxFeeCkb !== undefined ? ckbToShannons(maxFeeCkb) : undefined,
         dry_run: params.dryRun ? true : undefined,
+        ...(params.udtTypeScript ? { udt_type_script: params.udtTypeScript } : {}),
       });
 
+  const unit = isUdt ? 'UDT' : 'CKB';
   const payload = {
     mode: isManual ? 'manual' : 'auto',
     selfPubkey,
-    amountCkb,
+    amount: isUdt ? amount.toString() : shannonsToCkb(toHex(amount)),
+    unit,
     maxFeeCkb: isManual ? undefined : maxFeeCkb,
     routeHopCount,
     paymentHash: result.payment_hash,
@@ -111,6 +124,7 @@ async function executeRebalance(
     feeCkb: shannonsToCkb(result.fee),
     failureReason: result.failed_error,
     dryRun: params.dryRun,
+    udtTypeScript: params.udtTypeScript,
   };
 
   if (params.json) {
@@ -122,7 +136,7 @@ async function executeRebalance(
         : `Rebalance sent (${payload.mode} route)`,
     );
     console.log(`  Self:   ${payload.selfPubkey}`);
-    console.log(`  Amount: ${payload.amountCkb} CKB`);
+    console.log(`  Amount: ${payload.amount} ${payload.unit}`);
     if (payload.mode === 'manual' && payload.routeHopCount !== undefined) {
       console.log(`  Hops:   ${payload.routeHopCount}`);
     }
@@ -142,12 +156,14 @@ export function registerPaymentRebalanceCommand(parent: Command, config: CliConf
   parent
     .command('rebalance')
     .description('Technical rebalance command mapped to payment-layer circular self-payment')
-    .requiredOption('--amount <ckb>', 'Amount in CKB to rebalance')
+    .requiredOption('--amount <amount>', 'Amount to rebalance (CKB or UDT raw units)')
     .option('--max-fee <ckb>', 'Maximum fee in CKB (auto mode only)')
     .option(
       '--hops <pubkeys>',
       'Comma-separated peer pubkeys for manual route mode (self pubkey appended automatically)',
     )
+    .option('--udt-type-script <json>', 'UDT type script as JSON CKB Script')
+    .option('--udt-name <name>', 'UDT name from node_info.udt_cfg_infos')
     .option('--dry-run', 'Simulate route/payment and return estimated result')
     .option('--json')
     .action(async (options) => {
@@ -176,6 +192,31 @@ export function registerPaymentRebalanceCommand(parent: Command, config: CliConf
         process.exit(1);
       }
 
+      const rpc = await createReadyRpcClient(config);
+      let udtTypeScript: UdtTypeScript | undefined;
+      try {
+        const resolved = await resolveUdtTypeScript({
+          rawScript: options.udtTypeScript as string | undefined,
+          name: options.udtName as string | undefined,
+          rpc,
+        });
+        udtTypeScript = resolved.script;
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Invalid UDT option';
+        if (options.json) {
+          printJsonError({
+            code: 'PAYMENT_REBALANCE_INPUT_INVALID',
+            message,
+            recoverable: true,
+            suggestion:
+              'Provide a valid JSON script or UDT name, e.g. {"code_hash":"0x...","hash_type":"type","args":"0x..."} or --udt-name RUSD',
+          });
+        } else {
+          console.error(`Error: ${message}`);
+        }
+        process.exit(1);
+      }
+
       await executeRebalance(config, {
         amountInput: options.amount,
         maxFeeInput: options.maxFee,
@@ -183,6 +224,7 @@ export function registerPaymentRebalanceCommand(parent: Command, config: CliConf
         dryRun: Boolean(options.dryRun),
         json: Boolean(options.json),
         errorCode: 'PAYMENT_REBALANCE_INPUT_INVALID',
+        udtTypeScript,
       });
     });
 }
@@ -191,10 +233,12 @@ export function registerChannelRebalanceCommand(parent: Command, config: CliConf
   parent
     .command('rebalance')
     .description('High-level channel rebalance wrapper using payment-layer orchestration')
-    .requiredOption('--amount <ckb>', 'Amount in CKB to rebalance')
+    .requiredOption('--amount <amount>', 'Amount to rebalance (CKB or UDT raw units)')
     .option('--from-channel <channelId>', 'Source-biased channel id (optional)')
     .option('--to-channel <channelId>', 'Destination-biased channel id (optional)')
     .option('--max-fee <ckb>', 'Maximum fee in CKB (auto mode only)')
+    .option('--udt-type-script <json>', 'UDT type script as JSON CKB Script')
+    .option('--udt-name <name>', 'UDT name from node_info.udt_cfg_infos')
     .option('--dry-run', 'Simulate route/payment and return estimated result')
     .option('--json')
     .action(async (options) => {
@@ -291,6 +335,31 @@ export function registerChannelRebalanceCommand(parent: Command, config: CliConf
         guidedHops = [fromPubkey, toPubkey];
       }
 
+      const rpc = await createReadyRpcClient(config);
+      let udtTypeScript: UdtTypeScript | undefined;
+      try {
+        const resolved = await resolveUdtTypeScript({
+          rawScript: options.udtTypeScript as string | undefined,
+          name: options.udtName as string | undefined,
+          rpc,
+        });
+        udtTypeScript = resolved.script;
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Invalid UDT option';
+        if (json) {
+          printJsonError({
+            code: 'CHANNEL_REBALANCE_INPUT_INVALID',
+            message,
+            recoverable: true,
+            suggestion:
+              'Provide a valid JSON script or UDT name, e.g. {"code_hash":"0x...","hash_type":"type","args":"0x..."} or --udt-name RUSD',
+          });
+        } else {
+          console.error(`Error: ${message}`);
+        }
+        process.exit(1);
+      }
+
       await executeRebalance(config, {
         amountInput: options.amount,
         maxFeeInput: options.maxFee,
@@ -298,6 +367,7 @@ export function registerChannelRebalanceCommand(parent: Command, config: CliConf
         dryRun: Boolean(options.dryRun),
         json,
         errorCode: 'CHANNEL_REBALANCE_INPUT_INVALID',
+        udtTypeScript,
       });
     });
 }

--- a/packages/cli/src/lib/format.ts
+++ b/packages/cli/src/lib/format.ts
@@ -158,6 +158,8 @@ export function formatChannel(channel: Channel): Record<string, unknown> {
   const capacity = local + remote;
   const localPct = capacity > 0n ? Number((local * 100n) / capacity) : 0;
   const remotePct = capacity > 0n ? 100 - localPct : 0;
+  const isUdt = channel.funding_udt_type_script !== null;
+  const unit = isUdt ? 'UDT' : 'CKB';
 
   return {
     channelId: channel.channel_id,
@@ -167,9 +169,14 @@ export function formatChannel(channel: Channel): Record<string, unknown> {
     state: channel.state.state_name,
     stateLabel: stateLabel(channel.state.state_name),
     stateFlags: channel.state.state_flags,
-    localBalanceCkb: shannonsToCkb(channel.local_balance),
-    remoteBalanceCkb: shannonsToCkb(channel.remote_balance),
-    capacityCkb: shannonsToCkb(toHex(capacity)),
+    localBalance: isUdt ? local.toString() : shannonsToCkb(channel.local_balance),
+    remoteBalance: isUdt ? remote.toString() : shannonsToCkb(channel.remote_balance),
+    capacity: isUdt ? capacity.toString() : shannonsToCkb(toHex(capacity)),
+    localBalanceCkb: isUdt ? undefined : shannonsToCkb(channel.local_balance),
+    remoteBalanceCkb: isUdt ? undefined : shannonsToCkb(channel.remote_balance),
+    capacityCkb: isUdt ? undefined : shannonsToCkb(toHex(capacity)),
+    unit,
+    fundingUdtTypeScript: channel.funding_udt_type_script ?? undefined,
     balanceRatio: `${localPct}/${remotePct}`,
     pendingTlcs: channel.pending_tlcs.length,
     enabled: channel.enabled,
@@ -179,13 +186,33 @@ export function formatChannel(channel: Channel): Record<string, unknown> {
 }
 
 export function getChannelSummary(channels: Channel[]): Record<string, unknown> {
-  let totalLocal = 0n;
-  let totalRemote = 0n;
+  let totalLocalCkb = 0n;
+  let totalRemoteCkb = 0n;
+  const udtTotals = new Map<
+    string,
+    { local: bigint; remote: bigint; script: NonNullable<Channel['funding_udt_type_script']> }
+  >();
   let active = 0;
 
   for (const channel of channels) {
-    totalLocal += BigInt(channel.local_balance);
-    totalRemote += BigInt(channel.remote_balance || '0x0');
+    const local = BigInt(channel.local_balance);
+    const remote = BigInt(channel.remote_balance || '0x0');
+
+    if (channel.funding_udt_type_script) {
+      const key = `${channel.funding_udt_type_script.code_hash}:${channel.funding_udt_type_script.hash_type}:${channel.funding_udt_type_script.args}`;
+      const entry = udtTotals.get(key) ?? {
+        local: 0n,
+        remote: 0n,
+        script: channel.funding_udt_type_script,
+      };
+      entry.local += local;
+      entry.remote += remote;
+      udtTotals.set(key, entry);
+    } else {
+      totalLocalCkb += local;
+      totalRemoteCkb += remote;
+    }
+
     if (channel.state.state_name === ChannelState.ChannelReady) {
       active++;
     }
@@ -194,9 +221,15 @@ export function getChannelSummary(channels: Channel[]): Record<string, unknown> 
   return {
     count: channels.length,
     activeCount: active,
-    totalLocalCkb: shannonsToCkb(toHex(totalLocal)),
-    totalRemoteCkb: shannonsToCkb(toHex(totalRemote)),
-    totalCapacityCkb: shannonsToCkb(toHex(totalLocal + totalRemote)),
+    totalLocalCkb: shannonsToCkb(toHex(totalLocalCkb)),
+    totalRemoteCkb: shannonsToCkb(toHex(totalRemoteCkb)),
+    totalCapacityCkb: shannonsToCkb(toHex(totalLocalCkb + totalRemoteCkb)),
+    udtTotals: Array.from(udtTotals.values()).map((entry) => ({
+      localBalance: entry.local.toString(),
+      remoteBalance: entry.remote.toString(),
+      capacity: (entry.local + entry.remote).toString(),
+      fundingUdtTypeScript: entry.script,
+    })),
   };
 }
 
@@ -279,9 +312,18 @@ export function printJsonEvent(event: string, data: unknown, ts = new Date().toI
 }
 
 export function printChannelDetailHuman(channel: Channel): void {
-  const local = shannonsToCkb(channel.local_balance);
-  const remote = shannonsToCkb(channel.remote_balance);
-  const capacity = local + remote;
+  const isUdt = channel.funding_udt_type_script !== null;
+  const unit = isUdt ? 'UDT' : 'CKB';
+  const local = isUdt
+    ? BigInt(channel.local_balance).toString()
+    : shannonsToCkb(channel.local_balance);
+  const remote = isUdt
+    ? BigInt(channel.remote_balance).toString()
+    : shannonsToCkb(channel.remote_balance);
+  const capacity =
+    typeof local === 'number' || typeof remote === 'number'
+      ? (local as number) + (remote as number)
+      : (BigInt(channel.local_balance) + BigInt(channel.remote_balance)).toString();
 
   console.log('Channel');
   console.log(`  ID:            ${channel.channel_id}`);
@@ -292,8 +334,11 @@ export function printChannelDetailHuman(channel: Channel): void {
   console.log(`  Enabled:       ${channel.enabled ? 'yes' : 'no'}`);
   console.log(`  Public:        ${channel.is_public ? 'yes' : 'no'}`);
   console.log(
-    `  Balance:       local ${local} CKB | remote ${remote} CKB | capacity ${capacity} CKB`,
+    `  Balance:       local ${local} ${unit} | remote ${remote} ${unit} | capacity ${capacity} ${unit}`,
   );
+  if (isUdt) {
+    console.log(`  UDT Type Script: ${JSON.stringify(channel.funding_udt_type_script)}`);
+  }
   console.log(`  Pending TLCs:  ${channel.pending_tlcs.length}`);
   console.log(`  Age:           ${formatAge(parseHexTimestampMs(channel.created_at))}`);
   console.log(
@@ -365,28 +410,51 @@ export function printChannelListHuman(channels: Channel[]): void {
     totalLocalCkb: number;
     totalRemoteCkb: number;
     totalCapacityCkb: number;
+    udtTotals: Array<{
+      localBalance: string;
+      remoteBalance: string;
+      capacity: string;
+      fundingUdtTypeScript: NonNullable<Channel['funding_udt_type_script']>;
+    }>;
   };
 
   console.log(`Channels: ${summary.count} total, ${summary.activeCount} ready`);
   console.log(
     `Liquidity: local ${summary.totalLocalCkb} CKB | remote ${summary.totalRemoteCkb} CKB | capacity ${summary.totalCapacityCkb} CKB`,
   );
+  if (summary.udtTotals.length > 0) {
+    for (const udt of summary.udtTotals) {
+      console.log(
+        `UDT: local ${udt.localBalance} | remote ${udt.remoteBalance} | capacity ${udt.capacity}`,
+      );
+    }
+  }
   console.log('');
   console.log(
-    'ID                     PEER                   STATE                     LOCAL      REMOTE     TLC',
+    'ID                     PEER                   STATE                     LOCAL      REMOTE     UNIT TLC',
   );
   console.log(
-    '---------------------------------------------------------------------------------------------------',
+    '------------------------------------------------------------------------------------------------------',
   );
 
   for (const channel of channels) {
     const id = truncateMiddle(channel.channel_id, 10, 8).padEnd(22, ' ');
     const peer = truncateMiddle(channel.pubkey, 10, 8).padEnd(22, ' ');
     const state = channel.state.state_name.padEnd(24, ' ');
-    const local = `${shannonsToCkb(channel.local_balance)}`.padStart(8, ' ');
-    const remote = `${shannonsToCkb(channel.remote_balance)}`.padStart(8, ' ');
+    const isUdt = channel.funding_udt_type_script !== null;
+    const unit = isUdt ? 'UDT' : 'CKB';
+    const local =
+      `${isUdt ? BigInt(channel.local_balance).toString() : shannonsToCkb(channel.local_balance)}`.padStart(
+        8,
+        ' ',
+      );
+    const remote =
+      `${isUdt ? BigInt(channel.remote_balance).toString() : shannonsToCkb(channel.remote_balance)}`.padStart(
+        8,
+        ' ',
+      );
     const tlcs = `${channel.pending_tlcs.length}`.padStart(4, ' ');
-    console.log(`${id} ${peer} ${state} ${local} ${remote} ${tlcs}`);
+    console.log(`${id} ${peer} ${state} ${local} ${remote} ${unit.padEnd(4)} ${tlcs}`);
   }
 }
 

--- a/packages/cli/src/lib/parse-options.ts
+++ b/packages/cli/src/lib/parse-options.ts
@@ -1,4 +1,4 @@
-import { ckbToShannons, type HexString } from '@fiber-pay/sdk';
+import type { HexString } from '@fiber-pay/sdk';
 
 export function parseIntegerOption(value: string | undefined, name: string): number | undefined {
   if (value === undefined) {
@@ -70,18 +70,35 @@ export function parseUdtTypeScript(
 }
 
 export function parsePaymentAmount(value: string, isUdt: boolean): bigint {
+  if (value.trim() !== value || value.trim().length === 0) {
+    throw new Error(
+      `Invalid ${isUdt ? 'UDT' : 'CKB'} amount: "${value}". Expected a positive ${isUdt ? 'integer' : 'number'}.`,
+    );
+  }
+
   if (isUdt) {
-    const trimmed = value.trim();
-    if (!/^\d+$/.test(trimmed)) {
+    if (!/^\d+$/.test(value)) {
       throw new Error(`Invalid UDT amount "${value}": expected a non-negative integer`);
     }
-    const amount = BigInt(trimmed);
+    const amount = BigInt(value);
     if (amount <= 0n) {
       throw new Error('UDT amount must be greater than 0');
     }
     return amount;
   }
-  return BigInt(ckbToShannons(parseFloat(value)));
+
+  if (!/^\d+(\.\d{1,8})?$/.test(value)) {
+    throw new Error(
+      `Invalid CKB amount: "${value}". Expected a positive number with at most 8 decimal places.`,
+    );
+  }
+  const [integerPart, fractionalPart = ''] = value.split('.');
+  const shannonsPerCkb = 10n ** 8n;
+  const amount = BigInt(integerPart) * shannonsPerCkb + BigInt(fractionalPart.padEnd(8, '0'));
+  if (amount <= 0n) {
+    throw new Error('CKB amount must be greater than 0');
+  }
+  return amount;
 }
 
 export function parseFundingAmount(value: string, isUdt: boolean): bigint {

--- a/packages/cli/src/lib/parse-options.ts
+++ b/packages/cli/src/lib/parse-options.ts
@@ -1,4 +1,4 @@
-import type { HexString } from '@fiber-pay/sdk';
+import { ckbToShannons, type HexString } from '@fiber-pay/sdk';
 
 export function parseIntegerOption(value: string | undefined, name: string): number | undefined {
   if (value === undefined) {
@@ -67,6 +67,21 @@ export function parseUdtTypeScript(
     hash_type: script.hash_type as UdtTypeScript['hash_type'],
     args: script.args as HexString,
   };
+}
+
+export function parsePaymentAmount(value: string, isUdt: boolean): bigint {
+  if (isUdt) {
+    const trimmed = value.trim();
+    if (!/^\d+$/.test(trimmed)) {
+      throw new Error(`Invalid UDT amount "${value}": expected a non-negative integer`);
+    }
+    const amount = BigInt(trimmed);
+    if (amount <= 0n) {
+      throw new Error('UDT amount must be greater than 0');
+    }
+    return amount;
+  }
+  return BigInt(ckbToShannons(parseFloat(value)));
 }
 
 export function parseFundingAmount(value: string, isUdt: boolean): bigint {

--- a/packages/cli/src/lib/udt.ts
+++ b/packages/cli/src/lib/udt.ts
@@ -10,12 +10,16 @@ export interface UdtResolution {
 export interface UdtResolutionOptions {
   rawScript?: string;
   name?: string;
+  scriptOptionName?: string;
   rpc: { nodeInfo(): Promise<{ udt_cfg_infos: UdtCfgInfos }> };
 }
 
 export async function resolveUdtTypeScript(options: UdtResolutionOptions): Promise<UdtResolution> {
   if (options.rawScript !== undefined) {
-    const script = parseUdtTypeScript(options.rawScript, '--udt-type-script');
+    const script = parseUdtTypeScript(
+      options.rawScript,
+      options.scriptOptionName ?? '--udt-type-script',
+    );
     if (script === undefined) {
       return { unit: 'CKB' };
     }

--- a/packages/cli/src/lib/udt.ts
+++ b/packages/cli/src/lib/udt.ts
@@ -1,8 +1,8 @@
-import type { Script, UdtCfgInfos } from '@fiber-pay/sdk';
-import { parseUdtTypeScript } from './parse-options.js';
+import type { UdtCfgInfos } from '@fiber-pay/sdk';
+import { parseUdtTypeScript, type UdtTypeScript } from './parse-options.js';
 
 export interface UdtResolution {
-  script?: Script;
+  script?: UdtTypeScript;
   unit: 'CKB' | 'UDT';
   name?: string;
 }

--- a/packages/cli/src/lib/udt.ts
+++ b/packages/cli/src/lib/udt.ts
@@ -1,0 +1,35 @@
+import type { Script, UdtCfgInfos } from '@fiber-pay/sdk';
+import { parseUdtTypeScript } from './parse-options.js';
+
+export interface UdtResolution {
+  script?: Script;
+  unit: 'CKB' | 'UDT';
+  name?: string;
+}
+
+export interface UdtResolutionOptions {
+  rawScript?: string;
+  name?: string;
+  rpc: { nodeInfo(): Promise<{ udt_cfg_infos: UdtCfgInfos }> };
+}
+
+export async function resolveUdtTypeScript(options: UdtResolutionOptions): Promise<UdtResolution> {
+  if (options.rawScript !== undefined) {
+    const script = parseUdtTypeScript(options.rawScript, '--udt-type-script');
+    if (script === undefined) {
+      return { unit: 'CKB' };
+    }
+    return { script, unit: 'UDT' };
+  }
+
+  if (options.name !== undefined) {
+    const info = await options.rpc.nodeInfo();
+    const match = info.udt_cfg_infos.find((entry) => entry.name === options.name);
+    if (!match) {
+      throw new Error(`UDT name not found in node config: ${options.name}`);
+    }
+    return { script: match.script, unit: 'UDT', name: match.name };
+  }
+
+  return { unit: 'CKB' };
+}

--- a/packages/cli/tests/channel-udt.test.ts
+++ b/packages/cli/tests/channel-udt.test.ts
@@ -137,7 +137,7 @@ describe('channel open UDT resolution', () => {
 
     const json = JSON.parse(output.join('\n'));
     expect(json.success).toBe(true);
-    expect(json.data.fundingLabel).toBe('UDT');
+    expect(json.data.fundingLabel).toBe('RUSD');
     expect(json.data.fundingUdtTypeScript).toEqual({
       code_hash: '0x1234',
       hash_type: 'type',
@@ -180,7 +180,7 @@ describe('channel open UDT resolution', () => {
     restore();
 
     const joined = output.join('\n');
-    expect(joined).toContain('Funding:              1000 UDT');
+    expect(joined).toContain('Funding:              1000 RUSD');
     expect(joined).toContain('UDT Type Script:');
     expect(joined).toContain('"code_hash":"0x1234"');
     expect(joined).toContain('"hash_type":"type"');

--- a/packages/cli/tests/channel-udt.test.ts
+++ b/packages/cli/tests/channel-udt.test.ts
@@ -1,0 +1,106 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createChannelCommand } from '../src/commands/channel.js';
+
+const openChannel = vi.fn().mockResolvedValue({ temporary_channel_id: '0x1234' });
+const nodeInfo = vi.fn().mockResolvedValue({
+  udt_cfg_infos: [
+    {
+      name: 'RUSD',
+      script: { code_hash: '0x1234', hash_type: 'type', args: '0x5678' },
+      cell_deps: [],
+    },
+  ],
+});
+
+vi.mock('../src/lib/rpc.js', () => ({
+  createReadyRpcClient: vi.fn().mockImplementation(() =>
+    Promise.resolve({
+      nodeInfo,
+      openChannel,
+    }),
+  ),
+  resolveRpcEndpoint: vi.fn().mockReturnValue({ target: 'node-rpc', url: 'http://localhost' }),
+}));
+
+function makeConfig() {
+  return {
+    dataDir: '/tmp/fiber-pay-test',
+    configPath: '/tmp/fiber-pay-test/config.yml',
+    network: 'testnet' as const,
+    rpcUrl: 'http://127.0.0.1:8227',
+  };
+}
+
+describe('channel open UDT resolution', () => {
+  beforeEach(() => {
+    openChannel.mockClear();
+    nodeInfo.mockClear();
+  });
+
+  it('resolves a UDT by name and includes funding_udt_type_script in openChannel params', async () => {
+    const channel = createChannelCommand(makeConfig());
+    await channel.parseAsync([
+      'node',
+      'script',
+      'open',
+      '--peer',
+      '0xabcd',
+      '--funding',
+      '1000',
+      '--funding-udt-name',
+      'RUSD',
+      '--json',
+    ]);
+
+    expect(nodeInfo).toHaveBeenCalledTimes(1);
+    expect(openChannel).toHaveBeenCalledWith(
+      expect.objectContaining({
+        pubkey: '0xabcd',
+        funding_amount: '0x3e8',
+        funding_udt_type_script: { code_hash: '0x1234', hash_type: 'type', args: '0x5678' },
+      }),
+    );
+  });
+
+  it('still accepts a raw funding-udt-type-script and includes it in openChannel params', async () => {
+    const channel = createChannelCommand(makeConfig());
+    await channel.parseAsync([
+      'node',
+      'script',
+      'open',
+      '--peer',
+      '0xabcd',
+      '--funding',
+      '500',
+      '--funding-udt-type-script',
+      '{"code_hash":"0xabcd","hash_type":"data","args":"0x"}',
+      '--json',
+    ]);
+
+    expect(nodeInfo).not.toHaveBeenCalled();
+    expect(openChannel).toHaveBeenCalledWith(
+      expect.objectContaining({
+        funding_udt_type_script: { code_hash: '0xabcd', hash_type: 'data', args: '0x' },
+      }),
+    );
+  });
+
+  it('opens a CKB channel when no UDT option is provided', async () => {
+    const channel = createChannelCommand(makeConfig());
+    await channel.parseAsync([
+      'node',
+      'script',
+      'open',
+      '--peer',
+      '0xabcd',
+      '--funding',
+      '1.5',
+      '--json',
+    ]);
+
+    expect(nodeInfo).not.toHaveBeenCalled();
+    const [params] = openChannel.mock.calls[0];
+    expect(params).toHaveProperty('funding_amount', '0x8f0d180');
+    expect(params).not.toHaveProperty('funding_udt_type_script');
+  });
+});

--- a/packages/cli/tests/channel-udt.test.ts
+++ b/packages/cli/tests/channel-udt.test.ts
@@ -31,6 +31,20 @@ function makeConfig() {
   };
 }
 
+function captureLogs(): { output: string[]; restore: () => void } {
+  const originalLog = console.log;
+  const output: string[] = [];
+  console.log = (...args: unknown[]) => {
+    output.push(args.map(String).join(' '));
+  };
+  return {
+    output,
+    restore: () => {
+      console.log = originalLog;
+    },
+  };
+}
+
 describe('channel open UDT resolution', () => {
   beforeEach(() => {
     openChannel.mockClear();
@@ -102,5 +116,74 @@ describe('channel open UDT resolution', () => {
     const [params] = openChannel.mock.calls[0];
     expect(params).toHaveProperty('funding_amount', '0x8f0d180');
     expect(params).not.toHaveProperty('funding_udt_type_script');
+  });
+
+  it('JSON output includes fundingLabel UDT and resolved fundingUdtTypeScript', async () => {
+    const { output, restore } = captureLogs();
+    const channel = createChannelCommand(makeConfig());
+    await channel.parseAsync([
+      'node',
+      'script',
+      'open',
+      '--peer',
+      '0xabcd',
+      '--funding',
+      '1000',
+      '--funding-udt-name',
+      'RUSD',
+      '--json',
+    ]);
+    restore();
+
+    const json = JSON.parse(output.join('\n'));
+    expect(json.success).toBe(true);
+    expect(json.data.fundingLabel).toBe('UDT');
+    expect(json.data.fundingUdtTypeScript).toEqual({
+      code_hash: '0x1234',
+      hash_type: 'type',
+      args: '0x5678',
+    });
+  });
+
+  it('human output includes fundingLabel CKB when no UDT option is provided', async () => {
+    const { output, restore } = captureLogs();
+    const channel = createChannelCommand(makeConfig());
+    await channel.parseAsync([
+      'node',
+      'script',
+      'open',
+      '--peer',
+      '0xabcd',
+      '--funding',
+      '1.5',
+    ]);
+    restore();
+
+    const joined = output.join('\n');
+    expect(joined).toContain('Funding:              150000000 CKB');
+  });
+
+  it('human output includes fundingLabel UDT and resolved UDT type script', async () => {
+    const { output, restore } = captureLogs();
+    const channel = createChannelCommand(makeConfig());
+    await channel.parseAsync([
+      'node',
+      'script',
+      'open',
+      '--peer',
+      '0xabcd',
+      '--funding',
+      '1000',
+      '--funding-udt-name',
+      'RUSD',
+    ]);
+    restore();
+
+    const joined = output.join('\n');
+    expect(joined).toContain('Funding:              1000 UDT');
+    expect(joined).toContain('UDT Type Script:');
+    expect(joined).toContain('"code_hash":"0x1234"');
+    expect(joined).toContain('"hash_type":"type"');
+    expect(joined).toContain('"args":"0x5678"');
   });
 });

--- a/packages/cli/tests/format-udt.test.ts
+++ b/packages/cli/tests/format-udt.test.ts
@@ -1,0 +1,172 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Channel } from '@fiber-pay/sdk';
+import {
+  formatChannel,
+  getChannelSummary,
+  printChannelDetailHuman,
+  printChannelListHuman,
+} from '../src/lib/format.js';
+
+function makeChannel(overrides: Partial<Channel> = {}): Channel {
+  return {
+    channel_id: '0xchannel1',
+    pubkey: '0xpubkey1',
+    state: { state_name: 'ChannelReady', state_flags: [] },
+    local_balance: '0x5f5e100',
+    remote_balance: '0x2faf080',
+    funding_udt_type_script: null,
+    pending_tlcs: [],
+    enabled: true,
+    is_public: true,
+    created_at: '0x0',
+    channel_outpoint: { tx_hash: '0xtx1', index: '0x0' },
+    ...overrides,
+  } as Channel;
+}
+
+function captureLogs(): { output: string[]; restore: () => void } {
+  const originalLog = console.log;
+  const output: string[] = [];
+  console.log = (...args: unknown[]) => {
+    output.push(args.map(String).join(' '));
+  };
+  return {
+    output,
+    restore: () => {
+      console.log = originalLog;
+    },
+  };
+}
+
+describe('UDT-aware channel formatting', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('formatChannel labels CKB channels with unit CKB', () => {
+    const formatted = formatChannel(makeChannel());
+    expect(formatted.unit).toBe('CKB');
+    expect(formatted.fundingUdtTypeScript).toBeUndefined();
+    expect(formatted.localBalanceCkb).toBe(1);
+    expect(formatted.localBalance).toBe(1);
+  });
+
+  it('formatChannel labels UDT channels with unit UDT and raw balances', () => {
+    const formatted = formatChannel(
+      makeChannel({
+        local_balance: '0x3e8',
+        remote_balance: '0x1f4',
+        funding_udt_type_script: {
+          code_hash: '0x1234',
+          hash_type: 'type',
+          args: '0x5678',
+        },
+      }),
+    );
+
+    expect(formatted.unit).toBe('UDT');
+    expect(formatted.localBalance).toBe('1000');
+    expect(formatted.remoteBalance).toBe('500');
+    expect(formatted.capacity).toBe('1500');
+    expect(formatted.localBalanceCkb).toBeUndefined();
+    expect(formatted.fundingUdtTypeScript).toEqual({
+      code_hash: '0x1234',
+      hash_type: 'type',
+      args: '0x5678',
+    });
+  });
+
+  it('getChannelSummary aggregates CKB and UDT totals separately', () => {
+    const summary = getChannelSummary([
+      makeChannel({
+        channel_id: '0xckb',
+        local_balance: '0x5f5e100',
+        remote_balance: '0x2faf080',
+      }),
+      makeChannel({
+        channel_id: '0xudt1',
+        local_balance: '0x3e8',
+        remote_balance: '0x1f4',
+        funding_udt_type_script: {
+          code_hash: '0x1234',
+          hash_type: 'type',
+          args: '0x5678',
+        },
+      }),
+      makeChannel({
+        channel_id: '0xudt2',
+        local_balance: '0x64',
+        remote_balance: '0x32',
+        funding_udt_type_script: {
+          code_hash: '0x1234',
+          hash_type: 'type',
+          args: '0x5678',
+        },
+      }),
+    ]);
+
+    expect(summary.totalLocalCkb).toBe(1);
+    expect(summary.totalRemoteCkb).toBe(0.5);
+    expect(summary.totalCapacityCkb).toBe(1.5);
+    expect(summary.udtTotals).toHaveLength(1);
+    expect(summary.udtTotals).toEqual([
+      expect.objectContaining({
+        localBalance: '1100',
+        remoteBalance: '550',
+        capacity: '1650',
+        fundingUdtTypeScript: {
+          code_hash: '0x1234',
+          hash_type: 'type',
+          args: '0x5678',
+        },
+      }),
+    ]);
+  });
+
+  it('printChannelDetailHuman labels UDT channel balances as UDT', () => {
+    const { output, restore } = captureLogs();
+    printChannelDetailHuman(
+      makeChannel({
+        local_balance: '0x3e8',
+        remote_balance: '0x1f4',
+        funding_udt_type_script: {
+          code_hash: '0x1234',
+          hash_type: 'type',
+          args: '0x5678',
+        },
+      }),
+    );
+    restore();
+
+    const joined = output.join('\n');
+    expect(joined).toContain('local 1000 UDT | remote 500 UDT | capacity 1500 UDT');
+    expect(joined).toContain('UDT Type Script:');
+  });
+
+  it('printChannelListHuman labels UDT rows with UDT unit', () => {
+    const { output, restore } = captureLogs();
+    printChannelListHuman([
+      makeChannel({
+        channel_id: '0xckb',
+        local_balance: '0x5f5e100',
+        remote_balance: '0x2faf080',
+      }),
+      makeChannel({
+        channel_id: '0xudt',
+        local_balance: '0x3e8',
+        remote_balance: '0x1f4',
+        funding_udt_type_script: {
+          code_hash: '0x1234',
+          hash_type: 'type',
+          args: '0x5678',
+        },
+      }),
+    ]);
+    restore();
+
+    const joined = output.join('\n');
+    expect(joined).toContain('UDT');
+    expect(joined).toContain('1000');
+    expect(joined).toContain('500');
+  });
+});

--- a/packages/cli/tests/invoice-udt.test.ts
+++ b/packages/cli/tests/invoice-udt.test.ts
@@ -167,7 +167,7 @@ describe('invoice create UDT', () => {
 
     const json = JSON.parse(output.join('\n'));
     expect(json.success).toBe(true);
-    expect(json.data.unit).toBe('UDT');
+    expect(json.data.unit).toBe('RUSD');
     expect(json.data.amount).toBe('1000');
     expect(json.data.udtTypeScript).toEqual({
       code_hash: '0x1234',
@@ -203,7 +203,7 @@ describe('invoice create UDT', () => {
     restore();
 
     const joined = output.join('\n');
-    expect(joined).toContain('Amount:       1000 UDT');
+    expect(joined).toContain('Amount:       1000 RUSD');
     expect(joined).toContain('UDT Type Script:');
     expect(joined).toContain('"code_hash":"0x1234"');
     expect(joined).toContain('"hash_type":"type"');

--- a/packages/cli/tests/invoice-udt.test.ts
+++ b/packages/cli/tests/invoice-udt.test.ts
@@ -1,0 +1,212 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createInvoiceCommand } from '../src/commands/invoice.js';
+import type { CliConfig } from '../src/lib/config.js';
+
+const newInvoice = vi.fn().mockResolvedValue({
+  invoice_address: 'fibt1...',
+  invoice: { data: { payment_hash: '0xabc' } },
+});
+
+const nodeInfo = vi.fn().mockResolvedValue({
+  udt_cfg_infos: [
+    {
+      name: 'RUSD',
+      script: { code_hash: '0x1234', hash_type: 'type', args: '0x5678' },
+      cell_deps: [],
+    },
+  ],
+});
+
+vi.mock('../src/lib/rpc.js', () => ({
+  createReadyRpcClient: vi.fn().mockImplementation(() =>
+    Promise.resolve({
+      nodeInfo,
+      newInvoice,
+    }),
+  ),
+  resolveRpcEndpoint: vi.fn().mockReturnValue({ target: 'node-rpc', url: 'http://localhost' }),
+}));
+
+function makeConfig(): CliConfig {
+  return {
+    dataDir: '/tmp/fiber-pay-test',
+    configPath: '/tmp/fiber-pay-test/config.yml',
+    network: 'testnet' as const,
+    rpcUrl: 'http://127.0.0.1:8227',
+  };
+}
+
+function captureLogs(): { output: string[]; restore: () => void } {
+  const originalLog = console.log;
+  const output: string[] = [];
+  console.log = (...args: unknown[]) => {
+    output.push(args.map(String).join(' '));
+  };
+  return {
+    output,
+    restore: () => {
+      console.log = originalLog;
+    },
+  };
+}
+
+describe('invoice create UDT', () => {
+  beforeEach(() => {
+    newInvoice.mockClear();
+    nodeInfo.mockClear();
+  });
+
+  it('creates a UDT invoice by name and sets udt_type_script', async () => {
+    const invoice = createInvoiceCommand(makeConfig());
+
+    await invoice.parseAsync([
+      'node',
+      'test',
+      'create',
+      '--amount',
+      '1000',
+      '--udt-name',
+      'RUSD',
+      '--json',
+    ]);
+
+    expect(nodeInfo).toHaveBeenCalledTimes(1);
+    expect(newInvoice).toHaveBeenCalledWith(
+      expect.objectContaining({
+        amount: '0x3e8',
+        udt_type_script: { code_hash: '0x1234', hash_type: 'type', args: '0x5678' },
+      }),
+    );
+  });
+
+  it('accepts a raw udt-type-script and includes it in newInvoice params', async () => {
+    const invoice = createInvoiceCommand(makeConfig());
+
+    await invoice.parseAsync([
+      'node',
+      'test',
+      'create',
+      '--amount',
+      '500',
+      '--udt-type-script',
+      '{"code_hash":"0xabcd","hash_type":"data","args":"0x"}',
+      '--json',
+    ]);
+
+    expect(nodeInfo).not.toHaveBeenCalled();
+    expect(newInvoice).toHaveBeenCalledWith(
+      expect.objectContaining({
+        amount: '0x1f4',
+        udt_type_script: { code_hash: '0xabcd', hash_type: 'data', args: '0x' },
+      }),
+    );
+  });
+
+  it('interprets amount as CKB when no UDT option is provided', async () => {
+    const invoice = createInvoiceCommand(makeConfig());
+
+    await invoice.parseAsync([
+      'node',
+      'test',
+      'create',
+      '--amount',
+      '1.5',
+      '--json',
+    ]);
+
+    expect(nodeInfo).not.toHaveBeenCalled();
+    const [params] = newInvoice.mock.calls[0];
+    expect(params).toHaveProperty('amount', '0x8f0d180');
+    expect(params).not.toHaveProperty('udt_type_script');
+  });
+
+  it('rejects a decimal UDT amount', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((code) => {
+      throw new Error(`process.exit(${code})`);
+    });
+    const { output, restore } = captureLogs();
+    const invoice = createInvoiceCommand(makeConfig());
+
+    await expect(
+      invoice.parseAsync([
+        'node',
+        'test',
+        'create',
+        '--amount',
+        '1.5',
+        '--udt-name',
+        'RUSD',
+        '--json',
+      ]),
+    ).rejects.toThrow('process.exit(1)');
+
+    restore();
+    exitSpy.mockRestore();
+
+    const json = JSON.parse(output.join('\n'));
+    expect(json.success).toBe(false);
+    expect(json.error.message).toContain('Invalid UDT amount');
+    expect(newInvoice).not.toHaveBeenCalled();
+  });
+
+  it('JSON output includes unit UDT, amount, and resolved udtTypeScript', async () => {
+    const { output, restore } = captureLogs();
+    const invoice = createInvoiceCommand(makeConfig());
+
+    await invoice.parseAsync([
+      'node',
+      'test',
+      'create',
+      '--amount',
+      '1000',
+      '--udt-name',
+      'RUSD',
+      '--json',
+    ]);
+    restore();
+
+    const json = JSON.parse(output.join('\n'));
+    expect(json.success).toBe(true);
+    expect(json.data.unit).toBe('UDT');
+    expect(json.data.amount).toBe('1000');
+    expect(json.data.udtTypeScript).toEqual({
+      code_hash: '0x1234',
+      hash_type: 'type',
+      args: '0x5678',
+    });
+  });
+
+  it('human output labels amount as CKB when no UDT option is provided', async () => {
+    const { output, restore } = captureLogs();
+    const invoice = createInvoiceCommand(makeConfig());
+
+    await invoice.parseAsync(['node', 'test', 'create', '--amount', '1.5']);
+    restore();
+
+    const joined = output.join('\n');
+    expect(joined).toContain('Amount:       1.5 CKB');
+  });
+
+  it('human output labels amount as UDT and prints resolved UDT type script', async () => {
+    const { output, restore } = captureLogs();
+    const invoice = createInvoiceCommand(makeConfig());
+
+    await invoice.parseAsync([
+      'node',
+      'test',
+      'create',
+      '--amount',
+      '1000',
+      '--udt-name',
+      'RUSD',
+    ]);
+    restore();
+
+    const joined = output.join('\n');
+    expect(joined).toContain('Amount:       1000 UDT');
+    expect(joined).toContain('UDT Type Script:');
+    expect(joined).toContain('"code_hash":"0x1234"');
+    expect(joined).toContain('"hash_type":"type"');
+    expect(joined).toContain('"args":"0x5678"');
+  });
+});

--- a/packages/cli/tests/parse-options.test.ts
+++ b/packages/cli/tests/parse-options.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { parseFundingAmount, parseUdtTypeScript } from '../src/lib/parse-options.js';
+import {
+  parseFundingAmount,
+  parsePaymentAmount,
+  parseUdtTypeScript,
+} from '../src/lib/parse-options.js';
 
 describe('parseUdtTypeScript', () => {
   it('returns undefined when value is undefined', () => {
@@ -136,5 +140,30 @@ describe('parseFundingAmount', () => {
     expect(() => parseFundingAmount('1.2.3', false)).toThrow('CKB funding amount');
     expect(() => parseFundingAmount('1e2', false)).toThrow('CKB funding amount');
     expect(() => parseFundingAmount('0.123456789', false)).toThrow('CKB funding amount');
+  });
+});
+
+describe('parsePaymentAmount', () => {
+  it('converts CKB amount to shannons', () => {
+    expect(parsePaymentAmount('1.5', false)).toBe(150_000_000n);
+    expect(parsePaymentAmount('100', false)).toBe(10_000_000_000n);
+  });
+
+  it('parses UDT amount as raw integer', () => {
+    expect(parsePaymentAmount('1000', true)).toBe(1000n);
+    expect(parsePaymentAmount('12345678901234567890', true)).toBe(12345678901234567890n);
+  });
+
+  it('throws on non-positive UDT amount', () => {
+    expect(() => parsePaymentAmount('0', true)).toThrow('greater than 0');
+    expect(() => parsePaymentAmount('-1', true)).toThrow('Invalid UDT amount');
+  });
+
+  it('throws on decimal UDT amount', () => {
+    expect(() => parsePaymentAmount('1.5', true)).toThrow('Invalid UDT amount');
+  });
+
+  it('throws on non-numeric CKB amount', () => {
+    expect(() => parsePaymentAmount('abc', false)).toThrow();
   });
 });

--- a/packages/cli/tests/parse-options.test.ts
+++ b/packages/cli/tests/parse-options.test.ts
@@ -163,7 +163,22 @@ describe('parsePaymentAmount', () => {
     expect(() => parsePaymentAmount('1.5', true)).toThrow('Invalid UDT amount');
   });
 
-  it('throws on non-numeric CKB amount', () => {
-    expect(() => parsePaymentAmount('abc', false)).toThrow();
+  it('throws on non-positive CKB amount', () => {
+    expect(() => parsePaymentAmount('0', false)).toThrow('greater than 0');
+    expect(() => parsePaymentAmount('-1', false)).toThrow('Invalid CKB amount');
+  });
+
+  it('rejects malformed or over-precise CKB amounts', () => {
+    expect(() => parsePaymentAmount('', false)).toThrow('Invalid CKB amount');
+    expect(() => parsePaymentAmount('   ', false)).toThrow('Invalid CKB amount');
+    expect(() => parsePaymentAmount(' 1.5', false)).toThrow('Invalid CKB amount');
+    expect(() => parsePaymentAmount('1.5 ', false)).toThrow('Invalid CKB amount');
+    expect(() => parsePaymentAmount('1.2.3', false)).toThrow('Invalid CKB amount');
+    expect(() => parsePaymentAmount('1e2', false)).toThrow('Invalid CKB amount');
+    expect(() => parsePaymentAmount('0.000000007', false)).toThrow('Invalid CKB amount');
+  });
+
+  it('parses tiny CKB amounts exactly without floating-point error', () => {
+    expect(parsePaymentAmount('0.00000007', false)).toBe(7n);
   });
 });

--- a/packages/cli/tests/payment-route-udt.test.ts
+++ b/packages/cli/tests/payment-route-udt.test.ts
@@ -13,6 +13,13 @@ const buildRouter = vi.fn().mockResolvedValue({
   ],
 });
 
+const sendPaymentWithRouter = vi.fn().mockResolvedValue({
+  payment_hash: '0xdeadbeef',
+  status: 'Success',
+  fee: '0x0',
+  failed_error: undefined,
+});
+
 const nodeInfo = vi.fn().mockResolvedValue({
   udt_cfg_infos: [
     {
@@ -28,6 +35,7 @@ vi.mock('../src/lib/rpc.js', () => ({
     Promise.resolve({
       nodeInfo,
       buildRouter,
+      sendPaymentWithRouter,
     }),
   ),
   resolveRpcEndpoint: vi.fn().mockReturnValue({ target: 'node-rpc', url: 'http://localhost' }),
@@ -59,6 +67,7 @@ function captureLogs(): { output: string[]; restore: () => void } {
 describe('payment route UDT', () => {
   beforeEach(() => {
     buildRouter.mockClear();
+    sendPaymentWithRouter.mockClear();
     nodeInfo.mockClear();
   });
 
@@ -194,5 +203,95 @@ describe('payment route UDT', () => {
 
     const joined = output.join('\n');
     expect(joined).toContain('Amount:     1000 UDT');
+  });
+
+  it('send-route resolves a UDT by name and forwards udt_type_script', async () => {
+    const payment = createPaymentCommand(makeConfig());
+    await payment.parseAsync([
+      'node',
+      'script',
+      'send-route',
+      '--router',
+      JSON.stringify([
+        {
+          target: '0xaaa',
+          channel_outpoint: { tx_hash: '0xtx1', index: '0x0' },
+          amount_received: '0x3e8',
+          incoming_tlc_expiry: '0x123',
+        },
+      ]),
+      '--udt-name',
+      'RUSD',
+      '--json',
+    ]);
+
+    expect(nodeInfo).toHaveBeenCalledTimes(1);
+    expect(sendPaymentWithRouter).toHaveBeenCalledWith(
+      expect.objectContaining({
+        udt_type_script: { code_hash: '0x1234', hash_type: 'type', args: '0x5678' },
+      }),
+    );
+  });
+
+  it('send-route accepts a raw udt-type-script', async () => {
+    const payment = createPaymentCommand(makeConfig());
+    await payment.parseAsync([
+      'node',
+      'script',
+      'send-route',
+      '--router',
+      JSON.stringify([{ target: '0xaaa', channel_outpoint: { tx_hash: '0xtx1', index: '0x0' } }]),
+      '--udt-type-script',
+      '{"code_hash":"0xabcd","hash_type":"data","args":"0x"}',
+      '--json',
+    ]);
+
+    expect(nodeInfo).not.toHaveBeenCalled();
+    expect(sendPaymentWithRouter).toHaveBeenCalledWith(
+      expect.objectContaining({
+        udt_type_script: { code_hash: '0xabcd', hash_type: 'data', args: '0x' },
+      }),
+    );
+  });
+
+  it('send-route JSON output includes unit and udtTypeScript', async () => {
+    const { output, restore } = captureLogs();
+    const payment = createPaymentCommand(makeConfig());
+    await payment.parseAsync([
+      'node',
+      'script',
+      'send-route',
+      '--router',
+      JSON.stringify([{ target: '0xaaa', channel_outpoint: { tx_hash: '0xtx1', index: '0x0' } }]),
+      '--udt-name',
+      'RUSD',
+      '--json',
+    ]);
+    restore();
+
+    const json = JSON.parse(output.join('\n'));
+    expect(json.success).toBe(true);
+    expect(json.data.unit).toBe('UDT');
+    expect(json.data.udtTypeScript).toEqual({
+      code_hash: '0x1234',
+      hash_type: 'type',
+      args: '0x5678',
+    });
+  });
+
+  it('send-route omits udt_type_script when no UDT option is provided', async () => {
+    const payment = createPaymentCommand(makeConfig());
+    await payment.parseAsync([
+      'node',
+      'script',
+      'send-route',
+      '--router',
+      JSON.stringify([{ target: '0xaaa', channel_outpoint: { tx_hash: '0xtx1', index: '0x0' } }]),
+      '--json',
+    ]);
+
+    expect(nodeInfo).not.toHaveBeenCalled();
+    const [params] = sendPaymentWithRouter.mock.calls[0];
+    expect(params).not.toHaveProperty('udt_type_script');
   });
 });

--- a/packages/cli/tests/payment-route-udt.test.ts
+++ b/packages/cli/tests/payment-route-udt.test.ts
@@ -1,0 +1,198 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createPaymentCommand } from '../src/commands/payment.js';
+import type { CliConfig } from '../src/lib/config.js';
+
+const buildRouter = vi.fn().mockResolvedValue({
+  router_hops: [
+    {
+      target: '0xaaa',
+      channel_outpoint: { tx_hash: '0xtx1', index: '0x0' },
+      amount_received: '0x3e8',
+      incoming_tlc_expiry: '0x123',
+    },
+  ],
+});
+
+const nodeInfo = vi.fn().mockResolvedValue({
+  udt_cfg_infos: [
+    {
+      name: 'RUSD',
+      script: { code_hash: '0x1234', hash_type: 'type', args: '0x5678' },
+      cell_deps: [],
+    },
+  ],
+});
+
+vi.mock('../src/lib/rpc.js', () => ({
+  createReadyRpcClient: vi.fn().mockImplementation(() =>
+    Promise.resolve({
+      nodeInfo,
+      buildRouter,
+    }),
+  ),
+  resolveRpcEndpoint: vi.fn().mockReturnValue({ target: 'node-rpc', url: 'http://localhost' }),
+}));
+
+function makeConfig(): CliConfig {
+  return {
+    dataDir: '/tmp/fiber-pay-test',
+    configPath: '/tmp/fiber-pay-test/config.yml',
+    network: 'testnet' as const,
+    rpcUrl: 'http://127.0.0.1:8227',
+  };
+}
+
+function captureLogs(): { output: string[]; restore: () => void } {
+  const originalLog = console.log;
+  const output: string[] = [];
+  console.log = (...args: unknown[]) => {
+    output.push(args.map(String).join(' '));
+  };
+  return {
+    output,
+    restore: () => {
+      console.log = originalLog;
+    },
+  };
+}
+
+describe('payment route UDT', () => {
+  beforeEach(() => {
+    buildRouter.mockClear();
+    nodeInfo.mockClear();
+  });
+
+  it('resolves a UDT by name and forwards udt_type_script to buildRouter', async () => {
+    const payment = createPaymentCommand(makeConfig());
+    await payment.parseAsync([
+      'node',
+      'script',
+      'route',
+      '--hops',
+      '0xaaa',
+      '--amount',
+      '1000',
+      '--udt-name',
+      'RUSD',
+      '--json',
+    ]);
+
+    expect(nodeInfo).toHaveBeenCalledTimes(1);
+    expect(buildRouter).toHaveBeenCalledWith(
+      expect.objectContaining({
+        hops_info: [{ pubkey: '0xaaa' }],
+        amount: '0x3e8',
+        udt_type_script: { code_hash: '0x1234', hash_type: 'type', args: '0x5678' },
+      }),
+    );
+  });
+
+  it('accepts a raw udt-type-script and forwards it to buildRouter', async () => {
+    const payment = createPaymentCommand(makeConfig());
+    await payment.parseAsync([
+      'node',
+      'script',
+      'route',
+      '--hops',
+      '0xaaa',
+      '--amount',
+      '500',
+      '--udt-type-script',
+      '{"code_hash":"0xabcd","hash_type":"data","args":"0x"}',
+      '--json',
+    ]);
+
+    expect(nodeInfo).not.toHaveBeenCalled();
+    expect(buildRouter).toHaveBeenCalledWith(
+      expect.objectContaining({
+        udt_type_script: { code_hash: '0xabcd', hash_type: 'data', args: '0x' },
+      }),
+    );
+  });
+
+  it('parses UDT amount as a raw integer', async () => {
+    const payment = createPaymentCommand(makeConfig());
+    await payment.parseAsync([
+      'node',
+      'script',
+      'route',
+      '--hops',
+      '0xaaa',
+      '--amount',
+      '999',
+      '--udt-name',
+      'RUSD',
+      '--json',
+    ]);
+
+    const [params] = buildRouter.mock.calls[0];
+    expect(params).toHaveProperty('amount', '0x3e7');
+  });
+
+  it('interprets amount as CKB when no UDT option is provided', async () => {
+    const payment = createPaymentCommand(makeConfig());
+    await payment.parseAsync([
+      'node',
+      'script',
+      'route',
+      '--hops',
+      '0xaaa',
+      '--amount',
+      '1.5',
+      '--json',
+    ]);
+
+    expect(nodeInfo).not.toHaveBeenCalled();
+    const [params] = buildRouter.mock.calls[0];
+    expect(params).toHaveProperty('amount', '0x8f0d180');
+    expect(params).not.toHaveProperty('udt_type_script');
+  });
+
+  it('JSON output includes unit UDT and resolved udtTypeScript', async () => {
+    const { output, restore } = captureLogs();
+    const payment = createPaymentCommand(makeConfig());
+    await payment.parseAsync([
+      'node',
+      'script',
+      'route',
+      '--hops',
+      '0xaaa',
+      '--amount',
+      '1000',
+      '--udt-name',
+      'RUSD',
+      '--json',
+    ]);
+    restore();
+
+    const json = JSON.parse(output.join('\n'));
+    expect(json.success).toBe(true);
+    expect(json.data.unit).toBe('UDT');
+    expect(json.data.udtTypeScript).toEqual({
+      code_hash: '0x1234',
+      hash_type: 'type',
+      args: '0x5678',
+    });
+    expect(json.data.routerHops).toHaveLength(1);
+  });
+
+  it('human output labels hop amounts with UDT', async () => {
+    const { output, restore } = captureLogs();
+    const payment = createPaymentCommand(makeConfig());
+    await payment.parseAsync([
+      'node',
+      'script',
+      'route',
+      '--hops',
+      '0xaaa',
+      '--amount',
+      '1000',
+      '--udt-name',
+      'RUSD',
+    ]);
+    restore();
+
+    const joined = output.join('\n');
+    expect(joined).toContain('Amount:     1000 UDT');
+  });
+});

--- a/packages/cli/tests/payment-udt.test.ts
+++ b/packages/cli/tests/payment-udt.test.ts
@@ -1,0 +1,219 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createPaymentCommand } from '../src/commands/payment.js';
+
+const sendPayment = vi.fn().mockResolvedValue({
+  payment_hash: '0xdeadbeef',
+  status: 'Success',
+  fee: '0x0',
+  failed_error: undefined,
+});
+const nodeInfo = vi.fn().mockResolvedValue({
+  udt_cfg_infos: [
+    {
+      name: 'RUSD',
+      script: { code_hash: '0x1234', hash_type: 'type', args: '0x5678' },
+      cell_deps: [],
+    },
+  ],
+});
+
+vi.mock('../src/lib/rpc.js', () => ({
+  createReadyRpcClient: vi.fn().mockImplementation(() =>
+    Promise.resolve({
+      nodeInfo,
+      sendPayment,
+    }),
+  ),
+  resolveRpcEndpoint: vi.fn().mockReturnValue({ target: 'node-rpc', url: 'http://localhost' }),
+}));
+
+function makeConfig() {
+  return {
+    dataDir: '/tmp/fiber-pay-test',
+    configPath: '/tmp/fiber-pay-test/config.yml',
+    network: 'testnet' as const,
+    rpcUrl: 'http://127.0.0.1:8227',
+  };
+}
+
+function captureLogs(): { output: string[]; restore: () => void } {
+  const originalLog = console.log;
+  const output: string[] = [];
+  console.log = (...args: unknown[]) => {
+    output.push(args.map(String).join(' '));
+  };
+  return {
+    output,
+    restore: () => {
+      console.log = originalLog;
+    },
+  };
+}
+
+describe('payment send UDT resolution', () => {
+  beforeEach(() => {
+    sendPayment.mockClear();
+    nodeInfo.mockClear();
+  });
+
+  it('resolves a UDT by name and includes udt_type_script in sendPayment params', async () => {
+    const payment = createPaymentCommand(makeConfig());
+    await payment.parseAsync([
+      'node',
+      'script',
+      'send',
+      '--to',
+      '0xabcd',
+      '--amount',
+      '1000',
+      '--udt-name',
+      'RUSD',
+      '--json',
+    ]);
+
+    expect(nodeInfo).toHaveBeenCalledTimes(1);
+    expect(sendPayment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        target_pubkey: '0xabcd',
+        amount: '0x3e8',
+        keysend: true,
+        udt_type_script: { code_hash: '0x1234', hash_type: 'type', args: '0x5678' },
+      }),
+    );
+  });
+
+  it('still accepts a raw udt-type-script and includes it in sendPayment params', async () => {
+    const payment = createPaymentCommand(makeConfig());
+    await payment.parseAsync([
+      'node',
+      'script',
+      'send',
+      '--to',
+      '0xabcd',
+      '--amount',
+      '500',
+      '--udt-type-script',
+      '{"code_hash":"0xabcd","hash_type":"data","args":"0x"}',
+      '--json',
+    ]);
+
+    expect(nodeInfo).not.toHaveBeenCalled();
+    expect(sendPayment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        udt_type_script: { code_hash: '0xabcd', hash_type: 'data', args: '0x' },
+      }),
+    );
+  });
+
+  it('interprets amount as CKB when no UDT option is provided', async () => {
+    const payment = createPaymentCommand(makeConfig());
+    await payment.parseAsync([
+      'node',
+      'script',
+      'send',
+      '--to',
+      '0xabcd',
+      '--amount',
+      '1.5',
+      '--json',
+    ]);
+
+    expect(nodeInfo).not.toHaveBeenCalled();
+    const [params] = sendPayment.mock.calls[0];
+    expect(params).toHaveProperty('amount', '0x8f0d180');
+    expect(params).not.toHaveProperty('udt_type_script');
+  });
+
+  it('leaves max fee in CKB even for UDT payments', async () => {
+    const payment = createPaymentCommand(makeConfig());
+    await payment.parseAsync([
+      'node',
+      'script',
+      'send',
+      '--to',
+      '0xabcd',
+      '--amount',
+      '1000',
+      '--udt-name',
+      'RUSD',
+      '--max-fee',
+      '0.1',
+      '--json',
+    ]);
+
+    const [params] = sendPayment.mock.calls[0];
+    expect(params).toHaveProperty('amount', '0x3e8');
+    expect(params).toHaveProperty('max_fee_amount', '0x989680');
+    expect(params).toHaveProperty('udt_type_script');
+  });
+
+  it('JSON output includes unit UDT and resolved udtTypeScript', async () => {
+    const { output, restore } = captureLogs();
+    const payment = createPaymentCommand(makeConfig());
+    await payment.parseAsync([
+      'node',
+      'script',
+      'send',
+      '--to',
+      '0xabcd',
+      '--amount',
+      '1000',
+      '--udt-name',
+      'RUSD',
+      '--json',
+    ]);
+    restore();
+
+    const json = JSON.parse(output.join('\n'));
+    expect(json.success).toBe(true);
+    expect(json.data.unit).toBe('UDT');
+    expect(json.data.amount).toBe('1000');
+    expect(json.data.udtTypeScript).toEqual({
+      code_hash: '0x1234',
+      hash_type: 'type',
+      args: '0x5678',
+    });
+  });
+
+  it('human output includes amount label CKB when no UDT option is provided', async () => {
+    const { output, restore } = captureLogs();
+    const payment = createPaymentCommand(makeConfig());
+    await payment.parseAsync([
+      'node',
+      'script',
+      'send',
+      '--to',
+      '0xabcd',
+      '--amount',
+      '1.5',
+    ]);
+    restore();
+
+    const joined = output.join('\n');
+    expect(joined).toContain('Amount: 150000000 CKB');
+  });
+
+  it('human output includes amount label UDT and resolved UDT type script', async () => {
+    const { output, restore } = captureLogs();
+    const payment = createPaymentCommand(makeConfig());
+    await payment.parseAsync([
+      'node',
+      'script',
+      'send',
+      '--to',
+      '0xabcd',
+      '--amount',
+      '1000',
+      '--udt-name',
+      'RUSD',
+    ]);
+    restore();
+
+    const joined = output.join('\n');
+    expect(joined).toContain('Amount: 1000 UDT');
+    expect(joined).toContain('UDT Type Script:');
+    expect(joined).toContain('"code_hash":"0x1234"');
+    expect(joined).toContain('"hash_type":"type"');
+    expect(joined).toContain('"args":"0x5678"');
+  });
+});

--- a/packages/cli/tests/payment-udt.test.ts
+++ b/packages/cli/tests/payment-udt.test.ts
@@ -166,7 +166,7 @@ describe('payment send UDT resolution', () => {
 
     const json = JSON.parse(output.join('\n'));
     expect(json.success).toBe(true);
-    expect(json.data.unit).toBe('UDT');
+    expect(json.data.unit).toBe('RUSD');
     expect(json.data.amount).toBe('1000');
     expect(json.data.udtTypeScript).toEqual({
       code_hash: '0x1234',
@@ -210,7 +210,7 @@ describe('payment send UDT resolution', () => {
     restore();
 
     const joined = output.join('\n');
-    expect(joined).toContain('Amount: 1000 UDT');
+    expect(joined).toContain('Amount: 1000 RUSD');
     expect(joined).toContain('UDT Type Script:');
     expect(joined).toContain('"code_hash":"0x1234"');
     expect(joined).toContain('"hash_type":"type"');

--- a/packages/cli/tests/rebalance-udt.test.ts
+++ b/packages/cli/tests/rebalance-udt.test.ts
@@ -228,7 +228,7 @@ describe('payment rebalance UDT', () => {
 
     const json = JSON.parse(output.join('\n'));
     expect(json.success).toBe(true);
-    expect(json.data.unit).toBe('UDT');
+    expect(json.data.unit).toBe('RUSD');
     expect(json.data.amount).toBe('1000');
     expect(json.data.udtTypeScript).toEqual({
       code_hash: '0x1234',

--- a/packages/cli/tests/rebalance-udt.test.ts
+++ b/packages/cli/tests/rebalance-udt.test.ts
@@ -1,0 +1,281 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Command } from 'commander';
+import {
+  registerChannelRebalanceCommand,
+  registerPaymentRebalanceCommand,
+} from '../src/commands/rebalance.js';
+import type { CliConfig } from '../src/lib/config.js';
+
+const buildRouter = vi.fn().mockResolvedValue({
+  router_hops: [
+    {
+      target: '0xpeer1',
+      channel_outpoint: { tx_hash: '0xtx1', index: '0x0' },
+      amount_received: '0x3e8',
+      incoming_tlc_expiry: '0x123',
+    },
+    {
+      target: '0xpeer2',
+      channel_outpoint: { tx_hash: '0xtx2', index: '0x0' },
+      amount_received: '0x3e8',
+      incoming_tlc_expiry: '0x123',
+    },
+  ],
+});
+
+const sendPayment = vi.fn().mockResolvedValue({
+  payment_hash: '0xdeadbeef',
+  status: 'Success',
+  fee: '0x0',
+  failed_error: undefined,
+});
+
+const sendPaymentWithRouter = vi.fn().mockResolvedValue({
+  payment_hash: '0xcafebabe',
+  status: 'Success',
+  fee: '0x0',
+  failed_error: undefined,
+});
+
+const listChannels = vi.fn().mockResolvedValue({
+  channels: [
+    {
+      channel_id: '0xch1',
+      pubkey: '0xpeer1',
+      state: { state_name: 'ChannelReady' },
+      local_balance: '0x0',
+      remote_balance: '0x0',
+      pending_tlcs: [],
+      enabled: true,
+      is_public: true,
+      created_at: '0x0',
+    },
+    {
+      channel_id: '0xch2',
+      pubkey: '0xpeer2',
+      state: { state_name: 'ChannelReady' },
+      local_balance: '0x0',
+      remote_balance: '0x0',
+      pending_tlcs: [],
+      enabled: true,
+      is_public: true,
+      created_at: '0x0',
+    },
+  ],
+});
+
+const nodeInfo = vi.fn().mockResolvedValue({
+  pubkey: '0xself',
+  udt_cfg_infos: [
+    {
+      name: 'RUSD',
+      script: { code_hash: '0x1234', hash_type: 'type', args: '0x5678' },
+      cell_deps: [],
+    },
+  ],
+});
+
+vi.mock('../src/lib/rpc.js', () => ({
+  createReadyRpcClient: vi.fn().mockImplementation(() =>
+    Promise.resolve({
+      nodeInfo,
+      buildRouter,
+      sendPayment,
+      sendPaymentWithRouter,
+      listChannels,
+    }),
+  ),
+  resolveRpcEndpoint: vi.fn().mockReturnValue({ target: 'node-rpc', url: 'http://localhost' }),
+}));
+
+function makeConfig(): CliConfig {
+  return {
+    dataDir: '/tmp/fiber-pay-test',
+    configPath: '/tmp/fiber-pay-test/config.yml',
+    network: 'testnet' as const,
+    rpcUrl: 'http://127.0.0.1:8227',
+  };
+}
+
+function captureLogs(): { output: string[]; restore: () => void } {
+  const originalLog = console.log;
+  const output: string[] = [];
+  console.log = (...args: unknown[]) => {
+    output.push(args.map(String).join(' '));
+  };
+  return {
+    output,
+    restore: () => {
+      console.log = originalLog;
+    },
+  };
+}
+
+describe('payment rebalance UDT', () => {
+  beforeEach(() => {
+    buildRouter.mockClear();
+    sendPayment.mockClear();
+    sendPaymentWithRouter.mockClear();
+    nodeInfo.mockClear();
+  });
+
+  it('auto rebalance forwards udt_type_script to sendPayment', async () => {
+    const parent = new Command('payment');
+    registerPaymentRebalanceCommand(parent, makeConfig());
+
+    await parent.parseAsync([
+      'node',
+      'script',
+      'rebalance',
+      '--amount',
+      '1000',
+      '--udt-name',
+      'RUSD',
+      '--json',
+    ]);
+
+    expect(sendPayment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        amount: '0x3e8',
+        udt_type_script: { code_hash: '0x1234', hash_type: 'type', args: '0x5678' },
+      }),
+    );
+  });
+
+  it('manual rebalance forwards udt_type_script to buildRouter and sendPaymentWithRouter', async () => {
+    const parent = new Command('payment');
+    registerPaymentRebalanceCommand(parent, makeConfig());
+
+    await parent.parseAsync([
+      'node',
+      'script',
+      'rebalance',
+      '--amount',
+      '1000',
+      '--hops',
+      '0xpeer1',
+      '--udt-name',
+      'RUSD',
+      '--json',
+    ]);
+
+    expect(buildRouter).toHaveBeenCalledWith(
+      expect.objectContaining({
+        amount: '0x3e8',
+        udt_type_script: { code_hash: '0x1234', hash_type: 'type', args: '0x5678' },
+      }),
+    );
+    expect(sendPaymentWithRouter).toHaveBeenCalledWith(
+      expect.objectContaining({
+        udt_type_script: { code_hash: '0x1234', hash_type: 'type', args: '0x5678' },
+      }),
+    );
+  });
+
+  it('parses UDT amount as a raw integer', async () => {
+    const parent = new Command('payment');
+    registerPaymentRebalanceCommand(parent, makeConfig());
+
+    await parent.parseAsync([
+      'node',
+      'script',
+      'rebalance',
+      '--amount',
+      '999',
+      '--udt-name',
+      'RUSD',
+      '--json',
+    ]);
+
+    const [params] = sendPayment.mock.calls[0];
+    expect(params).toHaveProperty('amount', '0x3e7');
+  });
+
+  it('interprets amount as CKB when no UDT option is provided', async () => {
+    const parent = new Command('payment');
+    registerPaymentRebalanceCommand(parent, makeConfig());
+
+    await parent.parseAsync([
+      'node',
+      'script',
+      'rebalance',
+      '--amount',
+      '1.5',
+      '--json',
+    ]);
+
+    const [params] = sendPayment.mock.calls[0];
+    expect(params).toHaveProperty('amount', '0x8f0d180');
+    expect(params).not.toHaveProperty('udt_type_script');
+  });
+
+  it('JSON output includes unit and udtTypeScript', async () => {
+    const { output, restore } = captureLogs();
+    const parent = new Command('payment');
+    registerPaymentRebalanceCommand(parent, makeConfig());
+
+    await parent.parseAsync([
+      'node',
+      'script',
+      'rebalance',
+      '--amount',
+      '1000',
+      '--udt-name',
+      'RUSD',
+      '--json',
+    ]);
+    restore();
+
+    const json = JSON.parse(output.join('\n'));
+    expect(json.success).toBe(true);
+    expect(json.data.unit).toBe('UDT');
+    expect(json.data.amount).toBe('1000');
+    expect(json.data.udtTypeScript).toEqual({
+      code_hash: '0x1234',
+      hash_type: 'type',
+      args: '0x5678',
+    });
+  });
+});
+
+describe('channel rebalance UDT', () => {
+  beforeEach(() => {
+    buildRouter.mockClear();
+    sendPayment.mockClear();
+    sendPaymentWithRouter.mockClear();
+    nodeInfo.mockClear();
+    listChannels.mockClear();
+  });
+
+  it('guided rebalance forwards udt_type_script through manual hops', async () => {
+    const parent = new Command('channel');
+    registerChannelRebalanceCommand(parent, makeConfig());
+
+    await parent.parseAsync([
+      'node',
+      'script',
+      'rebalance',
+      '--amount',
+      '1000',
+      '--from-channel',
+      '0xch1',
+      '--to-channel',
+      '0xch2',
+      '--udt-name',
+      'RUSD',
+      '--json',
+    ]);
+
+    expect(buildRouter).toHaveBeenCalledWith(
+      expect.objectContaining({
+        amount: '0x3e8',
+        udt_type_script: { code_hash: '0x1234', hash_type: 'type', args: '0x5678' },
+      }),
+    );
+    expect(sendPaymentWithRouter).toHaveBeenCalledWith(
+      expect.objectContaining({
+        udt_type_script: { code_hash: '0x1234', hash_type: 'type', args: '0x5678' },
+      }),
+    );
+  });
+});

--- a/packages/cli/tests/udt.test.ts
+++ b/packages/cli/tests/udt.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from 'vitest';
+import { resolveUdtTypeScript } from '../src/lib/udt.js';
+
+describe('resolveUdtTypeScript', () => {
+  const makeRpc = (names: string[]) => ({
+    nodeInfo: vi.fn().mockResolvedValue({
+      udt_cfg_infos: names.map((name) => ({
+        name,
+        script: { code_hash: '0x1234', hash_type: 'type', args: `0x${name}` },
+        cell_deps: [],
+      })),
+    }),
+  });
+
+  it('returns CKB when no UDT options are given', async () => {
+    const result = await resolveUdtTypeScript({ rpc: makeRpc([]) as any });
+    expect(result.unit).toBe('CKB');
+    expect(result.script).toBeUndefined();
+  });
+
+  it('parses a raw JSON UDT script', async () => {
+    const result = await resolveUdtTypeScript({
+      rawScript: '{"code_hash":"0xabcd","hash_type":"data","args":"0x"}',
+      rpc: makeRpc([]) as any,
+    });
+    expect(result.unit).toBe('UDT');
+    expect(result.script).toEqual({ code_hash: '0xabcd', hash_type: 'data', args: '0x' });
+  });
+
+  it('resolves a UDT by name from node info', async () => {
+    const result = await resolveUdtTypeScript({
+      name: 'RUSD',
+      rpc: makeRpc(['RUSD']) as any,
+    });
+    expect(result.unit).toBe('UDT');
+    expect(result.name).toBe('RUSD');
+    expect(result.script).toEqual({ code_hash: '0x1234', hash_type: 'type', args: '0xRUSD' });
+  });
+
+  it('throws when named UDT is not found', async () => {
+    await expect(
+      resolveUdtTypeScript({ name: 'MISSING', rpc: makeRpc(['RUSD']) as any }),
+    ).rejects.toThrow('UDT name not found');
+  });
+});

--- a/packages/cli/tests/udt.test.ts
+++ b/packages/cli/tests/udt.test.ts
@@ -37,6 +37,22 @@ describe('resolveUdtTypeScript', () => {
     expect(result.script).toEqual({ code_hash: '0x1234', hash_type: 'type', args: '0xRUSD' });
   });
 
+  it('throws with default option name when raw script is invalid JSON', async () => {
+    await expect(
+      resolveUdtTypeScript({ rawScript: 'not-json', rpc: makeRpc([]) as any }),
+    ).rejects.toThrow('Invalid --udt-type-script: must be a valid JSON object');
+  });
+
+  it('uses custom scriptOptionName in raw script validation errors', async () => {
+    await expect(
+      resolveUdtTypeScript({
+        rawScript: 'not-json',
+        scriptOptionName: '--funding-udt-type-script',
+        rpc: makeRpc([]) as any,
+      }),
+    ).rejects.toThrow('Invalid --funding-udt-type-script: must be a valid JSON object');
+  });
+
   it('throws when named UDT is not found', async () => {
     await expect(
       resolveUdtTypeScript({ name: 'MISSING', rpc: makeRpc(['RUSD']) as any }),


### PR DESCRIPTION
This PR extends UDT support across the fiber-pay CLI, building on the existing UDT channel open and payment send support.

New capabilities:
- `invoice create --udt-type-script/--udt-name`
- `payment route --udt-type-script/--udt-name`
- `payment send-route --udt-type-script/--udt-name`
- `payment rebalance --udt-type-script/--udt-name`
- `channel rebalance --udt-type-script/--udt-name`
- UDT-aware formatting for `channel list` / `channel get` / `channel watch`

Amounts are parsed as CKB-shannons for CKB and raw integers for UDT; fees remain CKB. `--udt-name` resolves against `node_info.udt_cfg_infos`.
