### PR TITLE
docs: align @fiber-pay/react description format with other packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ https://retricsu.github.io/fiber-pay/
 
 - `@fiber-pay/cli`: operations and automation for humans and agents (profiles, node/channel/payment lifecycle, runtime jobs, L402 proxy, `agent serve` / `agent call`)
 - `@fiber-pay/sdk`: application-facing typed APIs (universal + node + browser entrypoints)
-- `@fiber-pay/react` is the higher-level React layer built on top of `@fiber-pay/sdk/browser`, intended for fast browser UI integration.
+- `@fiber-pay/react`: the higher-level React layer built on top of `@fiber-pay/sdk/browser`, intended for fast browser UI integration.
 
 Package maturity note:
 


### PR DESCRIPTION
## Changes
- Changed `@fiber-pay/react` description in README.md from `is the` to `:` for consistency with `@fiber-pay/cli` and `@fiber-pay/sdk` descriptions

## Ref
[RET-140](mention://issue/ef0aff3c-b2ac-4eb4-9bfc-e3be621c5bee)

## Test
Documentation-only change, no functional impact.