### PR TITLE
docs: sync documentation with source changes since v0.2.7 (UDT + fiber version)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 AI-friendly toolchain for CKB Lightning on Fiber Network.
 
-Fiber target: `v0.9.0-rc4`
+Fiber target: `v0.9.0-rc7`
 
 https://retricsu.github.io/fiber-pay/
 

--- a/docs/develop.md
+++ b/docs/develop.md
@@ -238,7 +238,7 @@ Useful env overrides:
 
 - `SKIP_BUILD=1`
 - `SKIP_BINARY_DOWNLOAD=1`
-- `FIBER_BINARY_VERSION=v0.9.0-rc4`
+- `FIBER_BINARY_VERSION=v0.9.0-rc7`
 - `CHANNEL_FUNDING_CKB` (default `200`)
 - `INVOICE_AMOUNT_CKB` (default `1`, keep tiny for long-term reuse)
 - `MIN_FUNDING_BALANCE_CKB`

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -1,6 +1,6 @@
 # @fiber-pay/agent
 
-AI-agent orchestration layer for Fiber Network (targeting Fiber `v0.9.0-rc4`).
+AI-agent orchestration layer for Fiber Network (targeting Fiber `v0.9.0-rc7`).
 
 > Status: Experimental. This package is currently **not recommended** for production use.
 > It has not been fully validated by end-to-end tests yet, and implementation quality is still rough.
@@ -141,7 +141,7 @@ See `src/mcp-tools.ts` for complete tool names and JSON schemas.
 ## Compatibility
 
 - Node.js: `>=20`
-- Fiber RPC semantics: aligned with Fiber `v0.9.0-rc4`
+- Fiber RPC semantics: aligned with Fiber `v0.9.0-rc7`
 
 ## Known gaps
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -18,10 +18,27 @@ fiber-pay agent serve --agent codex --price 0.1
 fiber-pay agent call http://host:8402 --prompt "your question"
 ```
 
+## UDT (User-Defined Token) Support
+
+The CLI supports UDT channels, invoices, payments, and rebalances on Fiber `v0.9.0-rc7`:
+
+```bash
+# Open a UDT channel
+fiber-pay channel open --peer <addr> --funding <UDT-amount> \
+  --funding-udt-type-script '{"code_hash":"0x...","hash_type":"type","args":"0x..."}' --json
+
+# Create a UDT invoice
+fiber-pay invoice create --amount <UDT-amount> \
+  --udt-type-script '{"code_hash":"0x...","hash_type":"type","args":"0x..."}' --json
+fiber-pay invoice create --amount <UDT-amount> --udt-name <name> --json
+
+# Send payment and rebalance work across CKB and UDT channels.
+```
+
 See [docs/l402-agent-guide.md](./docs/l402-agent-guide.md) for L402 and agent details.
 
 ## Compatibility
 
 - Node.js `>=20`
-- Fiber target: `v0.9.0-rc4`
+- Fiber target: `v0.9.0-rc7`
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -24,10 +24,14 @@ The CLI supports UDT channels, invoices, payments, and rebalances on Fiber `v0.9
 
 ```bash
 # Open a UDT channel
-fiber-pay channel open --peer <addr> --funding <UDT-amount> \
+fiber-pay channel open --peer <peer> --funding <UDT-amount> \
   --funding-udt-type-script '{"code_hash":"0x...","hash_type":"type","args":"0x..."}' --json
+fiber-pay channel open --peer <peer> --funding <UDT-amount> --funding-udt-name <name> --json
 
 # Create a UDT invoice
+# Note: UDT amounts are raw integer units. If both --udt-name and --udt-type-script
+# are provided, the type script takes precedence. Verify the type script against the
+# token's official deployment before funding or accepting payment.
 fiber-pay invoice create --amount <UDT-amount> \
   --udt-type-script '{"code_hash":"0x...","hash_type":"type","args":"0x..."}' --json
 fiber-pay invoice create --amount <UDT-amount> --udt-name <name> --json

--- a/packages/cli/docs/human-quickstart.md
+++ b/packages/cli/docs/human-quickstart.md
@@ -69,6 +69,8 @@ fiber-pay invoice create --amount <CKB> --description "<desc>" --json
 
 Create a UDT invoice by configured name or type script:
 
+> **Note:** UDT amounts are raw integer units (smallest decimal precision). If both `--udt-name` and `--udt-type-script` are provided, the type script takes precedence. Verify the type script against the token issuer's official deployment before accepting payment.
+
 ```bash
 fiber-pay invoice create --amount <UDT-amount> --udt-name <name> --json
 fiber-pay invoice create --amount <UDT-amount> \

--- a/packages/cli/docs/human-quickstart.md
+++ b/packages/cli/docs/human-quickstart.md
@@ -67,6 +67,14 @@ Create an invoice (receiver side):
 fiber-pay invoice create --amount <CKB> --description "<desc>" --json
 ```
 
+Create a UDT invoice by configured name or type script:
+
+```bash
+fiber-pay invoice create --amount <UDT-amount> --udt-name <name> --json
+fiber-pay invoice create --amount <UDT-amount> \
+  --udt-type-script '{"code_hash":"0x...","hash_type":"type","args":"0x..."}' --json
+```
+
 Pay an invoice (sender side):
 
 ```bash

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -1,6 +1,6 @@
 # @fiber-pay/runtime
 
-Runtime monitor + job orchestration for Fiber (`fnn v0.9.0-rc4`).
+Runtime monitor + job orchestration for Fiber (`fnn v0.9.0-rc7`).
 
 ## Quick start
 

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -177,6 +177,9 @@ import {
 ### Common UDT Workflows
 
 **Parsing user input** — safely convert CLI/browser input into validated types:
+
+> **Note:** `validateUdtTypeScript` checks structural validity (required fields and types) only. The `code_hash` and `args` values must still be verified against the token's official deployment for authenticity.
+
 ```ts
 const script = parseUdtTypeScript(rawJson, '--udt-type-script');
 // or validate an already-parsed object:
@@ -187,6 +190,9 @@ const paymentAmount = parsePaymentAmount('500', { kind: 'udt', script });
 ```
 
 **Resolving by name** — look up configured UDTs from node info:
+
+> **Note:** `resolveUdtAsset` returns whatever the RPC node's `udt_cfg_infos` maps the name to. A compromised or misconfigured node could alias a familiar name to a counterfeit type script. Verify the returned `UdtTypeScript` against the token issuer's official deployment before signing transactions. For repeated use, cache the resolved `UdtTypeScript` to avoid redundant RPC calls.
+
 ```ts
 const asset = await resolveUdtAsset({
   name: 'RUSD',

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -148,7 +148,64 @@ L402 primitives include:
 
 See [packages/cli/docs/l402-agent-guide.md](../cli/docs/l402-agent-guide.md) for usage.
 
+## UDT (User-Defined Token) Support
+
+The SDK provides typed UDT helpers for parsing, formatting, and resolving UDT assets:
+
+```ts
+import {
+  parseUdtTypeScript,
+  validateUdtTypeScript,
+  resolveUdtAsset,
+  parseFundingAmount,
+  parsePaymentAmount,
+  formatChannelBalances,
+  formatAssetName,
+  DEFAULT_CKB_ASSET,
+} from '@fiber-pay/sdk';
+// Also available from '@fiber-pay/sdk/browser'
+```
+
+### UDT Types
+
+| Type | Description |
+|------|-------------|
+| `UdtAsset` | Union type: `{ kind: 'ckb' }` or `{ kind: 'udt'; script: UdtTypeScript; name?: string }` |
+| `UdtTypeScript` | CKB type script `{ code_hash, hash_type, args }` |
+| `FormattedChannelBalances` | Display-ready balance fields with `kind: 'ckb'` or `kind: 'udt'` |
+
+### Common UDT Workflows
+
+**Parsing user input** — safely convert CLI/browser input into validated types:
+```ts
+const script = parseUdtTypeScript(rawJson, '--udt-type-script');
+// or validate an already-parsed object:
+validateUdtTypeScript(obj, '--udt-type-script');
+
+const fundingAmount = parseFundingAmount('1000', { kind: 'udt', script, name: 'TEST' });
+const paymentAmount = parsePaymentAmount('500', { kind: 'udt', script });
+```
+
+**Resolving by name** — look up configured UDTs from node info:
+```ts
+const asset = await resolveUdtAsset({
+  name: 'RUSD',
+  rpc: client,
+});
+// asset = { kind: 'udt', script: {...}, name: 'RUSD' }
+```
+
+**Formatting channels** — handle both CKB and UDT channels in display code:
+```ts
+const balances = formatChannelBalances(channel);
+if (balances.kind === 'udt') {
+  console.log(`UDT: local ${balances.local}, remote ${balances.remote}`);
+} else {
+  console.log(`CKB: local ${balances.local}, remote ${balances.remote}`);
+}
+```
+
 ## Compatibility
 
 - Node.js `>=20`
-- Fiber target: `v0.9.0-rc4`
+- Fiber target: `v0.9.0-rc7`

--- a/skills/fiber-pay/SKILL.md
+++ b/skills/fiber-pay/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: fiber-pay
-description: Operate CKB Lightning payments through fiber-pay CLI. Use when tasks involve node lifecycle, channel management, invoice/payment flows, config tuning, or multi-node orchestration on Fiber Network v0.9.0-rc4.
+description: Operate CKB Lightning payments through fiber-pay CLI, including UDT support. Use when tasks involve node lifecycle, channel management, invoice/payment flows, UDT operations, config tuning, or multi-node orchestration on Fiber Network v0.9.0-rc7.
 ---
 
 # fiber-pay

--- a/skills/fiber-pay/SKILL.md
+++ b/skills/fiber-pay/SKILL.md
@@ -5,11 +5,11 @@ description: Operate CKB Lightning payments through fiber-pay CLI. Use when task
 
 # fiber-pay
 
-fiber-pay is an AI payment layer over Fiber Network for CKB Lightning. It provides an AI-friendly CLI to manage node lifecycle, channels, invoices, payments, and more.
+fiber-pay is an AI payment layer over Fiber Network for CKB Lightning. It provides an AI-friendly CLI to manage node lifecycle, channels, invoices, payments, UDT (User-Defined Token) support, and more.
 
-- Last updated: 2026-05-26
-- Fiber node target: v0.9.0-rc4
-- Fiber RPC reference: https://github.com/nervosnetwork/fiber/blob/v0.9.0-rc4/crates/fiber-lib/src/rpc/README.md
+- Last updated: 2026-07-09
+- Fiber node target: v0.9.0-rc7
+- Fiber RPC reference: https://github.com/nervosnetwork/fiber/blob/v0.9.0-rc7/crates/fiber-lib/src/rpc/README.md
 
 ## Architecture
 

--- a/skills/fiber-pay/references/auth.md
+++ b/skills/fiber-pay/references/auth.md
@@ -4,8 +4,8 @@ This guide documents how `fiber-pay` works with Fiber RPC Biscuit authentication
 
 Upstream reference:
 
-- Fiber Biscuit auth doc: [docs/biscuit-auth.md](https://github.com/nervosnetwork/fiber/blob/v0.9.0-rc4/docs/biscuit-auth.md)
-- Fiber RPC reference: [crates/fiber-lib/src/rpc/README.md](https://github.com/nervosnetwork/fiber/blob/v0.9.0-rc4/crates/fiber-lib/src/rpc/README.md)
+- Fiber Biscuit auth doc: [docs/biscuit-auth.md](https://github.com/nervosnetwork/fiber/blob/v0.9.0-rc7/docs/biscuit-auth.md)
+- Fiber RPC reference: [crates/fiber-lib/src/rpc/README.md](https://github.com/nervosnetwork/fiber/blob/v0.9.0-rc7/crates/fiber-lib/src/rpc/README.md)
 
 ## Scope
 

--- a/skills/fiber-pay/references/config.md
+++ b/skills/fiber-pay/references/config.md
@@ -1,4 +1,4 @@
-# FNN Config Reference (v0.9.0-rc4)
+# FNN Config Reference (v0.9.0-rc7)
 
 - Structured reference for `config.yml` used by the Fiber Network Node (`fnn`). 
 - All values are set via `fiber-pay config set <path> <value>`.

--- a/skills/fiber-pay/references/core-operation.md
+++ b/skills/fiber-pay/references/core-operation.md
@@ -46,13 +46,25 @@ fiber-pay channel watch --until CHANNEL_READY --json
 
 To open a UDT (User-Defined Token) channel, provide the CKB type script and the funding amount in raw UDT units:
 
+> **Note:** UDT amounts are raw integer units (smallest decimal precision). Verify `code_hash` and `args` against the token's official deployment before funding — an incorrect type script can lock funds into a counterfeit token channel.
+
 ```bash
 fiber-pay peer connect <peer-multiaddr> --json
+
+# By type script (recommended for deterministic selection)
 fiber-pay channel open \
   --peer <peer-address> \
   --funding <UDT-amount> \
   --funding-udt-type-script '{"code_hash":"0x...","hash_type":"type","args":"0x..."}' \
   --json
+
+# By configured name (resolves from node_info.udt_cfg_infos)
+fiber-pay channel open \
+  --peer <peer-address> \
+  --funding <UDT-amount> \
+  --funding-udt-name <name> \
+  --json
+
 fiber-pay channel watch --until CHANNEL_READY --json
 ```
 
@@ -83,13 +95,17 @@ fiber-pay invoice create --amount <CKB> --description "<desc>" --json
 
 ### UDT invoices
 
+> **Note:** UDT amounts are raw integer units (smallest decimal precision).
+
 Create a UDT-denominated invoice by name (resolves from `node_info.udt_cfg_infos`) or by type script:
+
+> **Important:** If both `--udt-name` and `--udt-type-script` are provided, the type script takes precedence and the name is silently ignored. Use only one selector. When using `--udt-name`, verify the resolved type script against the token issuer's official deployment.
 
 ```bash
 # By configured UDT name
 fiber-pay invoice create --amount <UDT-amount> --udt-name <name> --json
 
-# By type script
+# By type script (recommended for deterministic selection)
 fiber-pay invoice create --amount <UDT-amount> \
   --udt-type-script '{"code_hash":"0x...","hash_type":"type","args":"0x..."}' --json
 ```
@@ -136,6 +152,8 @@ fiber-pay channel rebalance --amount <CKB> --from-channel <channelA_id> --to-cha
 ### UDT rebalance
 
 Rebalance also works across UDT channels. Use `--udt-type-script` or `--udt-name` to specify the asset:
+
+> **Note:** UDT amounts are raw integer units. If both `--udt-name` and `--udt-type-script` are provided, the type script takes precedence. Verify the resolved type script before rebalancing — a misconfigured node could map a familiar name to a counterfeit script.
 
 ```bash
 fiber-pay channel rebalance --amount <UDT-amount> --udt-name <name> --dry-run --json

--- a/skills/fiber-pay/references/core-operation.md
+++ b/skills/fiber-pay/references/core-operation.md
@@ -42,6 +42,22 @@ fiber-pay channel open --peer <peer-address> --funding <CKB> --json
 fiber-pay channel watch --until CHANNEL_READY --json
 ```
 
+### UDT channels
+
+To open a UDT (User-Defined Token) channel, provide the CKB type script and the funding amount in raw UDT units:
+
+```bash
+fiber-pay peer connect <peer-multiaddr> --json
+fiber-pay channel open \
+  --peer <peer-address> \
+  --funding <UDT-amount> \
+  --funding-udt-type-script '{"code_hash":"0x...","hash_type":"type","args":"0x..."}' \
+  --json
+fiber-pay channel watch --until CHANNEL_READY --json
+```
+
+UDT channels are displayed with `unit: 'UDT'` in `channel list` output, alongside CKB channels.
+
 Verification checks:
 
 ```bash
@@ -63,6 +79,19 @@ Create invoice:
 
 ```bash
 fiber-pay invoice create --amount <CKB> --description "<desc>" --json
+```
+
+### UDT invoices
+
+Create a UDT-denominated invoice by name (resolves from `node_info.udt_cfg_infos`) or by type script:
+
+```bash
+# By configured UDT name
+fiber-pay invoice create --amount <UDT-amount> --udt-name <name> --json
+
+# By type script
+fiber-pay invoice create --amount <UDT-amount> \
+  --udt-type-script '{"code_hash":"0x...","hash_type":"type","args":"0x..."}' --json
 ```
 
 Track invoice/payment state:
@@ -102,6 +131,16 @@ Use high-level channel command:
 fiber-pay channel rebalance --amount <CKB> --max-fee <CKB> --dry-run --json
 fiber-pay channel rebalance --amount <CKB> --max-fee <CKB> --json
 fiber-pay channel rebalance --amount <CKB> --from-channel <channelA_id> --to-channel <channelB_id> --json
+```
+
+### UDT rebalance
+
+Rebalance also works across UDT channels. Use `--udt-type-script` or `--udt-name` to specify the asset:
+
+```bash
+fiber-pay channel rebalance --amount <UDT-amount> --udt-name <name> --dry-run --json
+fiber-pay channel rebalance --amount <UDT-amount> \
+  --udt-type-script '{"code_hash":"0x...","hash_type":"type","args":"0x..."}' --json
 ```
 
 Direction quick rule:

--- a/skills/fiber-pay/references/fnn.reference.yml
+++ b/skills/fiber-pay/references/fnn.reference.yml
@@ -1,7 +1,7 @@
 # =============================================================================
 # Fiber Network Node (fnn) - Full Configuration Reference
 # =============================================================================
-# Version: v0.9.0-rc4
+# Version: v0.9.0-rc7
 #
 # Usage:
 #   fnn --config /path/to/config.yml

--- a/skills/fiber-pay/references/rebalance.md
+++ b/skills/fiber-pay/references/rebalance.md
@@ -50,6 +50,27 @@ fiber-pay channel rebalance --amount <CKB> --max-fee <CKB> --dry-run --json
 fiber-pay channel rebalance --amount <CKB> --max-fee <CKB> --json
 ```
 
+### UDT rebalance
+
+Rebalance also works across UDT channels. Specify the asset via configured name or type script:
+
+```bash
+# By name (resolves from node_info.udt_cfg_infos)
+fiber-pay channel rebalance --amount <UDT-amount> --udt-name <name> --dry-run --json
+fiber-pay channel rebalance --amount <UDT-amount> --udt-name <name> --json
+
+# By type script
+fiber-pay channel rebalance --amount <UDT-amount> \
+  --udt-type-script '{"code_hash":"0x...","hash_type":"type","args":"0x..."}' --dry-run --json
+fiber-pay channel rebalance --amount <UDT-amount> \
+  --udt-type-script '{"code_hash":"0x...","hash_type":"type","args":"0x..."}' --json
+
+# Guided mode also supports UDT channels
+fiber-pay channel rebalance --amount <UDT-amount> \
+  --from-channel <channelA_id> --to-channel <channelB_id> \
+  --udt-type-script '{"code_hash":"0x...","hash_type":"type","args":"0x..."}' --json
+```
+
 Manual route mode (pin path hops, payment-level technical mode):
 
 ```bash

--- a/skills/fiber-pay/references/rebalance.md
+++ b/skills/fiber-pay/references/rebalance.md
@@ -54,12 +54,14 @@ fiber-pay channel rebalance --amount <CKB> --max-fee <CKB> --json
 
 Rebalance also works across UDT channels. Specify the asset via configured name or type script:
 
+> **Note:** UDT amounts are raw integer units (smallest decimal precision). If both `--udt-name` and `--udt-type-script` are provided, the type script takes precedence and the name is silently ignored. When using `--udt-name`, verify the resolved type script before rebalancing — a compromised or misconfigured node could alias a familiar name to a counterfeit script.
+
 ```bash
 # By name (resolves from node_info.udt_cfg_infos)
 fiber-pay channel rebalance --amount <UDT-amount> --udt-name <name> --dry-run --json
 fiber-pay channel rebalance --amount <UDT-amount> --udt-name <name> --json
 
-# By type script
+# By type script (recommended for deterministic selection)
 fiber-pay channel rebalance --amount <UDT-amount> \
   --udt-type-script '{"code_hash":"0x...","hash_type":"type","args":"0x..."}' --dry-run --json
 fiber-pay channel rebalance --amount <UDT-amount> \
@@ -120,7 +122,7 @@ Single-channel case:
 
 ## 4) Parameter semantics
 
-- `--amount`: required CKB amount to rebalance.
+- `--amount`: required amount to rebalance (CKB shannon or raw UDT units, depending on selected asset).
 - `--max-fee`: optional cap for auto mode only.
 - `--hops`: payment-only optional comma-separated hop pubkeys for manual mode.
 - `--from-channel` + `--to-channel`: channel-only guided mode input (must be provided together).

--- a/skills/fiber-pay/references/upgrade.md
+++ b/skills/fiber-pay/references/upgrade.md
@@ -19,7 +19,7 @@ fiber-pay node stop
 
 # 2. Upgrade binary + prepare store
 fiber-pay node upgrade                    # latest version
-fiber-pay node upgrade --version v0.9.0-rc4   # specific version
+fiber-pay node upgrade --version v0.9.0-rc7   # specific version
 
 # custom binary path: migration-only (no auto-download)
 fiber-pay --binary-path /opt/fiber/custom/fnn node upgrade


### PR DESCRIPTION
## Changes

This PR syncs the repository documentation with source-level changes introduced since v0.2.7 release:

### Fiber version update (v0.9.0-rc4 → v0.9.0-rc7)
- `README.md`, `packages/cli/README.md`, `packages/sdk/README.md`, `docs/develop.md`, `skills/fiber-pay/SKILL.md`

### UDT (User-Defined Token) documentation
- **`packages/sdk/README.md`**: New UDT section with `UdtAsset`, `UdtTypeScript`, `FormattedChannelBalances` types, parsing/formatting/resolving workflows, and code examples
- **`packages/cli/README.md`**: UDT CLI usage reference (channel open, invoice create, payment, rebalance)
- **`skills/fiber-pay/references/core-operation.md`**: UDT channel open, UDT invoice creation, and UDT rebalance sections with examples
- **`packages/cli/docs/human-quickstart.md`**: UDT invoice creation examples
- **`skills/fiber-pay/references/rebalance.md`**: UDT rebalance command examples

### SKILL.md refresh
- Updated last-updated date to 2026-07-09
- Added UDT mention in description
- Updated RPC reference URL

## Ref
[RET-152](mention://issue/5bf8126a-b268-48e7-99dd-6d92f8dd7d33)

## Test
Docs-only change — verify with `pnpm format:check`.