### PR TITLE
fix(react): harden UDT payment flows

### DIFF
--- a/.changeset/react-udt-hardening.md
+++ b/.changeset/react-udt-hardening.md
@@ -1,0 +1,6 @@
+---
+'@fiber-pay/react': patch
+'@fiber-pay/sdk': patch
+---
+
+Harden high-level React UDT flows by fixing StrictMode state handling, validating invoice network and serialized UDT identity before payment, recovering channel actions after invalid scripts, matching channel labels by type script, inheriting network from shared Fiber sessions, and exposing asset-aware external funding context. Also add canonical UDT script serialization/equality helpers and reject incomplete hex bytes.

--- a/examples/browser-sdk-playground/package.json
+++ b/examples/browser-sdk-playground/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@fiber-pay/sdk": "workspace:*",
-    "@nervosnetwork/fiber-js": "~0.8.1",
+    "@nervosnetwork/fiber-js": "catalog:",
     "react": "^19.2.4",
     "react-dom": "^19.2.4"
   },

--- a/examples/react-fiber-node-button-lab/README.md
+++ b/examples/react-fiber-node-button-lab/README.md
@@ -13,6 +13,7 @@ You will learn:
 3. renderAction override for selected actions.
 4. t callback for lightweight i18n overrides.
 5. externalFunding.resolve integration path with CCC signer handoff.
+6. CKB/RUSD asset switching with an explicit UDT whitelist and raw base-unit amounts.
 
 Out of scope:
 

--- a/examples/react-fiber-node-button-lab/package.json
+++ b/examples/react-fiber-node-button-lab/package.json
@@ -14,7 +14,7 @@
     "@ckb-ccc/core": "^1.12.5",
     "@fiber-pay/react": "workspace:*",
     "@fiber-pay/sdk": "workspace:*",
-    "@nervosnetwork/fiber-js": "~0.8.1",
+    "@nervosnetwork/fiber-js": "catalog:",
     "react": "^19.2.4",
     "react-dom": "^19.2.4"
   },

--- a/examples/react-fiber-node-button-lab/src/App.tsx
+++ b/examples/react-fiber-node-button-lab/src/App.tsx
@@ -3,6 +3,8 @@ import {
   FiberNodeButton,
   type FiberNodeButtonRenderAction,
   type FiberNodeButtonTabConfig,
+  type UdtAsset,
+  type UseFiberNodeOptions,
   useFiberNode,
 } from '@fiber-pay/react';
 import {
@@ -19,15 +21,42 @@ interface EventLogEntry {
 }
 
 const TESTNET_CKB_RPC_URL = 'https://testnet.ckbapp.dev/';
+const RUSD_SCRIPT = {
+  code_hash: '0x1142755a044bf2ee358cba9f2da187ce928c91cd4dc8692ded0337efa677d21a',
+  hash_type: 'type',
+  args: '0x878fcc6f1f08d48e87bb1c3b3d5083f23f8a39c5d5c764f253b55b998526439b',
+} as const;
+const RUSD_ASSET: UdtAsset = { kind: 'udt', name: 'RUSD', script: RUSD_SCRIPT };
+const CKB_ASSET: UdtAsset = { kind: 'ckb' };
+const RUSD_NODE_CONFIG = {
+  udtWhitelist: [
+    {
+      name: 'RUSD',
+      script: RUSD_SCRIPT,
+      cellDeps: [
+        {
+          typeId: {
+            code_hash: '0x00000000000000000000000000000000000000000000000000545950455f4944',
+            hash_type: 'type',
+            args: '0x97d30b723c0b2c66e9cb8d4d0df4ab5d7222cbb00d4a9a2055ce2e5d7f0d8b0f',
+          },
+        },
+      ],
+      autoAcceptAmount: '1000000000',
+    },
+  ],
+} satisfies NonNullable<UseFiberNodeOptions['nodeConfig']>;
 
 const integrationSnippet = `const fiber = useFiberNode({
   network: 'testnet',
   walletId: 'my-app-fiber-session',
   externalWallet,
+  nodeConfig: { udtWhitelist: [RUSD_WHITELIST_ENTRY] },
 });
 
 <FiberNodeButton
   fiber={fiber}
+  asset={selectedAsset}
   strategy={strategy}
   password={strategy === 'password' ? password : undefined}
   externalFunding={{ enabled: externalWallet, resolve: resolveExternalFunding }}
@@ -307,6 +336,7 @@ export function App() {
 
   const [strategy, setStrategy] = useState<ConnectStrategy>('password');
   const [externalWallet, setExternalWallet] = useState(false);
+  const [assetKind, setAssetKind] = useState<'ckb' | 'rusd'>('ckb');
   const [customTabMode, setCustomTabMode] = useState(false);
   const [password, setPassword] = useState('demo-secret');
   const [externalWalletAddress, setExternalWalletAddress] = useState<string | null>(null);
@@ -316,7 +346,9 @@ export function App() {
     network: 'testnet',
     walletId: 'quick-card-connect-demo',
     externalWallet,
+    nodeConfig: RUSD_NODE_CONFIG,
   });
+  const selectedAsset = assetKind === 'rusd' ? RUSD_ASSET : CKB_ASSET;
 
   const addLog = useCallback((message: string) => {
     const now = new Date();
@@ -415,7 +447,8 @@ export function App() {
               {t('demo.customTab.activeChannels', 'Active channels')}: {state.activeChannelCount}
             </p>
             <p style={{ margin: '6px 0 0', fontSize: '0.78rem', color: '#475569' }}>
-              {t('demo.customTab.paymentStatus', 'Payment status')}: {state.paymentResult?.status ?? 'Idle'}
+              {t('demo.customTab.paymentStatus', 'Payment status')}:{' '}
+              {state.paymentResult?.status ?? 'Idle'}
             </p>
           </section>
         ),
@@ -470,32 +503,43 @@ export function App() {
         <header style={styles.hero}>
           <h1 style={styles.title}>FiberNodeButton Developer Demo</h1>
           <p style={styles.subtitle}>
-            One component, one page: learn FiberNodeButton integration fast, then verify behavior in the
-            live panel and runtime logs.
+            One component, one page: learn FiberNodeButton integration fast, then verify behavior in
+            the live panel and runtime logs.
           </p>
         </header>
 
         <div style={styles.layout}>
           <aside style={styles.panel}>
             <h2 style={styles.panelTitle}>Integration Guide</h2>
-            <p style={styles.panelLead}>Copy this wiring model and replace wallet/session config with your app values.</p>
+            <p style={styles.panelLead}>
+              Copy this wiring model and replace wallet/session config with your app values.
+            </p>
 
             <ol style={styles.stepList}>
               <li style={styles.stepItem}>
                 <p style={styles.stepTitle}>Step 1. Create one shared fiber hook</p>
-                <p style={styles.stepDesc}>Keep useFiberNode in your page or provider and pass the same fiber object into FiberNodeButton.</p>
+                <p style={styles.stepDesc}>
+                  Keep useFiberNode in your page or provider and pass the same fiber object into
+                  FiberNodeButton.
+                </p>
               </li>
               <li style={styles.stepItem}>
                 <p style={styles.stepTitle}>Step 2. Choose auth strategy at runtime</p>
-                <p style={styles.stepDesc}>Password and passkey can share one component, switch via strategy prop.</p>
+                <p style={styles.stepDesc}>
+                  Password and passkey can share one component, switch via strategy prop.
+                </p>
               </li>
               <li style={styles.stepItem}>
                 <p style={styles.stepTitle}>Step 3. Plug external funding only when needed</p>
-                <p style={styles.stepDesc}>Use externalFunding.enabled plus resolve callback for CCC signer handoff.</p>
+                <p style={styles.stepDesc}>
+                  Use externalFunding.enabled plus resolve callback for CCC signer handoff.
+                </p>
               </li>
               <li style={styles.stepItem}>
                 <p style={styles.stepTitle}>Step 4. Subscribe to callback events</p>
-                <p style={styles.stepDesc}>onConnect, onDisconnect, onError, onLog cover most app-level telemetry needs.</p>
+                <p style={styles.stepDesc}>
+                  onConnect, onDisconnect, onError, onLog cover most app-level telemetry needs.
+                </p>
               </li>
             </ol>
 
@@ -518,7 +562,9 @@ export function App() {
 
           <section style={styles.panel}>
             <h2 style={styles.panelTitle}>Live Playground</h2>
-            <p style={styles.panelLead}>Choose strategy, toggle funding mode, then open FiberNodeButton.</p>
+            <p style={styles.panelLead}>
+              Choose strategy, toggle funding mode, then open FiberNodeButton.
+            </p>
 
             <div style={styles.row}>
               <button
@@ -581,8 +627,42 @@ export function App() {
               ) : null}
             </div>
 
+            <div style={styles.row}>
+              <button
+                type="button"
+                onClick={() => setAssetKind('ckb')}
+                disabled={externalWalletToggleLocked}
+                style={{
+                  ...styles.modeButton,
+                  ...(assetKind === 'ckb' ? styles.modeButtonActive : {}),
+                }}
+              >
+                CKB
+              </button>
+              <button
+                type="button"
+                onClick={() => setAssetKind('rusd')}
+                disabled={externalWalletToggleLocked}
+                style={{
+                  ...styles.modeButton,
+                  ...(assetKind === 'rusd' ? styles.modeButtonActive : {}),
+                }}
+              >
+                RUSD (base units)
+              </button>
+            </div>
+
+            <p style={styles.helperText}>
+              {assetKind === 'rusd'
+                ? 'RUSD mode uses the explicit testnet whitelist above. Amounts are raw integer base units.'
+                : 'CKB mode uses human-readable CKB amounts.'}
+            </p>
+
             <FiberNodeButton
               fiber={fiber}
+              asset={selectedAsset}
+              initialFundingAmount={assetKind === 'rusd' ? '1000000000' : '1000'}
+              invoiceAmount={assetKind === 'rusd' ? '100000000' : '1'}
               strategy={strategy}
               password={strategy === 'password' ? password : undefined}
               onLog={addLog}
@@ -607,7 +687,8 @@ export function App() {
                   ? () => (
                       <div style={{ display: 'grid', gap: 6 }}>
                         <div style={{ fontSize: 12, color: '#475569' }}>
-                          CCC wallet: <strong>{connectedExternalWallet?.name ?? 'Not connected'}</strong>
+                          CCC wallet:{' '}
+                          <strong>{connectedExternalWallet?.name ?? 'Not connected'}</strong>
                           {connectedExternalWallet && externalWalletAddress
                             ? ` | address: ${shorten(externalWalletAddress, 20, 10)}`
                             : ''}
@@ -628,7 +709,9 @@ export function App() {
                               fontWeight: 700,
                             }}
                           >
-                            {connectedExternalWallet ? 'Switch External Wallet' : 'Connect External Wallet'}
+                            {connectedExternalWallet
+                              ? 'Switch External Wallet'
+                              : 'Connect External Wallet'}
                           </button>
                           <button
                             type="button"
@@ -674,7 +757,9 @@ export function App() {
                 Use External Wallet (CCC Signer)
               </label>
 
-              <p style={styles.helperText}>{externalWallet ? 'External mode enabled.' : 'Internal mode enabled.'}</p>
+              <p style={styles.helperText}>
+                {externalWallet ? 'External mode enabled.' : 'Internal mode enabled.'}
+              </p>
 
               {externalWalletToggleLocked ? (
                 <p style={styles.warningText}>Disconnect the node before switching funding mode.</p>
@@ -682,7 +767,8 @@ export function App() {
             </div>
 
             <p style={styles.compactMeta}>
-              Node: {fiber.nodeInfo?.pubkey ? shorten(fiber.nodeInfo.pubkey, 18, 12) : 'Not connected'}
+              Node:{' '}
+              {fiber.nodeInfo?.pubkey ? shorten(fiber.nodeInfo.pubkey, 18, 12) : 'Not connected'}
             </p>
 
             <div style={styles.statusGrid}>

--- a/examples/react-min-connect/package.json
+++ b/examples/react-min-connect/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@fiber-pay/react": "workspace:*",
-    "@nervosnetwork/fiber-js": "~0.8.1",
+    "@nervosnetwork/fiber-js": "catalog:",
     "react": "^19.2.4",
     "react-dom": "^19.2.4"
   },

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -52,8 +52,9 @@ set these headers on your web server or CDN (for example Nginx, Cloudflare, Verc
 
 ## Bundle Size Notes
 
-Browser Fiber WASM artifacts are large by nature. In the current examples, a production build includes
-an additional ~14 MB JS chunk (~6.5 MB gzip) for WASM/runtime assets.
+Browser Fiber WASM artifacts are large by nature. With `fiber-js` 0.9.0-rc4, the current
+`react-fiber-node-button-lab` production build includes an additional ~45.5 MB JS chunk
+(~13.4 MB gzip) for WASM/runtime assets.
 
 Recommended integration strategy:
 
@@ -85,6 +86,7 @@ For a complete browser passkey + payment walkthrough, see [docs/wasm-passkey-pay
 `FiberPayQuickCard` supports lightweight integration hooks:
 
 - `fiber` (reuse existing `useFiberNode()` session)
+- `asset`, `invoiceAmount` (CKB or whitelisted UDT payment context)
 - `className`, `style`, `title`
 - `onInvoiceCreated(invoice)`
 - `onPaymentResult(result)`
@@ -145,10 +147,10 @@ export function NodeDashboard() {
 |------|--------|
 | **Node state badge** | Visual status indicator (idle, starting, running, error, etc.) |
 | **Pubkey** | Full display with **copy-to-clipboard button** |
-| **CKB Address** | Derived from the node's lock script, displayed with **copy button** |
+| **Funding Address** | Derived from the node's lock script, displayed with **copy button** |
 | **Peers / Channels count** | Compact stat cards |
-| **CKB Balance** | Queried from chain via RPC (updated every 15s) |
-| **QR Code** | Optional — shows CKB address for "Scan to deposit CKB" (`showQrCode` prop) |
+| **CKB / UDT Balance** | Queried from chain via RPC for the selected `asset` (updated every 15s) |
+| **QR Code** | Optional — encodes the funding address only (`showQrCode` prop). For UDT deposits, the wallet must still select the matching token script. |
 
 ### Props
 
@@ -156,6 +158,7 @@ export function NodeDashboard() {
 |------|------|---------|-------------|
 | `node` | `FiberBrowserNode \| null` | — | The running node instance. Pass `null` for idle state. |
 | `network` | `"testnet" \| "mainnet"` | — | Network for address derivation and RPC URL. |
+| `asset` | `UdtAsset` | `{ kind: "ckb" }` | Balance asset. UDT values are displayed in raw base units. |
 | `pollInterval` | `number` | `15000` | Stats refresh interval in milliseconds. |
 | `showQrCode` | `boolean` | `false` | Show a QR code of the CKB address (requires `qrcode.react`). |
 | `renderQrCode` | `(value: string) => ReactNode` | — | Override QR rendering with your own library. |
@@ -217,8 +220,8 @@ export function WalletWithDeposit() {
         {
           id: 'deposit',
           label: 'Deposit',
-          render: ({ fiber: { node } }) => (
-            <NodeInfoPanel node={node} network="testnet" showQrCode />
+          render: ({ fiber: { node }, asset }) => (
+            <NodeInfoPanel node={node} network="testnet" asset={asset} showQrCode />
           ),
         },
         { id: 'diagnostics' },
@@ -284,7 +287,7 @@ export function WalletEntry() {
 
 | Prop | Type | Default | Description |
 |------|------|---------|-------------|
-| `network` | `"testnet" \| "mainnet"` | `"testnet"` | Network to connect to. |
+| `network` | `"testnet" \| "mainnet"` | `fiber.network`, then `"testnet"` | Network used for node startup and invoice currency. |
 | `fiber` | `UseFiberNodeResult` | — | Pre-existing hook result. When provided, the button shares this session instead of creating its own. |
 | `strategy` | `"passkey" \| "password"` | `"passkey"` | Credential strategy for authentication. |
 | `externalWallet` | `boolean` | `false` | Enable external wallet mode (no internal CKB key derivation). |
@@ -293,6 +296,7 @@ export function WalletEntry() {
 | `passkeyUsername` | `string` | `"User"` | Display name for passkey registration. |
 | `wasmFactory` | `FiberWasmFactory` | — | Optional WASM factory override. |
 | `nodeConfig` | `UseFiberNodeOptions["nodeConfig"]` | — | Additional node configuration. |
+| `asset` | `UdtAsset` | `{ kind: "ckb" }` | Asset used for channel funding, invoices, and payments. |
 | `className` | `string` | — | Additional CSS class for the root container. |
 | `style` | `CSSProperties` | — | Inline styles for the root container. |
 | `dropdownStyle` | `CSSProperties` | — | Inline styles for the dropdown panel. |
@@ -303,12 +307,69 @@ export function WalletEntry() {
 | `initialPeerPubkey` | `string` | `""` | Pre-filled peer pubkey for the open-channel form. |
 | `initialPeerAddress` | `string` | `""` | Pre-filled peer address for the open-channel form. |
 | `initialFundingAmountCkb` | `string` | `"1000"` | Pre-filled funding amount (in CKB) for the open-channel form. |
+| `initialFundingAmount` | `string` | — | CKB display amount or raw integer UDT base units. Takes precedence over `initialFundingAmountCkb`. |
+| `invoiceAmount` | `string` | `"1"` | CKB display amount or raw integer UDT base units. |
 | `externalFunding` | `FiberNodeButtonExternalFundingConfig` | — | External funding resolver configuration. |
 | `renderConnectorSection` | `(context) => ReactNode` | — | Custom renderer for the connector section inside the panel. |
 | `tabs` | `FiberNodeButtonTabConfig[]` | — | Reorder, hide, or extend built-in tabs. |
 | `renderTabContent` | `(tabId, context) => ReactNode \| undefined` | — | Override tab body rendering per tab. Return `undefined` to fall through. |
 | `renderAction` | `(context) => ReactNode \| undefined` | — | Replace default action buttons (e.g. Pay Invoice, Open Channel). |
 | `t` | `FiberNodeButtonI18n` | — | Localization function for labels and copy. |
+
+### UDT setup
+
+Passing `asset` selects the token for UI and RPC calls, but it does **not** configure the Fiber node. The same type script must be present in `nodeConfig.udtWhitelist`, including the token's official cell deps. Both channel peers must support the token.
+
+UDT amounts are raw integer base units. For a token with 8 decimals, `100000000` represents one display token.
+
+```tsx
+import { FiberNodeButton, useFiberNode, type UdtAsset } from '@fiber-pay/react';
+
+const RUSD_SCRIPT = {
+  code_hash: '0x1142755a044bf2ee358cba9f2da187ce928c91cd4dc8692ded0337efa677d21a',
+  hash_type: 'type' as const,
+  args: '0x878fcc6f1f08d48e87bb1c3b3d5083f23f8a39c5d5c764f253b55b998526439b',
+};
+
+const RUSD: UdtAsset = { kind: 'udt', name: 'RUSD', script: RUSD_SCRIPT };
+
+export function RusdWallet() {
+  const fiber = useFiberNode({
+    network: 'testnet',
+    walletId: 'rusd-wallet',
+    nodeConfig: {
+      udtWhitelist: [
+        {
+          name: 'RUSD',
+          script: RUSD_SCRIPT,
+          cellDeps: [
+            {
+              typeId: {
+                code_hash: '0x00000000000000000000000000000000000000000000000000545950455f4944',
+                hash_type: 'type',
+                args: '0x97d30b723c0b2c66e9cb8d4d0df4ab5d7222cbb00d4a9a2055ce2e5d7f0d8b0f',
+              },
+            },
+          ],
+          autoAcceptAmount: '1000000000',
+        },
+      ],
+    },
+  });
+
+  return (
+    <FiberNodeButton
+      fiber={fiber}
+      asset={RUSD}
+      initialFundingAmount="1000000000"
+      invoiceAmount="100000000"
+      onError={console.error}
+    />
+  );
+}
+```
+
+`FiberNodeButton` verifies that the configured UDT appears in `nodeInfo.udt_cfg_infos`, checks pasted invoice network and serialized UDT script before payment, and rejects mismatches before `send_payment`.
 
 ### State mapping
 
@@ -415,6 +476,8 @@ export function CustomPanelDemo() {
 For external funding, pass `externalFunding` with an async `resolve` callback that returns
 `signFundingTx` and optional script / dep overrides.
 
+The resolver context includes `asset` and `fundingAmount`; for UDTs the amount is raw base units. The legacy `fundingAmountCkb` field remains for compatibility and should not be used for new integrations.
+
 If you use CCC wallets, `@fiber-pay/sdk/browser` provides
 `createCccExternalFundingResolver(...)` so you do not need to handwrite resolve logic:
 
@@ -484,7 +547,7 @@ The following common keys can be localized via the `t` prop (additional keys exi
 ## Hooks
 
 - `useFiberNode(options)`
-- `useFiberPayment(node)`
+- `useFiberPayment(node, { asset?, network? })`
 
 `useFiberNode` exposes passkey/password startup, node lifecycle methods, and passkey diagnostics (`passkeySupportReason`, `passkeyUnavailableReason`).
 
@@ -494,6 +557,8 @@ The following common keys can be localized via the `t` prop (additional keys exi
 - `parseInvoice(invoice)`
 - `sendPayment(invoice)`
 - `waitForPayment(paymentHash)`
+
+`payInvoice` parses and validates invoice network/asset before sending. The lower-level staged `sendPayment` API cannot validate an invoice by itself; staged callers should inspect the `parseInvoice` result before calling it.
 
 Staged flow example:
 

--- a/packages/react/docs/wasm-passkey-payment-component-quickstart.md
+++ b/packages/react/docs/wasm-passkey-payment-component-quickstart.md
@@ -330,7 +330,7 @@ Use this path when you want to ship a functional payment panel quickly, then pro
 - Treat browser XSS hardening as top priority (CSP, script hygiene, strict dependency review).
 - Avoid exposing privileged backend tokens in browser bundles.
 - For browser multithreaded WASM runtime, keep COOP/COEP settings correctly configured.
-- Expect a large WASM-related bundle chunk (roughly ~14 MB raw, ~6.5 MB gzip in current demos);
+- Expect a large WASM-related bundle chunk (roughly ~45.5 MB raw, ~13.4 MB gzip with fiber-js 0.9.0-rc4 in the current React lab);
   use route-level split/lazy mounting for payment-heavy UI.
 
 ## 8) Reference Paths

--- a/packages/react/src/connect-button.tsx
+++ b/packages/react/src/connect-button.tsx
@@ -357,6 +357,7 @@ export function ConnectButton(props: ConnectButtonProps) {
   // --- Local UI state -------------------------------------------------------
   const [isConnecting, setIsConnecting] = useState(false);
   const [showDropdown, setShowDropdown] = useState(false);
+  const [hasOpenedDropdown, setHasOpenedDropdown] = useState(false);
   const [localError, setLocalError] = useState<string | null>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
   const dropdownId = useId();
@@ -379,16 +380,24 @@ export function ConnectButton(props: ConnectButtonProps) {
     return () => document.removeEventListener('mousedown', handleClickOutside);
   }, [showDropdown]);
 
+  useEffect(() => {
+    if (!isRunning) {
+      setShowDropdown(false);
+      setHasOpenedDropdown(false);
+    }
+  }, [isRunning]);
+
   // Notify parent on connect/disconnect
   const prevRunningRef = useRef(false);
   useEffect(() => {
-    if (isRunning && !prevRunningRef.current && node && nodeInfo) {
+    if (isRunning && node && nodeInfo && !prevRunningRef.current) {
       onConnect?.(node, nodeInfo);
+      prevRunningRef.current = true;
     }
     if (!isRunning && prevRunningRef.current) {
       onDisconnect?.();
+      prevRunningRef.current = false;
     }
-    prevRunningRef.current = isRunning;
   }, [isRunning, node, nodeInfo, onConnect, onDisconnect]);
 
   // Notify parent on error once per distinct message.
@@ -450,6 +459,7 @@ export function ConnectButton(props: ConnectButtonProps) {
       setLocalError(msg);
     } finally {
       setShowDropdown(false);
+      setHasOpenedDropdown(false);
     }
   }, [stop]);
 
@@ -477,7 +487,10 @@ export function ConnectButton(props: ConnectButtonProps) {
         <Chevron open={showDropdown} />
       </>
     );
-    buttonOnClick = () => setShowDropdown((s) => !s);
+    buttonOnClick = () => {
+      setHasOpenedDropdown(true);
+      setShowDropdown((s) => !s);
+    };
     buttonStyle = { ...styles.button, ...styles.connectedButton };
   } else if (effectiveIsStarting) {
     buttonLabel = (
@@ -531,12 +544,17 @@ export function ConnectButton(props: ConnectButtonProps) {
             {buttonLabel}
           </button>
 
-          {showDropdown && (
+          {hasOpenedDropdown && (
             <div
               id={dropdownId}
               role="dialog"
               aria-label="Connection panel"
-              style={{ ...styles.dropdown, ...dropdownStyle }}
+              hidden={!showDropdown}
+              style={{
+                ...styles.dropdown,
+                ...dropdownStyle,
+                display: showDropdown ? dropdownStyle?.display : 'none',
+              }}
             >
               {renderConnectedDropdown ? (
                 renderConnectedDropdown({

--- a/packages/react/src/fiber-node-button/channels-tab.tsx
+++ b/packages/react/src/fiber-node-button/channels-tab.tsx
@@ -1,5 +1,9 @@
 import type { FormattedChannelBalances, UdtAsset } from '@fiber-pay/sdk/browser';
-import { formatAssetName, formatChannelBalances } from '@fiber-pay/sdk/browser';
+import {
+  areUdtTypeScriptsEqual,
+  formatAssetName,
+  formatChannelBalances,
+} from '@fiber-pay/sdk/browser';
 import { useMemo } from 'react';
 import type { UseFiberNodeResult } from '../use-fiber-node.js';
 import { renderPanelAction } from './render-action.js';
@@ -23,7 +27,14 @@ function formatChannelBalanceValue(
 
 function formatChannelBalanceUnit(balances: FormattedChannelBalances, asset?: UdtAsset): string {
   if (balances.kind === 'udt') {
-    return asset?.kind === 'udt' ? formatAssetName(asset) : 'UDT';
+    if (
+      asset?.kind === 'udt' &&
+      areUdtTypeScriptsEqual(balances.fundingUdtTypeScript, asset.script)
+    ) {
+      return formatAssetName(asset);
+    }
+    const codeHash = balances.fundingUdtTypeScript.code_hash;
+    return `UDT · ${codeHash.slice(0, 10)}…${codeHash.slice(-6)}`;
   }
   return 'CKB';
 }
@@ -31,9 +42,11 @@ function formatChannelBalanceUnit(balances: FormattedChannelBalances, asset?: Ud
 function SelectedChannelBalance({
   balances,
   side,
+  asset,
 }: {
   balances: FormattedChannelBalances | null;
   side: 'local' | 'remote';
+  asset?: UdtAsset;
 }) {
   if (!balances) {
     return <span style={styles.badge}>{side === 'local' ? 'Local' : 'Remote'} — CKB</span>;
@@ -42,7 +55,7 @@ function SelectedChannelBalance({
   return (
     <span style={styles.badge}>
       {side === 'local' ? 'Local' : 'Remote'} {formatChannelBalanceValue(balances, side)}{' '}
-      {formatChannelBalanceUnit(balances)}
+      {formatChannelBalanceUnit(balances, asset)}
     </span>
   );
 }
@@ -192,8 +205,12 @@ export function ChannelsTab({ state, fiber, asset, onLog, renderAction, t }: Cha
           </p>
 
           <div style={styles.row}>
-            <SelectedChannelBalance balances={selectedChannelBalances} side="local" />
-            <SelectedChannelBalance balances={selectedChannelBalances} side="remote" />
+            <SelectedChannelBalance balances={selectedChannelBalances} side="local" asset={asset} />
+            <SelectedChannelBalance
+              balances={selectedChannelBalances}
+              side="remote"
+              asset={asset}
+            />
             <span
               style={styles.badge}
               title="Pending TLCs are in-flight payment locks associated with this channel."

--- a/packages/react/src/fiber-node-button/channels-tab.tsx
+++ b/packages/react/src/fiber-node-button/channels-tab.tsx
@@ -33,7 +33,10 @@ function formatChannelBalanceUnit(balances: FormattedChannelBalances, asset?: Ud
     ) {
       return formatAssetName(asset);
     }
-    const codeHash = balances.fundingUdtTypeScript.code_hash;
+    const codeHash = balances.fundingUdtTypeScript?.code_hash;
+    if (!codeHash) {
+      return 'UDT';
+    }
     return `UDT · ${codeHash.slice(0, 10)}…${codeHash.slice(-6)}`;
   }
   return 'CKB';

--- a/packages/react/src/fiber-node-button/index.tsx
+++ b/packages/react/src/fiber-node-button/index.tsx
@@ -24,7 +24,7 @@ export type {
 
 export function FiberNodeButton(props: FiberNodeButtonProps) {
   const {
-    network = 'testnet',
+    network: requestedNetwork,
     fiber: externalFiber,
     strategy = 'passkey',
     externalWallet = false,
@@ -53,6 +53,8 @@ export function FiberNodeButton(props: FiberNodeButtonProps) {
     renderAction,
     t,
   } = props;
+
+  const network = requestedNetwork ?? externalFiber?.network ?? 'testnet';
 
   const managedFiber = useFiberNode({
     network,

--- a/packages/react/src/fiber-node-button/types.ts
+++ b/packages/react/src/fiber-node-button/types.ts
@@ -126,6 +126,10 @@ export interface FiberNodeButtonExternalFundingResolved {
 export interface FiberNodeButtonExternalFundingResolverContext {
   node: FiberBrowserNode;
   pubkey: HexString;
+  asset: UdtAsset;
+  /** Funding amount in CKB display units or raw UDT base units. */
+  fundingAmount: string;
+  /** @deprecated Use `fundingAmount` and `asset` instead. */
   fundingAmountCkb: string;
 }
 
@@ -144,6 +148,7 @@ export interface FiberNodeButtonConnectorSectionContext {
 }
 
 export interface FiberNodeButtonProps {
+  /** Defaults to the provided fiber.network, then testnet. */
   network?: 'testnet' | 'mainnet';
   fiber?: UseFiberNodeResult;
   strategy?: ConnectStrategy;
@@ -165,9 +170,9 @@ export interface FiberNodeButtonProps {
   initialPeerPubkey?: string;
   initialPeerAddress?: string;
   initialFundingAmountCkb?: string;
-  /** Generic funding amount (CKB or UDT units). Takes precedence over initialFundingAmountCkb. */
+  /** CKB display amount or raw integer UDT base units. Takes precedence over initialFundingAmountCkb. */
   initialFundingAmount?: string;
-  /** Invoice amount in CKB or UDT units. Defaults to 1 (CKB or UDT). */
+  /** CKB display amount or raw integer UDT base units. Defaults to 1. */
   invoiceAmount?: string;
   externalFunding?: FiberNodeButtonExternalFundingConfig;
   renderConnectorSection?: (context: FiberNodeButtonConnectorSectionContext) => ReactNode;

--- a/packages/react/src/fiber-node-button/use-panel-state.ts
+++ b/packages/react/src/fiber-node-button/use-panel-state.ts
@@ -4,8 +4,14 @@ import type {
   GetPaymentResult,
   HexString,
   ShutdownChannelParams,
+  UdtTypeScript,
 } from '@fiber-pay/sdk/browser';
-import { ChannelState, DEFAULT_CKB_ASSET } from '@fiber-pay/sdk/browser';
+import {
+  areUdtTypeScriptsEqual,
+  ChannelState,
+  DEFAULT_CKB_ASSET,
+  validateUdtTypeScript,
+} from '@fiber-pay/sdk/browser';
 import {
   type Dispatch,
   type SetStateAction,
@@ -106,6 +112,13 @@ export interface FiberNodeButtonPanelState {
   connectorContext: FiberNodeButtonConnectorSectionContext;
 }
 
+function getAssetIdentity(asset: FiberNodeButtonPanelProps['asset']): string {
+  if (!asset || asset.kind === 'ckb') {
+    return 'ckb';
+  }
+  return `${asset.script.code_hash}:${asset.script.hash_type}:${asset.script.args}`.toLowerCase();
+}
+
 export function useFiberNodeButtonPanelState(
   props: FiberNodeButtonPanelProps,
 ): FiberNodeButtonPanelState {
@@ -156,6 +169,7 @@ export function useFiberNodeButtonPanelState(
 
   const statusTimerRef = useRef<number | null>(null);
   const mountedRef = useRef(true);
+  const previousAssetIdentityRef = useRef(getAssetIdentity(asset));
   const peerListId = useId();
   const tabPanelId = useId();
 
@@ -164,7 +178,7 @@ export function useFiberNodeButtonPanelState(
     onLog,
   });
 
-  const paymentOptions = useMemo(() => ({ asset }), [asset]);
+  const paymentOptions = useMemo(() => ({ asset, network }), [asset, network]);
 
   const {
     payInvoice,
@@ -176,6 +190,7 @@ export function useFiberNodeButtonPanelState(
   const isNodeReady = fiber.isRunning && !!fiber.node;
 
   useEffect(() => {
+    mountedRef.current = true;
     return () => {
       mountedRef.current = false;
       if (statusTimerRef.current !== null) {
@@ -183,6 +198,20 @@ export function useFiberNodeButtonPanelState(
       }
     };
   }, []);
+
+  useEffect(() => {
+    const nextIdentity = getAssetIdentity(asset);
+    if (previousAssetIdentityRef.current === nextIdentity) {
+      return;
+    }
+
+    previousAssetIdentityRef.current = nextIdentity;
+    setFundingAmount(initialFundingAmount ?? initialFundingAmountCkb ?? '1000');
+    setInvoiceAmount(initialInvoiceAmount ?? '1');
+    setInvoiceInput('');
+    setCreatedInvoice('');
+    setLatestError(null);
+  }, [asset, initialFundingAmount, initialFundingAmountCkb, initialInvoiceAmount]);
 
   const flashStatus = useCallback((text: string, tone: 'info' | 'success' = 'info') => {
     setStatusNotice({ tone, text });
@@ -203,6 +232,31 @@ export function useFiberNodeButtonPanelState(
     },
     [onError, onLog],
   );
+
+  const ensureAssetConfigured = useCallback(() => {
+    if (asset.kind !== 'udt') {
+      return true;
+    }
+
+    let validatedScript: UdtTypeScript;
+    try {
+      validatedScript = validateUdtTypeScript(asset.script);
+    } catch (error) {
+      reportError(error instanceof Error ? error.message : String(error));
+      return false;
+    }
+
+    const configuredUdts = fiber.nodeInfo?.udt_cfg_infos ?? [];
+
+    if (configuredUdts.some((entry) => areUdtTypeScriptsEqual(entry.script, validatedScript))) {
+      return true;
+    }
+
+    reportError(
+      `UDT asset ${asset.name?.trim() || 'UDT'} is not present in the node whitelist. Configure nodeConfig.udtWhitelist with the same type script and cell deps before using it.`,
+    );
+    return false;
+  }, [asset, fiber.nodeInfo?.udt_cfg_infos, reportError]);
 
   const refreshConnectedPeers = useCallback(async () => {
     if (!fiber.node) {
@@ -417,6 +471,10 @@ export function useFiberNodeButtonPanelState(
       return;
     }
 
+    if (!ensureAssetConfigured()) {
+      return;
+    }
+
     channelOpenFlow.reset();
 
     try {
@@ -441,6 +499,8 @@ export function useFiberNodeButtonPanelState(
       const resolved = await externalFunding.resolve({
         node: fiber.node,
         pubkey,
+        asset,
+        fundingAmount,
         fundingAmountCkb: fundingAmount,
       });
 
@@ -470,6 +530,7 @@ export function useFiberNodeButtonPanelState(
     asset,
     channelOpenFlow,
     externalFunding,
+    ensureAssetConfigured,
     fiber.node,
     flashStatus,
     fundingAmount,
@@ -485,10 +546,14 @@ export function useFiberNodeButtonPanelState(
       return;
     }
 
+    if (!ensureAssetConfigured()) {
+      return;
+    }
+
     setIsCreatingInvoice(true);
 
     try {
-      const amountInput = invoiceAmount.trim() || '1';
+      const amountInput = invoiceAmount.trim();
       const params = buildNewInvoiceParams({
         amountInput,
         asset,
@@ -506,17 +571,31 @@ export function useFiberNodeButtonPanelState(
     } finally {
       setIsCreatingInvoice(false);
     }
-  }, [asset, fiber.node, flashStatus, invoiceAmount, network, onLog, reportError]);
+  }, [
+    asset,
+    ensureAssetConfigured,
+    fiber.node,
+    flashStatus,
+    invoiceAmount,
+    network,
+    onLog,
+    reportError,
+  ]);
 
   const submitPayment = useCallback(async () => {
-    if (!invoiceInput.trim()) {
+    const normalizedInvoice = invoiceInput.trim();
+    if (!normalizedInvoice) {
       reportError('Invoice is empty.');
       return;
     }
 
+    if (!ensureAssetConfigured()) {
+      return;
+    }
+
     onLog?.('fiber_panel_primary_action_clicked: pay_invoice');
-    await payInvoice(invoiceInput);
-  }, [invoiceInput, onLog, payInvoice, reportError]);
+    await payInvoice(normalizedInvoice);
+  }, [ensureAssetConfigured, invoiceInput, onLog, payInvoice, reportError]);
 
   useEffect(() => {
     if (!fiber.isRunning || !fiber.node) {

--- a/packages/react/src/fiber-node-button/use-panel-state.ts
+++ b/packages/react/src/fiber-node-button/use-panel-state.ts
@@ -116,6 +116,9 @@ function getAssetIdentity(asset: FiberNodeButtonPanelProps['asset']): string {
   if (!asset || asset.kind === 'ckb') {
     return 'ckb';
   }
+  if (!asset.script) {
+    return 'udt:invalid';
+  }
   return `${asset.script.code_hash}:${asset.script.hash_type}:${asset.script.args}`.toLowerCase();
 }
 

--- a/packages/react/src/fiber-node-button/workbench-tab.tsx
+++ b/packages/react/src/fiber-node-button/workbench-tab.tsx
@@ -30,6 +30,8 @@ export function WorkbenchTab({
   renderAction,
   t,
 }: WorkbenchTabProps) {
+  const assetName = formatAssetName(asset);
+  const amountUnit = asset.kind === 'udt' ? `${assetName} base units` : assetName;
   const {
     isNodeReady,
     connectorContext,
@@ -111,7 +113,7 @@ export function WorkbenchTab({
         </label>
 
         <label style={styles.fieldLabel}>
-          {t('workbench.openChannel.fundingAmount', `Funding Amount (${formatAssetName(asset)})`)}
+          {t('workbench.openChannel.fundingAmount', `Funding Amount (${amountUnit})`)}
           <input
             style={styles.input}
             value={fundingAmount}
@@ -158,7 +160,7 @@ export function WorkbenchTab({
         <h4 style={styles.sectionTitle}>{t('workbench.payments.title', 'Payments')}</h4>
 
         <label style={styles.fieldLabel}>
-          {t('workbench.payments.invoiceAmount', `Invoice Amount (${formatAssetName(asset)})`)}
+          {t('workbench.payments.invoiceAmount', `Invoice Amount (${amountUnit})`)}
           <input
             style={styles.input}
             value={invoiceAmount}
@@ -178,10 +180,10 @@ export function WorkbenchTab({
               id: 'create-invoice',
               label: t(
                 'actions.createInvoice',
-                `Create Invoice (${invoiceAmount || '1'} ${formatAssetName(asset)})`,
+                `Create Invoice (${invoiceAmount || '—'} ${assetName})`,
               ),
               loadingLabel: t('actions.createInvoice.loading', 'Creating...'),
-              disabled: isCreatingInvoice || !isNodeReady,
+              disabled: isCreatingInvoice || !isNodeReady || !invoiceAmount.trim(),
               loading: isCreatingInvoice,
               onTrigger: createInvoice,
             } satisfies FiberNodeButtonActionDefaultProps,

--- a/packages/react/src/fiber-pay-quick-card.tsx
+++ b/packages/react/src/fiber-pay-quick-card.tsx
@@ -47,10 +47,13 @@ export function FiberPayQuickCard(props: FiberPayQuickCardProps) {
   const asset = props.asset ?? DEFAULT_CKB_ASSET;
   const assetUnit = formatAssetName(asset);
   const assetAmountUnit = asset.kind === 'udt' ? `${assetUnit} base units` : assetUnit;
-  const assetIdentity =
-    asset.kind === 'ckb'
-      ? 'ckb'
-      : `${asset.script.code_hash}:${asset.script.hash_type}:${asset.script.args}`.toLowerCase();
+  let assetIdentity = 'ckb';
+  if (asset.kind === 'udt') {
+    const script = asset.script;
+    assetIdentity = script
+      ? `${script.code_hash}:${script.hash_type}:${script.args}`.toLowerCase()
+      : 'udt:invalid';
+  }
   const usesExternalFiber = !!props.fiber;
   const onError = props.onError;
   const onInvoiceCreated = props.onInvoiceCreated;

--- a/packages/react/src/fiber-pay-quick-card.tsx
+++ b/packages/react/src/fiber-pay-quick-card.tsx
@@ -1,6 +1,6 @@
 import type { GetPaymentResult, UdtAsset } from '@fiber-pay/sdk/browser';
 import { DEFAULT_CKB_ASSET, formatAssetName } from '@fiber-pay/sdk/browser';
-import { type CSSProperties, useEffect, useId, useMemo, useState } from 'react';
+import { type CSSProperties, useEffect, useId, useMemo, useRef, useState } from 'react';
 import { buildNewInvoiceParams } from './invoice-params.js';
 import { type UseFiberNodeResult, useFiberNode } from './use-fiber-node.js';
 import { useFiberPayment } from './use-fiber-payment.js';
@@ -13,7 +13,7 @@ export interface FiberPayQuickCardProps {
   passkeyUsername?: string;
   /** Asset for invoices and payments. Defaults to CKB. */
   asset?: UdtAsset;
-  /** Invoice amount in CKB or UDT units. Defaults to 1. */
+  /** CKB display amount or raw integer UDT base units. Defaults to 1. */
   invoiceAmount?: string;
   title?: string;
   className?: string;
@@ -41,11 +41,16 @@ const rowWithMarginStyle: CSSProperties = {
 };
 
 export function FiberPayQuickCard(props: FiberPayQuickCardProps) {
-  const network = props.network ?? 'testnet';
+  const network = props.network ?? props.fiber?.network ?? 'testnet';
   const passkeyUsername = props.passkeyUsername ?? 'User';
   const title = props.title ?? 'FiberPay Quick Card';
   const asset = props.asset ?? DEFAULT_CKB_ASSET;
   const assetUnit = formatAssetName(asset);
+  const assetAmountUnit = asset.kind === 'udt' ? `${assetUnit} base units` : assetUnit;
+  const assetIdentity =
+    asset.kind === 'ckb'
+      ? 'ckb'
+      : `${asset.script.code_hash}:${asset.script.hash_type}:${asset.script.args}`.toLowerCase();
   const usesExternalFiber = !!props.fiber;
   const onError = props.onError;
   const onInvoiceCreated = props.onInvoiceCreated;
@@ -75,7 +80,7 @@ export function FiberPayQuickCard(props: FiberPayQuickCardProps) {
     stop,
   } = fiber;
 
-  const paymentOptions = useMemo(() => ({ asset }), [asset]);
+  const paymentOptions = useMemo(() => ({ asset, network }), [asset, network]);
   const {
     payInvoice,
     isPaying,
@@ -89,6 +94,18 @@ export function FiberPayQuickCard(props: FiberPayQuickCardProps) {
   const [createdInvoice, setCreatedInvoice] = useState('');
   const [isCreatingInvoice, setIsCreatingInvoice] = useState(false);
   const [invoiceError, setInvoiceError] = useState<string | null>(null);
+  const previousAssetIdentityRef = useRef(assetIdentity);
+
+  useEffect(() => {
+    if (previousAssetIdentityRef.current === assetIdentity) {
+      return;
+    }
+    previousAssetIdentityRef.current = assetIdentity;
+    setInvoiceAmountInput(props.invoiceAmount ?? '1');
+    setInvoiceInput('');
+    setCreatedInvoice('');
+    setInvoiceError(null);
+  }, [assetIdentity, props.invoiceAmount]);
 
   useEffect(() => {
     if (nodeError) {
@@ -116,7 +133,7 @@ export function FiberPayQuickCard(props: FiberPayQuickCardProps) {
     setIsCreatingInvoice(true);
     setInvoiceError(null);
     try {
-      const amountInput = invoiceAmountInput.trim() || '1';
+      const amountInput = invoiceAmountInput.trim();
       const params = buildNewInvoiceParams({
         amountInput,
         asset,
@@ -193,17 +210,21 @@ export function FiberPayQuickCard(props: FiberPayQuickCardProps) {
           </p>
 
           <div style={rowWithMarginStyle}>
-            <button type="button" onClick={() => void createInvoice()} disabled={isCreatingInvoice}>
+            <button
+              type="button"
+              onClick={() => void createInvoice()}
+              disabled={isCreatingInvoice || !invoiceAmountInput.trim()}
+            >
               {isCreatingInvoice
                 ? 'Creating...'
-                : `Create Invoice (${invoiceAmountInput || '1'} ${assetUnit})`}
+                : `Create Invoice (${invoiceAmountInput || '—'} ${assetUnit})`}
             </button>
             <button type="button" onClick={() => void stop()}>
               Stop Node
             </button>
           </div>
 
-          <label htmlFor={invoiceAmountInputId}>Invoice Amount ({assetUnit})</label>
+          <label htmlFor={invoiceAmountInputId}>Invoice Amount ({assetAmountUnit})</label>
           <div style={rowWithMarginStyle}>
             <input
               id={invoiceAmountInputId}

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -4,8 +4,12 @@ export type {
   FiberWasmFactory,
   NodeInfoResult,
   PasskeySupportReason,
+  UdtAsset,
+  UdtTypeScript,
+  UdtWhitelistEntry,
 } from '@fiber-pay/sdk/browser';
 export {
+  areUdtTypeScriptsEqual,
   ChannelState,
   ConfigBuilder,
   ckbHash,
@@ -20,8 +24,10 @@ export {
   PasswordCredentialProvider,
   RawKeyCredentialProvider,
   scriptToAddress,
+  serializeUdtTypeScript,
   shannonsToCkb,
   toHex,
+  validateUdtTypeScript,
 } from '@fiber-pay/sdk/browser';
 export type {
   ConnectButtonConnectedDropdownContext,
@@ -59,5 +65,9 @@ export type {
 export { useChannelOpenFlow } from './use-channel-open-flow.js';
 export type { UseFiberNodeOptions, UseFiberNodeResult } from './use-fiber-node.js';
 export { useFiberNode } from './use-fiber-node.js';
-export type { UseFiberPaymentResult } from './use-fiber-payment.js';
+export type {
+  FiberPaymentOptions,
+  UseFiberPaymentOptions,
+  UseFiberPaymentResult,
+} from './use-fiber-payment.js';
 export { useFiberPayment } from './use-fiber-payment.js';

--- a/packages/react/src/invoice-params.ts
+++ b/packages/react/src/invoice-params.ts
@@ -14,7 +14,7 @@ export function buildNewInvoiceParams(options: BuildNewInvoiceParamsOptions): Ne
   const safeAmount = amountInput.replace(/[^\d.]/g, '').slice(0, 32);
   const safeName = (asset.kind === 'udt' ? asset.name?.trim() : 'CKB')?.slice(0, 32) ?? 'UDT';
 
-  const parsedAmount = parsePaymentAmount(amountInput.trim() || '1', asset);
+  const parsedAmount = parsePaymentAmount(amountInput.trim(), asset);
   const params: NewInvoiceParams = {
     amount: `0x${parsedAmount.toString(16)}`,
     currency: network === 'mainnet' ? 'Fibb' : 'Fibt',

--- a/packages/react/src/node-info-panel.tsx
+++ b/packages/react/src/node-info-panel.tsx
@@ -545,7 +545,11 @@ export function NodeInfoPanel(props: NodeInfoPanelProps) {
                   Install qrcode.react for QR code
                 </div>
               )}
-              <span style={styles.qrCaption}>Scan to deposit {stats.balanceUnit}</span>
+              <span style={styles.qrCaption}>
+                {asset.kind === 'udt'
+                  ? `Address only — select ${stats.balanceUnit} in your wallet`
+                  : 'Scan to deposit CKB'}
+              </span>
               <div style={styles.balanceRow}>
                 <span style={{ fontSize: '0.75rem', color: '#6b7280' }}>Balance</span>
                 <span

--- a/packages/react/src/use-channel-open-flow.ts
+++ b/packages/react/src/use-channel-open-flow.ts
@@ -104,12 +104,11 @@ export function useChannelOpenFlow(options: UseChannelOpenFlowOptions): UseChann
       let requestedFundingAmount: bigint | undefined;
       let effectiveFundingLockScript: Script | undefined = params.fundingLockScript;
       const asset = params.asset ?? DEFAULT_CKB_ASSET;
-      if (asset.kind === 'udt') {
-        validateUdtTypeScript(asset.script);
-      }
       const fundingAmountInput = params.fundingAmount?.trim() || params.fundingAmountCkb?.trim();
 
       try {
+        const validatedUdtScript =
+          asset.kind === 'udt' ? validateUdtTypeScript(asset.script) : undefined;
         if (!fundingAmountInput) {
           throw new Error('Funding amount is required.');
         }
@@ -122,8 +121,8 @@ export function useChannelOpenFlow(options: UseChannelOpenFlowOptions): UseChann
             pubkey,
             funding_amount: fundingAmountHex,
           };
-          if (asset.kind === 'udt') {
-            openChannelParams.funding_udt_type_script = asset.script;
+          if (validatedUdtScript) {
+            openChannelParams.funding_udt_type_script = validatedUdtScript;
           }
           const openResult = await node.openChannel(openChannelParams);
           const result: ChannelOpenFlowResult = {
@@ -152,7 +151,7 @@ export function useChannelOpenFlow(options: UseChannelOpenFlowOptions): UseChann
             shutdown_script: shutdownScript,
             funding_lock_script: effectiveFundingLockScript,
             funding_lock_script_cell_deps: params.fundingLockScriptCellDeps,
-            ...(asset.kind === 'udt' ? { funding_udt_type_script: asset.script } : {}),
+            ...(validatedUdtScript ? { funding_udt_type_script: validatedUdtScript } : {}),
           },
           signFundingTx: params.signFundingTx,
         });

--- a/packages/react/src/use-fiber-node.ts
+++ b/packages/react/src/use-fiber-node.ts
@@ -24,6 +24,8 @@ export interface UseFiberNodeOptions {
 }
 
 export interface UseFiberNodeResult {
+  /** Network used by this node. Exposed so composed components do not need duplicate config. */
+  network?: 'testnet' | 'mainnet';
   state: BrowserNodeState;
   node: FiberBrowserNode | null;
   nodeInfo: NodeInfoResult | null;
@@ -369,6 +371,7 @@ export function useFiberNode(options: UseFiberNodeOptions): UseFiberNodeResult {
   const isRunning = useMemo(() => state === 'running', [state]);
 
   return {
+    network: options.network,
     state,
     node: nodeRef.current,
     nodeInfo,

--- a/packages/react/src/use-fiber-payment.ts
+++ b/packages/react/src/use-fiber-payment.ts
@@ -4,6 +4,7 @@ import {
   type ParseInvoiceResult,
   type PaymentHash,
   type SendPaymentResult,
+  serializeUdtTypeScript,
   type UdtAsset,
   validateUdtTypeScript,
 } from '@fiber-pay/sdk/browser';
@@ -11,9 +12,9 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 
 export interface UseFiberPaymentResult {
   parseInvoice: (invoice: string) => Promise<ParseInvoiceResult>;
-  sendPayment: (invoice: string, options?: { asset?: UdtAsset }) => Promise<SendPaymentResult>;
+  sendPayment: (invoice: string, options?: FiberPaymentOptions) => Promise<SendPaymentResult>;
   waitForPayment: (paymentHash: PaymentHash) => Promise<GetPaymentResult>;
-  payInvoice: (invoice: string, options?: { asset?: UdtAsset }) => Promise<void>;
+  payInvoice: (invoice: string, options?: FiberPaymentOptions) => Promise<void>;
   isPaying: boolean;
   paymentResult: GetPaymentResult | null;
   error: string | null;
@@ -28,6 +29,60 @@ function asErrorMessage(error: unknown): string {
 
 export interface UseFiberPaymentOptions {
   asset?: UdtAsset;
+  network?: 'testnet' | 'mainnet';
+}
+
+export type FiberPaymentOptions = UseFiberPaymentOptions;
+
+function getPaymentContextKey(options: UseFiberPaymentOptions): string {
+  const asset = options.asset;
+  const assetKey =
+    !asset || asset.kind === 'ckb'
+      ? 'ckb'
+      : `${asset.script.code_hash}:${asset.script.hash_type}:${asset.script.args}`.toLowerCase();
+  return `${options.network ?? 'unknown'}:${assetKey}`;
+}
+
+function getInvoiceUdtScript(parsed: ParseInvoiceResult): string | null {
+  for (const attribute of parsed.invoice.data.attrs ?? []) {
+    const record = attribute as unknown as Record<string, unknown>;
+    const value = record.udt_script ?? record.UdtScript;
+    if (typeof value === 'string') {
+      return value.toLowerCase();
+    }
+  }
+  return null;
+}
+
+function validateInvoiceContext(parsed: ParseInvoiceResult, options: FiberPaymentOptions): void {
+  const asset = options.asset ?? { kind: 'ckb' as const };
+  const invoiceUdtScript = getInvoiceUdtScript(parsed);
+
+  if (options.network && parsed.invoice.currency) {
+    const expectedCurrency = options.network === 'mainnet' ? 'Fibb' : 'Fibt';
+    if (parsed.invoice.currency !== expectedCurrency) {
+      throw new Error(
+        `Invoice network mismatch: expected ${expectedCurrency}, received ${parsed.invoice.currency}`,
+      );
+    }
+  }
+
+  if (asset.kind === 'udt') {
+    if (!invoiceUdtScript) {
+      throw new Error('Invoice asset mismatch: expected a UDT invoice, received CKB');
+    }
+    const expectedScript = serializeUdtTypeScript(asset.script).toLowerCase();
+    if (invoiceUdtScript !== expectedScript) {
+      throw new Error(
+        'Invoice asset mismatch: UDT type script does not match the configured asset',
+      );
+    }
+    return;
+  }
+
+  if (invoiceUdtScript) {
+    throw new Error('Invoice asset mismatch: expected CKB, received a UDT invoice');
+  }
 }
 
 export function useFiberPayment(
@@ -39,15 +94,30 @@ export function useFiberPayment(
   const [error, setError] = useState<string | null>(null);
   const isMountedRef = useRef(true);
   const optionsRef = useRef(options);
+  const previousContextKeyRef = useRef(getPaymentContextKey(options));
+  const contextGenerationRef = useRef(0);
+  const contextKey = getPaymentContextKey(options);
 
   useEffect(() => {
     optionsRef.current = options;
-  }, [options]);
+    if (previousContextKeyRef.current !== contextKey) {
+      previousContextKeyRef.current = contextKey;
+      contextGenerationRef.current += 1;
+      setIsPaying(false);
+      setPaymentResult(null);
+      setError(null);
+    }
+  }, [contextKey, options]);
 
-  useEffect(
-    () => () => {
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
       isMountedRef.current = false;
-    },
+    };
+  }, []);
+
+  const canCommitState = useCallback(
+    (generation: number) => isMountedRef.current && generation === contextGenerationRef.current,
     [],
   );
 
@@ -62,20 +132,28 @@ export function useFiberPayment(
   const parseInvoiceInternal = useCallback(
     async (invoice: string) => {
       const activeNode = ensureNode();
-      return activeNode.parseInvoice({ invoice });
+      const normalizedInvoice = invoice.trim();
+      if (!normalizedInvoice) {
+        throw new Error('Invoice is empty');
+      }
+      return activeNode.parseInvoice({ invoice: normalizedInvoice });
     },
     [ensureNode],
   );
 
   const sendPaymentInternal = useCallback(
-    async (invoice: string, paymentOptions?: { asset?: UdtAsset }) => {
+    async (invoice: string, paymentOptions?: FiberPaymentOptions) => {
       const activeNode = ensureNode();
+      const normalizedInvoice = invoice.trim();
+      if (!normalizedInvoice) {
+        throw new Error('Invoice is empty');
+      }
       const asset = paymentOptions?.asset ?? optionsRef.current.asset;
       if (asset?.kind === 'udt') {
         const script = validateUdtTypeScript(asset.script);
-        return activeNode.sendPayment({ invoice, udt_type_script: script });
+        return activeNode.sendPayment({ invoice: normalizedInvoice, udt_type_script: script });
       }
-      return activeNode.sendPayment({ invoice });
+      return activeNode.sendPayment({ invoice: normalizedInvoice });
     },
     [ensureNode],
   );
@@ -90,25 +168,27 @@ export function useFiberPayment(
 
   const parseInvoice = useCallback(
     async (invoice: string) => {
-      if (isMountedRef.current) {
+      const generation = contextGenerationRef.current;
+      if (canCommitState(generation)) {
         setError(null);
       }
 
       try {
         return await parseInvoiceInternal(invoice);
       } catch (parseError) {
-        if (isMountedRef.current) {
+        if (canCommitState(generation)) {
           setError(asErrorMessage(parseError));
         }
         throw parseError;
       }
     },
-    [parseInvoiceInternal],
+    [canCommitState, parseInvoiceInternal],
   );
 
   const sendPayment = useCallback(
-    async (invoice: string, paymentOptions?: { asset?: UdtAsset }) => {
-      if (isMountedRef.current) {
+    async (invoice: string, paymentOptions?: FiberPaymentOptions) => {
+      const generation = contextGenerationRef.current;
+      if (canCommitState(generation)) {
         setIsPaying(true);
         setError(null);
         setPaymentResult(null);
@@ -117,22 +197,23 @@ export function useFiberPayment(
       try {
         return await sendPaymentInternal(invoice, paymentOptions);
       } catch (sendError) {
-        if (isMountedRef.current) {
+        if (canCommitState(generation)) {
           setError(asErrorMessage(sendError));
         }
         throw sendError;
       } finally {
-        if (isMountedRef.current) {
+        if (canCommitState(generation)) {
           setIsPaying(false);
         }
       }
     },
-    [sendPaymentInternal],
+    [canCommitState, sendPaymentInternal],
   );
 
   const waitForPayment = useCallback(
     async (paymentHash: PaymentHash) => {
-      if (isMountedRef.current) {
+      const generation = contextGenerationRef.current;
+      if (canCommitState(generation)) {
         setIsPaying(true);
         setError(null);
         setPaymentResult(null);
@@ -140,27 +221,28 @@ export function useFiberPayment(
 
       try {
         const result = await waitForPaymentInternal(paymentHash);
-        if (isMountedRef.current) {
+        if (canCommitState(generation)) {
           setPaymentResult(result);
         }
         return result;
       } catch (waitError) {
-        if (isMountedRef.current) {
+        if (canCommitState(generation)) {
           setError(asErrorMessage(waitError));
         }
         throw waitError;
       } finally {
-        if (isMountedRef.current) {
+        if (canCommitState(generation)) {
           setIsPaying(false);
         }
       }
     },
-    [waitForPaymentInternal],
+    [canCommitState, waitForPaymentInternal],
   );
 
   const payInvoice = useCallback(
-    async (invoice: string, paymentOptions?: { asset?: UdtAsset }) => {
-      if (isMountedRef.current) {
+    async (invoice: string, paymentOptions?: FiberPaymentOptions) => {
+      const generation = contextGenerationRef.current;
+      if (canCommitState(generation)) {
         setIsPaying(true);
         setError(null);
         setPaymentResult(null);
@@ -168,6 +250,8 @@ export function useFiberPayment(
 
       try {
         const parsed = await parseInvoiceInternal(invoice);
+        const effectiveOptions = { ...optionsRef.current, ...paymentOptions };
+        validateInvoiceContext(parsed, effectiveOptions);
         await sendPaymentInternal(invoice, paymentOptions);
 
         const paymentHash = parsed.invoice.data.payment_hash;
@@ -177,20 +261,20 @@ export function useFiberPayment(
           throw new Error(result.failed_error ?? 'Payment failed during routing/execution');
         }
 
-        if (isMountedRef.current) {
+        if (canCommitState(generation)) {
           setPaymentResult(result);
         }
       } catch (payError) {
-        if (isMountedRef.current) {
+        if (canCommitState(generation)) {
           setError(asErrorMessage(payError));
         }
       } finally {
-        if (isMountedRef.current) {
+        if (canCommitState(generation)) {
           setIsPaying(false);
         }
       }
     },
-    [parseInvoiceInternal, sendPaymentInternal, waitForPaymentInternal],
+    [canCommitState, parseInvoiceInternal, sendPaymentInternal, waitForPaymentInternal],
   );
 
   return {

--- a/packages/react/src/use-fiber-payment.ts
+++ b/packages/react/src/use-fiber-payment.ts
@@ -36,16 +36,22 @@ export type FiberPaymentOptions = UseFiberPaymentOptions;
 
 function getPaymentContextKey(options: UseFiberPaymentOptions): string {
   const asset = options.asset;
-  const assetKey =
-    !asset || asset.kind === 'ckb'
-      ? 'ckb'
-      : `${asset.script.code_hash}:${asset.script.hash_type}:${asset.script.args}`.toLowerCase();
+  let assetKey = 'ckb';
+  if (asset?.kind === 'udt') {
+    const script = asset.script;
+    assetKey = script
+      ? `${script.code_hash}:${script.hash_type}:${script.args}`.toLowerCase()
+      : 'udt:invalid';
+  }
   return `${options.network ?? 'unknown'}:${assetKey}`;
 }
 
 function getInvoiceUdtScript(parsed: ParseInvoiceResult): string | null {
   for (const attribute of parsed.invoice.data.attrs ?? []) {
-    const record = attribute as unknown as Record<string, unknown>;
+    if (!attribute || typeof attribute !== 'object') {
+      continue;
+    }
+    const record = attribute as Record<string, unknown>;
     const value = record.udt_script ?? record.UdtScript;
     if (typeof value === 'string') {
       return value.toLowerCase();

--- a/packages/react/tests/connect-button.test.tsx
+++ b/packages/react/tests/connect-button.test.tsx
@@ -92,6 +92,12 @@ describe('ConnectButton', () => {
       node: {} as UseFiberNodeResult['node'],
       nodeInfo: { pubkey: '0x0123456789abcdef0123456789abcdef' } as UseFiberNodeResult['nodeInfo'],
     });
+    const runningWithoutInfo = createFiberMock({
+      state: 'running',
+      isRunning: true,
+      node: {} as UseFiberNodeResult['node'],
+      nodeInfo: null,
+    });
 
     const { rerender } = render(
       <ConnectButton
@@ -101,6 +107,17 @@ describe('ConnectButton', () => {
         onDisconnect={onDisconnect}
       />,
     );
+
+    rerender(
+      <ConnectButton
+        fiber={runningWithoutInfo}
+        strategy="passkey"
+        onConnect={onConnect}
+        onDisconnect={onDisconnect}
+      />,
+    );
+
+    expect(onConnect).not.toHaveBeenCalled();
 
     rerender(
       <ConnectButton
@@ -171,5 +188,43 @@ describe('ConnectButton', () => {
     render(<ConnectButton fiber={fiber} strategy="passkey" asset={asset} />);
     fireEvent.click(screen.getByRole('button'));
     expect(screen.getByText('UDT')).toBeTruthy();
+  });
+
+  it('preserves custom panel state when the dropdown is closed and reopened', () => {
+    const fiber = createFiberMock({
+      state: 'running',
+      isRunning: true,
+      node: {} as UseFiberNodeResult['node'],
+      nodeInfo: { pubkey: '0x0123456789abcdef0123456789abcdef' } as UseFiberNodeResult['nodeInfo'],
+    });
+
+    render(
+      <ConnectButton
+        fiber={fiber}
+        strategy="passkey"
+        renderConnectedDropdown={({ closeDropdown }) => (
+          <>
+            <input aria-label="Persistent value" />
+            <button type="button" onClick={closeDropdown}>
+              Close custom panel
+            </button>
+          </>
+        )}
+      />,
+    );
+
+    const toggle = screen.getByRole('button', { name: /0x012345/i });
+    fireEvent.click(toggle);
+    const input = screen.getByRole('textbox', { name: 'Persistent value' });
+    fireEvent.change(input, { target: { value: 'in-flight invoice' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Close custom panel' }));
+
+    expect(screen.queryByRole('dialog', { name: 'Connection panel' })).toBeNull();
+
+    fireEvent.click(toggle);
+    expect(screen.getByRole('textbox', { name: 'Persistent value' })).toHaveProperty(
+      'value',
+      'in-flight invoice',
+    );
   });
 });

--- a/packages/react/tests/fiber-node-button.test.tsx
+++ b/packages/react/tests/fiber-node-button.test.tsx
@@ -1,6 +1,7 @@
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { ChannelState } from '@fiber-pay/sdk/browser';
+import { ChannelState, serializeUdtTypeScript } from '@fiber-pay/sdk/browser';
+import { StrictMode } from 'react';
 import { FiberNodeButton } from '../src/fiber-node-button.js';
 import type { UseFiberNodeResult } from '../src/use-fiber-node.js';
 import { validUdtScript } from './fixtures/udt.js';
@@ -18,8 +19,11 @@ function createNodeMock() {
     connectPeer: vi.fn(async () => ({})),
     shutdownChannel: vi.fn(async () => ({})),
     abandonChannel: vi.fn(async () => ({})),
+    openChannel: vi.fn(async () => ({ temporary_channel_id: '0xtemporary' })),
     newInvoice: vi.fn(async () => ({ invoice_address: 'ln-fake-invoice' })),
-    parseInvoice: vi.fn(async () => ({ invoice: { data: { payment_hash: '0x1' } } })),
+    parseInvoice: vi.fn(async () => ({
+      invoice: { currency: 'Fibt', data: { payment_hash: '0x1', attrs: [] } },
+    })),
     sendPayment: vi.fn(async () => ({})),
     waitForPayment: vi.fn(async () => ({ status: 'Succeeded' })),
   };
@@ -46,6 +50,30 @@ function createFiberMock(overrides: Partial<UseFiberNodeResult> = {}): UseFiberN
   };
 }
 
+function createUdtChannel(script = validUdtScript) {
+  return {
+    channel_id: '0xchannel',
+    is_public: false,
+    is_acceptor: false,
+    is_one_way: false,
+    channel_outpoint: null,
+    pubkey: '0xpeer',
+    funding_udt_type_script: script,
+    state: { state_name: ChannelState.ChannelReady },
+    local_balance: '0x64',
+    offered_tlc_balance: '0x0',
+    remote_balance: '0x32',
+    received_tlc_balance: '0x0',
+    pending_tlcs: [],
+    latest_commitment_transaction_hash: null,
+    created_at: '0x1',
+    enabled: true,
+    tlc_expiry_delta: '0x0',
+    tlc_fee_proportional_millionths: '0x0',
+    shutdown_transaction_hash: null,
+  };
+}
+
 describe('FiberNodeButton', () => {
   it('renders as a connect button when disconnected', () => {
     const fiber = createFiberMock();
@@ -61,7 +89,10 @@ describe('FiberNodeButton', () => {
       state: 'running',
       isRunning: true,
       node: node as unknown as UseFiberNodeResult['node'],
-      nodeInfo: { pubkey: '0x0123456789abcdef0123456789abcdef' } as UseFiberNodeResult['nodeInfo'],
+      nodeInfo: {
+        pubkey: '0x0123456789abcdef0123456789abcdef',
+        udt_cfg_infos: [{ script: validUdtScript }],
+      } as UseFiberNodeResult['nodeInfo'],
     });
 
     render(
@@ -93,6 +124,45 @@ describe('FiberNodeButton', () => {
 
     await waitFor(() => {
       expect(node.graphNodes).toHaveBeenCalled();
+    });
+  });
+
+  it('loads and renders panel data in React StrictMode', async () => {
+    const node = createNodeMock();
+    node.listChannels = vi.fn(async () => ({
+      channels: [
+        {
+          channel_id: '0xstrict',
+          pubkey: '0xpeer',
+          funding_udt_type_script: null,
+          state: { state_name: ChannelState.ChannelReady },
+          local_balance: '0x5f5e100',
+          remote_balance: '0x5f5e100',
+          pending_tlcs: [],
+        },
+      ],
+    }));
+    const fiber = createFiberMock({
+      state: 'running',
+      isRunning: true,
+      node: node as unknown as UseFiberNodeResult['node'],
+      nodeInfo: {
+        pubkey: '0x0123456789abcdef0123456789abcdef',
+        udt_cfg_infos: [{ script: validUdtScript }],
+      } as UseFiberNodeResult['nodeInfo'],
+    });
+
+    render(
+      <StrictMode>
+        <FiberNodeButton fiber={fiber} strategy="passkey" />
+      </StrictMode>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /0x012345/i }));
+    fireEvent.click(screen.getByRole('tab', { name: 'Channels' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'active (1)' })).toBeTruthy();
     });
   });
 
@@ -161,7 +231,10 @@ describe('FiberNodeButton', () => {
       state: 'running',
       isRunning: true,
       node: node as unknown as UseFiberNodeResult['node'],
-      nodeInfo: { pubkey: '0x0123456789abcdef0123456789abcdef' } as UseFiberNodeResult['nodeInfo'],
+      nodeInfo: {
+        pubkey: '0x0123456789abcdef0123456789abcdef',
+        udt_cfg_infos: [{ script: validUdtScript }],
+      } as UseFiberNodeResult['nodeInfo'],
     });
 
     render(
@@ -191,34 +264,190 @@ describe('FiberNodeButton', () => {
     });
   });
 
+  it('opens a UDT channel and pays a matching UDT invoice from the high-level panel', async () => {
+    const node = createNodeMock();
+    node.parseInvoice = vi.fn(async () => ({
+      invoice: {
+        currency: 'Fibt',
+        data: {
+          payment_hash: '0x1',
+          attrs: [{ udt_script: serializeUdtTypeScript(validUdtScript) }],
+        },
+      },
+    }));
+    const fiber = createFiberMock({
+      state: 'running',
+      isRunning: true,
+      node: node as unknown as UseFiberNodeResult['node'],
+      nodeInfo: {
+        pubkey: '0x0123456789abcdef0123456789abcdef',
+        udt_cfg_infos: [{ script: validUdtScript }],
+      } as UseFiberNodeResult['nodeInfo'],
+    });
+
+    render(
+      <FiberNodeButton
+        fiber={fiber}
+        strategy="passkey"
+        asset={{ kind: 'udt', script: validUdtScript, name: 'RUSD' }}
+        initialPeerPubkey="0xpeer"
+        initialFundingAmount="100"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /0x012345/i }));
+    fireEvent.click(screen.getByRole('button', { name: 'Open Channel' }));
+
+    await waitFor(() => {
+      expect(node.openChannel).toHaveBeenCalledWith({
+        pubkey: '0xpeer',
+        funding_amount: '0x64',
+        funding_udt_type_script: validUdtScript,
+      });
+    });
+
+    fireEvent.change(screen.getByLabelText('Invoice'), { target: { value: '  ln-udt  ' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Pay Invoice' }));
+
+    await waitFor(() => {
+      expect(node.sendPayment).toHaveBeenCalledWith({
+        invoice: 'ln-udt',
+        udt_type_script: validUdtScript,
+      });
+      expect(screen.getByText('Status: Succeeded')).toBeTruthy();
+    });
+  });
+
+  it('recovers the Open Channel action after an invalid UDT script error', async () => {
+    const node = createNodeMock();
+    const onError = vi.fn();
+    const fiber = createFiberMock({
+      state: 'running',
+      isRunning: true,
+      node: node as unknown as UseFiberNodeResult['node'],
+      nodeInfo: { pubkey: '0x0123456789abcdef0123456789abcdef' } as UseFiberNodeResult['nodeInfo'],
+    });
+
+    render(
+      <FiberNodeButton
+        fiber={fiber}
+        strategy="passkey"
+        asset={{ kind: 'udt', script: { ...validUdtScript, code_hash: '0x00' } }}
+        initialPeerPubkey="0xpeer"
+        onError={onError}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /0x012345/i }));
+    fireEvent.click(screen.getByRole('button', { name: 'Open Channel' }));
+
+    await waitFor(() => {
+      expect(onError).toHaveBeenCalledWith(expect.stringContaining('code_hash must be 66'));
+      expect(screen.getByRole('button', { name: 'Open Channel' }).hasAttribute('disabled')).toBe(
+        false,
+      );
+    });
+    expect(node.openChannel).not.toHaveBeenCalled();
+  });
+
+  it('reports an actionable error when the UDT is absent from the node whitelist', async () => {
+    const node = createNodeMock();
+    const onError = vi.fn();
+    const fiber = createFiberMock({
+      state: 'running',
+      isRunning: true,
+      node: node as unknown as UseFiberNodeResult['node'],
+      nodeInfo: {
+        pubkey: '0x0123456789abcdef0123456789abcdef',
+        udt_cfg_infos: [],
+      } as unknown as UseFiberNodeResult['nodeInfo'],
+    });
+
+    render(
+      <FiberNodeButton
+        fiber={fiber}
+        strategy="passkey"
+        asset={{ kind: 'udt', script: validUdtScript, name: 'RUSD' }}
+        initialPeerPubkey="0xpeer"
+        onError={onError}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /0x012345/i }));
+    fireEvent.click(screen.getByRole('button', { name: 'Open Channel' }));
+
+    await waitFor(() => {
+      expect(onError).toHaveBeenCalledWith(
+        expect.stringContaining('not present in the node whitelist'),
+      );
+    });
+    expect(node.openChannel).not.toHaveBeenCalled();
+  });
+
+  it('passes asset-aware amounts to external funding resolvers', async () => {
+    const node = createNodeMock();
+    const asset = { kind: 'udt' as const, script: validUdtScript, name: 'RUSD' };
+    const resolve = vi.fn(async () => {
+      throw new Error('stop after context capture');
+    });
+    const fiber = createFiberMock({
+      state: 'running',
+      isRunning: true,
+      node: node as unknown as UseFiberNodeResult['node'],
+      nodeInfo: {
+        pubkey: '0x0123456789abcdef0123456789abcdef',
+        udt_cfg_infos: [{ script: validUdtScript }],
+      } as UseFiberNodeResult['nodeInfo'],
+    });
+
+    render(
+      <FiberNodeButton
+        fiber={fiber}
+        strategy="passkey"
+        asset={asset}
+        initialPeerPubkey="0xpeer"
+        initialFundingAmount="500"
+        externalFunding={{ enabled: true, resolve }}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /0x012345/i }));
+    fireEvent.click(screen.getByRole('button', { name: 'Open Channel' }));
+
+    await waitFor(() => {
+      expect(resolve).toHaveBeenCalledWith(
+        expect.objectContaining({
+          node,
+          pubkey: '0xpeer',
+          asset,
+          fundingAmount: '500',
+          fundingAmountCkb: '500',
+        }),
+      );
+    });
+  });
+
+  it('uses the shared fiber network when creating invoices', async () => {
+    const node = createNodeMock();
+    const fiber = createFiberMock({
+      network: 'mainnet',
+      state: 'running',
+      isRunning: true,
+      node: node as unknown as UseFiberNodeResult['node'],
+      nodeInfo: { pubkey: '0x0123456789abcdef0123456789abcdef' } as UseFiberNodeResult['nodeInfo'],
+    });
+
+    render(<FiberNodeButton fiber={fiber} strategy="passkey" invoiceAmount="2" />);
+    fireEvent.click(screen.getByRole('button', { name: /0x012345/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Create Invoice/i }));
+
+    await waitFor(() => {
+      expect(node.newInvoice).toHaveBeenCalledWith(
+        expect.objectContaining({ currency: 'Fibb', amount: '0xbebc200' }),
+      );
+    });
+  });
+
   it('shows UDT unit for channels with funding_udt_type_script', async () => {
-    const udtChannel = {
-      channel_id: '0xchannel',
-      is_public: false,
-      is_acceptor: false,
-      is_one_way: false,
-      channel_outpoint: null,
-      pubkey: '0xpeer',
-      funding_udt_type_script: {
-        code_hash: '0x1142755a044bf2ee358cba9f2da187ce928c91cd4dc8692ded0337efa677d21a',
-        hash_type: 'type',
-        args: '0x00',
-      },
-      state: {
-        state_name: ChannelState.ChannelReady,
-      },
-      local_balance: '0x64',
-      offered_tlc_balance: '0x0',
-      remote_balance: '0x32',
-      received_tlc_balance: '0x0',
-      pending_tlcs: [],
-      latest_commitment_transaction_hash: null,
-      created_at: '0x1',
-      enabled: true,
-      tlc_expiry_delta: '0x0',
-      tlc_fee_proportional_millionths: '0x0',
-      shutdown_transaction_hash: null,
-    };
+    const udtChannel = createUdtChannel();
 
     const node = createNodeMock();
     node.listChannels = vi.fn(async () => ({ channels: [udtChannel] }));
@@ -230,19 +459,51 @@ describe('FiberNodeButton', () => {
       nodeInfo: { pubkey: '0x0123456789abcdef0123456789abcdef' } as UseFiberNodeResult['nodeInfo'],
     });
 
-    render(<FiberNodeButton fiber={fiber} strategy="passkey" asset={{ kind: 'udt', script: udtChannel.funding_udt_type_script }} />);
+    render(
+      <FiberNodeButton
+        fiber={fiber}
+        strategy="passkey"
+        asset={{ kind: 'udt', script: udtChannel.funding_udt_type_script, name: 'RUSD' }}
+      />,
+    );
 
     fireEvent.click(screen.getByRole('button', { name: /0x012345/i }));
     fireEvent.click(screen.getByRole('tab', { name: 'Channels' }));
 
     await waitFor(() => {
-      expect(screen.getAllByText(/\b100 UDT\b/).length).toBeGreaterThan(0);
+      expect(screen.getAllByText(/\b100 RUSD\b/).length).toBeGreaterThan(0);
     });
-
-    fireEvent.click(screen.getAllByText(/\b100 UDT\b/)[0]);
 
     await waitFor(() => {
-      expect(screen.getAllByText(/\b50 UDT\b/).length).toBeGreaterThan(0);
+      expect(screen.getByText(/Local 100 RUSD/)).toBeTruthy();
+      expect(screen.getByText(/Remote 50 RUSD/)).toBeTruthy();
     });
+  });
+
+  it('does not label a different UDT channel with the configured asset name', async () => {
+    const udtChannel = createUdtChannel({ ...validUdtScript, args: '0x01' });
+    const node = createNodeMock();
+    node.listChannels = vi.fn(async () => ({ channels: [udtChannel] }));
+    const fiber = createFiberMock({
+      state: 'running',
+      isRunning: true,
+      node: node as unknown as UseFiberNodeResult['node'],
+      nodeInfo: { pubkey: '0x0123456789abcdef0123456789abcdef' } as UseFiberNodeResult['nodeInfo'],
+    });
+
+    render(
+      <FiberNodeButton
+        fiber={fiber}
+        strategy="passkey"
+        asset={{ kind: 'udt', script: validUdtScript, name: 'RUSD' }}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /0x012345/i }));
+    fireEvent.click(screen.getByRole('tab', { name: 'Channels' }));
+
+    await waitFor(() => {
+      expect(screen.getAllByText(/UDT · 0x114275/).length).toBeGreaterThan(0);
+    });
+    expect(screen.queryByText(/100 RUSD/)).toBeNull();
   });
 });

--- a/packages/react/tests/fiber-pay-quick-card.test.tsx
+++ b/packages/react/tests/fiber-pay-quick-card.test.tsx
@@ -1,5 +1,6 @@
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { serializeUdtTypeScript } from '@fiber-pay/sdk/browser';
 import { FiberPayQuickCard } from '../src/fiber-pay-quick-card.js';
 import type { UseFiberNodeResult } from '../src/use-fiber-node.js';
 import { validUdtScript } from './fixtures/udt.js';
@@ -45,7 +46,12 @@ describe('FiberPayQuickCard', () => {
       isRunning: true,
       node: {
         newInvoice: vi.fn(async () => ({ invoice_address: 'ln-fake' })),
-        parseInvoice: vi.fn(async () => ({ invoice: { data: { payment_hash: '0x1' } } })),
+        parseInvoice: vi.fn(async () => ({
+          invoice: {
+            currency: 'Fibt',
+            data: { payment_hash: '0x1', attrs: [] },
+          },
+        })),
         sendPayment: vi.fn(async () => ({})),
         waitForPayment: vi.fn(async () => ({ status: 'Succeeded' })),
       } as unknown as UseFiberNodeResult['node'],
@@ -66,7 +72,15 @@ describe('FiberPayQuickCard', () => {
       isRunning: true,
       node: {
         newInvoice,
-        parseInvoice: vi.fn(async () => ({ invoice: { data: { payment_hash: '0x1' } } })),
+        parseInvoice: vi.fn(async () => ({
+          invoice: {
+            currency: 'Fibt',
+            data: {
+              payment_hash: '0x1',
+              attrs: [{ udt_script: serializeUdtTypeScript(validUdtScript) }],
+            },
+          },
+        })),
         sendPayment,
         waitForPayment: vi.fn(async () => ({ status: 'Succeeded' })),
       } as unknown as UseFiberNodeResult['node'],

--- a/packages/react/tests/node-info-panel.test.tsx
+++ b/packages/react/tests/node-info-panel.test.tsx
@@ -48,8 +48,7 @@ describe('NodeInfoPanel', () => {
           objects: [
             {
               output: { capacity: '0x0' },
-              output_data:
-                '0x10270000000000000000000000000000',
+              output_data: '0x10270000000000000000000000000000',
             },
           ],
           last_cursor: '0x',
@@ -73,7 +72,7 @@ describe('NodeInfoPanel', () => {
     });
 
     expect(fetchSpy).toHaveBeenCalled();
-    expect(screen.getByText(/Scan to deposit/).textContent).toContain('RUSD');
+    expect(screen.getByText(/Address only/).textContent).toContain('select RUSD');
   });
 
   it('falls back to generic UDT label when name is not provided', async () => {
@@ -106,6 +105,6 @@ describe('NodeInfoPanel', () => {
       expect(screen.getByText(/0 UDT/)).toBeTruthy();
     });
 
-    expect(screen.getByText(/Scan to deposit/).textContent).toContain('UDT');
+    expect(screen.getByText(/Address only/).textContent).toContain('select UDT');
   });
 });

--- a/packages/react/tests/use-channel-open-flow.test.ts
+++ b/packages/react/tests/use-channel-open-flow.test.ts
@@ -1,0 +1,34 @@
+import { act, cleanup, renderHook } from '@testing-library/react';
+import type { IFiberClient } from '@fiber-pay/sdk/browser';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { useChannelOpenFlow } from '../src/use-channel-open-flow.js';
+import { validUdtScript } from './fixtures/udt.js';
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('useChannelOpenFlow', () => {
+  it('recovers from invalid UDT configuration instead of remaining in the opening state', async () => {
+    const openChannel = vi.fn();
+    const node = { openChannel } as unknown as IFiberClient;
+    const { result } = renderHook(() => useChannelOpenFlow({ node }));
+
+    await act(async () => {
+      const opened = await result.current.openChannel({
+        pubkey: '0x01',
+        fundingAmount: '100',
+        externalWallet: false,
+        asset: {
+          kind: 'udt',
+          script: { ...validUdtScript, code_hash: '0x00' },
+        },
+      });
+      expect(opened).toBeNull();
+    });
+
+    expect(result.current.isOpening).toBe(false);
+    expect(result.current.error).toContain('code_hash');
+    expect(openChannel).not.toHaveBeenCalled();
+  });
+});

--- a/packages/react/tests/use-fiber-payment.test.ts
+++ b/packages/react/tests/use-fiber-payment.test.ts
@@ -104,6 +104,24 @@ describe('useFiberPayment', () => {
     expect(result.current.error).toBeNull();
   });
 
+  it('ignores malformed invoice attributes without crashing', async () => {
+    const node = createNodeMock({
+      parseInvoice: vi.fn(async () => ({
+        invoice: {
+          data: { payment_hash: '0xabc', attrs: [null, 'invalid'] as never[] },
+        },
+      })),
+    });
+    const { result } = renderHook(() => useFiberPayment(node, { asset: { kind: 'ckb' } }));
+
+    await act(async () => {
+      await result.current.payInvoice('ln-malformed-attrs');
+    });
+
+    expect(node.sendPayment).toHaveBeenCalledWith({ invoice: 'ln-malformed-attrs' });
+    expect(result.current.paymentResult?.status).toBe('Succeeded');
+  });
+
   it('keeps payment state updates working in React StrictMode', async () => {
     const node = createNodeMock();
     const { result } = renderHook(() => useFiberPayment(node), { wrapper: strictModeWrapper });

--- a/packages/react/tests/use-fiber-payment.test.ts
+++ b/packages/react/tests/use-fiber-payment.test.ts
@@ -1,5 +1,10 @@
 import { act, cleanup, renderHook } from '@testing-library/react';
-import type { FiberBrowserNode } from '@fiber-pay/sdk/browser';
+import {
+  serializeUdtTypeScript,
+  type FiberBrowserNode,
+  type UdtAsset,
+} from '@fiber-pay/sdk/browser';
+import { createElement, StrictMode, type ReactNode } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { useFiberPayment } from '../src/use-fiber-payment.js';
 
@@ -31,6 +36,10 @@ const validUdtScript = {
   hash_type: 'type' as const,
   args: '0x00',
 };
+
+function strictModeWrapper({ children }: { children: ReactNode }) {
+  return createElement(StrictMode, null, children);
+}
 
 describe('useFiberPayment', () => {
   it('supports staged parse/send/wait APIs', async () => {
@@ -95,6 +104,19 @@ describe('useFiberPayment', () => {
     expect(result.current.error).toBeNull();
   });
 
+  it('keeps payment state updates working in React StrictMode', async () => {
+    const node = createNodeMock();
+    const { result } = renderHook(() => useFiberPayment(node), { wrapper: strictModeWrapper });
+
+    await act(async () => {
+      await result.current.payInvoice('ln-strict');
+    });
+
+    expect(result.current.paymentResult?.status).toBe('Succeeded');
+    expect(result.current.error).toBeNull();
+    expect(result.current.isPaying).toBe(false);
+  });
+
   it('clears stale paymentResult when staged sendPayment starts', async () => {
     const node = createNodeMock();
     const { result } = renderHook(() => useFiberPayment(node));
@@ -109,6 +131,51 @@ describe('useFiberPayment', () => {
     });
 
     expect(result.current.paymentResult).toBeNull();
+  });
+
+  it('clears stale payment state when the asset context changes', async () => {
+    const node = createNodeMock();
+    const { result, rerender } = renderHook(({ asset }) => useFiberPayment(node, { asset }), {
+      initialProps: { asset: { kind: 'ckb' } as UdtAsset },
+    });
+
+    await act(async () => {
+      await result.current.waitForPayment('0xabc');
+    });
+    expect(result.current.paymentResult?.status).toBe('Succeeded');
+
+    rerender({ asset: { kind: 'udt', script: validUdtScript } as UdtAsset });
+
+    expect(result.current.paymentResult).toBeNull();
+    expect(result.current.error).toBeNull();
+  });
+
+  it('ignores an in-flight result after the asset context changes', async () => {
+    const deferred = createDeferred<{ status: 'Succeeded' }>();
+    const node = createNodeMock({
+      waitForPayment: vi.fn(() => deferred.promise),
+    });
+    const { result, rerender } = renderHook(({ asset }) => useFiberPayment(node, { asset }), {
+      initialProps: { asset: { kind: 'ckb' } as UdtAsset },
+    });
+
+    let pendingWait: Promise<unknown> | undefined;
+    await act(async () => {
+      pendingWait = result.current.waitForPayment('0xold-asset');
+      await Promise.resolve();
+    });
+    expect(result.current.isPaying).toBe(true);
+
+    rerender({ asset: { kind: 'udt', script: validUdtScript } as UdtAsset });
+    expect(result.current.isPaying).toBe(false);
+
+    await act(async () => {
+      deferred.resolve({ status: 'Succeeded' });
+      await pendingWait;
+    });
+
+    expect(result.current.paymentResult).toBeNull();
+    expect(result.current.isPaying).toBe(false);
   });
 
   it('clears stale paymentResult while staged waitForPayment is pending', async () => {
@@ -174,6 +241,81 @@ describe('useFiberPayment', () => {
       invoice: 'ln-udt',
       udt_type_script: validUdtScript,
     });
+  });
+
+  it('pays a matching UDT invoice and trims pasted whitespace', async () => {
+    const node = createNodeMock({
+      parseInvoice: vi.fn(async () => ({
+        invoice: {
+          currency: 'Fibt',
+          data: {
+            payment_hash: '0xabc',
+            attrs: [{ udt_script: serializeUdtTypeScript(validUdtScript) }],
+          },
+        },
+      })),
+    });
+    const asset = { kind: 'udt' as const, script: validUdtScript };
+    const { result } = renderHook(() => useFiberPayment(node, { asset, network: 'testnet' }));
+
+    await act(async () => {
+      await result.current.payInvoice('  ln-udt  ');
+    });
+
+    expect(node.parseInvoice).toHaveBeenCalledWith({ invoice: 'ln-udt' });
+    expect(node.sendPayment).toHaveBeenCalledWith({
+      invoice: 'ln-udt',
+      udt_type_script: validUdtScript,
+    });
+    expect(result.current.paymentResult?.status).toBe('Succeeded');
+  });
+
+  it('rejects UDT invoices whose script does not match the configured asset', async () => {
+    const node = createNodeMock({
+      parseInvoice: vi.fn(async () => ({
+        invoice: {
+          currency: 'Fibt',
+          data: {
+            payment_hash: '0xabc',
+            attrs: [
+              {
+                udt_script: serializeUdtTypeScript({ ...validUdtScript, args: '0x01' }),
+              },
+            ],
+          },
+        },
+      })),
+    });
+    const asset = { kind: 'udt' as const, script: validUdtScript };
+    const { result } = renderHook(() => useFiberPayment(node, { asset, network: 'testnet' }));
+
+    await act(async () => {
+      await result.current.payInvoice('ln-wrong-udt');
+    });
+
+    expect(node.sendPayment).not.toHaveBeenCalled();
+    expect(result.current.error).toContain('UDT type script does not match');
+  });
+
+  it('rejects invoices from the wrong network before sending', async () => {
+    const node = createNodeMock({
+      parseInvoice: vi.fn(async () => ({
+        invoice: {
+          currency: 'Fibt',
+          data: { payment_hash: '0xabc', attrs: [] },
+        },
+      })),
+    });
+    const { result } = renderHook(() =>
+      useFiberPayment(node, { asset: { kind: 'ckb' }, network: 'mainnet' }),
+    );
+
+    await act(async () => {
+      await result.current.payInvoice('ln-testnet');
+    });
+
+    expect(node.sendPayment).not.toHaveBeenCalled();
+    expect(result.current.error).toContain('expected Fibb, received Fibt');
   });
 
   it('sends UDT payment with per-call asset', async () => {

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -86,7 +86,7 @@ Nginx, Cloudflare, or Vercel), not only in local dev tooling.
 ### Bundle Size Expectations
 
 The Fiber browser runtime is intentionally heavy. Expect a large WASM-related chunk in production builds
-(roughly ~14 MB raw and ~6.5 MB gzip in current examples). Prefer route-level code splitting and lazy
+(roughly ~45.5 MB raw and ~13.4 MB gzip with fiber-js 0.9.0-rc4 in the current React lab). Prefer route-level code splitting and lazy
 mounting so the chunk loads only when payment/node features are needed.
 
 `@fiber-pay/sdk/browser` also exports `FiberRpcClient` for migration compatibility.
@@ -161,6 +161,8 @@ import {
   parsePaymentAmount,
   formatChannelBalances,
   formatAssetName,
+  serializeUdtTypeScript,
+  areUdtTypeScriptsEqual,
   DEFAULT_CKB_ASSET,
 } from '@fiber-pay/sdk';
 // Also available from '@fiber-pay/sdk/browser'
@@ -182,12 +184,18 @@ import {
 
 ```ts
 const script = parseUdtTypeScript(rawJson, '--udt-type-script');
+if (!script) throw new Error('UDT type script is required');
 // or validate an already-parsed object:
 validateUdtTypeScript(obj, '--udt-type-script');
 
 const fundingAmount = parseFundingAmount('1000', { kind: 'udt', script, name: 'TEST' });
 const paymentAmount = parsePaymentAmount('500', { kind: 'udt', script });
+
+// Compare the invoice's serialized udt_script attribute with this asset.
+const invoiceScript = serializeUdtTypeScript(script);
 ```
+
+UDT funding and payment amounts are raw integer base units. Apply the token's decimals only in display/input code; do not pass decimal strings to these helpers.
 
 **Resolving by name** — look up configured UDTs from node info:
 

--- a/packages/sdk/src/browser/index.ts
+++ b/packages/sdk/src/browser/index.ts
@@ -130,6 +130,7 @@ export type {
   UdtTypeScript,
 } from '../udt/index.js';
 export {
+  areUdtTypeScriptsEqual,
   DEFAULT_CKB_ASSET,
   formatAssetName,
   formatChannelBalances,
@@ -137,6 +138,7 @@ export {
   parsePaymentAmount,
   parseUdtTypeScript,
   resolveUdtAsset,
+  serializeUdtTypeScript,
   validateUdtTypeScript,
 } from '../udt/index.js';
 export {

--- a/packages/sdk/src/udt/parse.ts
+++ b/packages/sdk/src/udt/parse.ts
@@ -101,7 +101,13 @@ export function serializeUdtTypeScript(value: unknown): HexString {
 /** Compare UDT scripts by their canonical fields, ignoring hex letter casing. */
 export function areUdtTypeScriptsEqual(left: unknown, right: unknown): boolean {
   try {
-    return serializeUdtTypeScript(left) === serializeUdtTypeScript(right);
+    const normalizedLeft = validateUdtTypeScript(left);
+    const normalizedRight = validateUdtTypeScript(right);
+    return (
+      normalizedLeft.code_hash.toLowerCase() === normalizedRight.code_hash.toLowerCase() &&
+      normalizedLeft.hash_type === normalizedRight.hash_type &&
+      normalizedLeft.args.toLowerCase() === normalizedRight.args.toLowerCase()
+    );
   } catch {
     return false;
   }

--- a/packages/sdk/src/udt/parse.ts
+++ b/packages/sdk/src/udt/parse.ts
@@ -18,6 +18,10 @@ function validateHexString(
     throw new Error(`Invalid ${optionName}: ${field} must be a hex string starting with 0x`);
   }
 
+  if ((value.length - 2) % 2 !== 0) {
+    throw new Error(`Invalid ${optionName}: ${field} must contain complete bytes`);
+  }
+
   if (exactLength !== undefined && value.length !== exactLength) {
     throw new Error(`Invalid ${optionName}: ${field} must be ${exactLength} hex characters`);
   }
@@ -61,6 +65,46 @@ export function validateUdtTypeScript(
     hash_type: script.hash_type,
     args: script.args,
   };
+}
+
+const HASH_TYPE_BYTES: Record<UdtTypeScript['hash_type'], number> = {
+  data: 0,
+  type: 1,
+  data1: 2,
+  data2: 4,
+};
+
+function uint32LeHex(value: number): string {
+  const bytes = new Uint8Array(4);
+  new DataView(bytes.buffer).setUint32(0, value, true);
+  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join('');
+}
+
+/**
+ * Serialize a UDT type script to the Molecule bytes used by Fiber invoice attributes.
+ */
+export function serializeUdtTypeScript(value: unknown): HexString {
+  const script = validateUdtTypeScript(value, 'UDT type script');
+  const codeHash = script.code_hash.slice(2).toLowerCase();
+  const args = script.args.slice(2).toLowerCase();
+  const argsByteLength = args.length / 2;
+  const tableHeaderSize = 16;
+  const codeHashOffset = tableHeaderSize;
+  const hashTypeOffset = codeHashOffset + 32;
+  const argsOffset = hashTypeOffset + 1;
+  const totalSize = argsOffset + 4 + argsByteLength;
+  const hashType = HASH_TYPE_BYTES[script.hash_type].toString(16).padStart(2, '0');
+
+  return `0x${uint32LeHex(totalSize)}${uint32LeHex(codeHashOffset)}${uint32LeHex(hashTypeOffset)}${uint32LeHex(argsOffset)}${codeHash}${hashType}${uint32LeHex(argsByteLength)}${args}`;
+}
+
+/** Compare UDT scripts by their canonical fields, ignoring hex letter casing. */
+export function areUdtTypeScriptsEqual(left: unknown, right: unknown): boolean {
+  try {
+    return serializeUdtTypeScript(left) === serializeUdtTypeScript(right);
+  } catch {
+    return false;
+  }
 }
 
 /**

--- a/packages/sdk/tests/udt.test.ts
+++ b/packages/sdk/tests/udt.test.ts
@@ -1,19 +1,20 @@
 import { describe, expect, it } from 'vitest';
 import {
+  areUdtTypeScriptsEqual,
   formatAssetName,
   formatChannelBalances,
   parseFundingAmount,
   parsePaymentAmount,
   parseUdtTypeScript,
   resolveUdtAsset,
+  serializeUdtTypeScript,
   validateUdtTypeScript,
   type UdtAsset,
 } from '../src/udt/index.js';
 import type { Channel, UdtCfgInfos } from '../src/types/rpc.js';
 
 const validCodeHash = '0x1142755a044bf2ee358cba9f2da187ce928c91cd4dc8692ded0337efa677d21a';
-const validUdtScript =
-  `{"code_hash":"${validCodeHash}","hash_type":"type","args":"0x878fcc6f1f08d48e87bb1c3b3d5083f23f8a39c5d5c764f253b55b998526439b"}`;
+const validUdtScript = `{"code_hash":"${validCodeHash}","hash_type":"type","args":"0x878fcc6f1f08d48e87bb1c3b3d5083f23f8a39c5d5c764f253b55b998526439b"}`;
 
 describe('parseUdtTypeScript', () => {
   it('returns undefined when value is undefined', () => {
@@ -42,9 +43,7 @@ describe('parseUdtTypeScript', () => {
 
   it('rejects invalid hash_type', () => {
     expect(() =>
-      parseUdtTypeScript(
-        `{"code_hash":"${validCodeHash}","hash_type":"invalid","args":"0x"}`,
-      ),
+      parseUdtTypeScript(`{"code_hash":"${validCodeHash}","hash_type":"invalid","args":"0x"}`),
     ).toThrow('hash_type must be one of type, data, data1, data2');
   });
 
@@ -82,9 +81,35 @@ describe('validateUdtTypeScript', () => {
   });
 
   it('rejects invalid script object', () => {
-    expect(() => validateUdtTypeScript({ code_hash: '0x00', hash_type: 'type', args: '0x' })).toThrow(
-      'code_hash must be 66 hex characters',
+    expect(() =>
+      validateUdtTypeScript({ code_hash: '0x00', hash_type: 'type', args: '0x' }),
+    ).toThrow('code_hash must be 66 hex characters');
+  });
+
+  it('rejects hex fields that do not contain complete bytes', () => {
+    expect(() =>
+      validateUdtTypeScript({ code_hash: validCodeHash, hash_type: 'type', args: '0x0' }),
+    ).toThrow('args must contain complete bytes');
+  });
+
+  it('serializes scripts to Fiber invoice Molecule bytes', () => {
+    expect(
+      serializeUdtTypeScript({ code_hash: validCodeHash, hash_type: 'type', args: '0x00' }),
+    ).toBe(
+      '0x360000001000000030000000310000001142755a044bf2ee358cba9f2da187ce928c91cd4dc8692ded0337efa677d21a010100000000',
     );
+  });
+
+  it('compares scripts by canonical fields and rejects mismatches', () => {
+    const script = { code_hash: validCodeHash, hash_type: 'type' as const, args: '0x00' };
+    expect(
+      areUdtTypeScriptsEqual(script, {
+        ...script,
+        code_hash: validCodeHash.toUpperCase().replace('0X', '0x'),
+      }),
+    ).toBe(true);
+    expect(areUdtTypeScriptsEqual(script, { ...script, args: '0x01' })).toBe(false);
+    expect(areUdtTypeScriptsEqual(script, { ...script, args: '0x0' })).toBe(false);
   });
 });
 
@@ -109,7 +134,9 @@ describe('parsePaymentAmount', () => {
   });
 
   it('rejects zero CKB amount', () => {
-    expect(() => parsePaymentAmount('0', { kind: 'ckb' })).toThrow('CKB amount must be greater than 0');
+    expect(() => parsePaymentAmount('0', { kind: 'ckb' })).toThrow(
+      'CKB amount must be greater than 0',
+    );
   });
 
   it('rejects zero UDT amount', () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,8 +86,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/sdk
       '@nervosnetwork/fiber-js':
-        specifier: ~0.8.1
-        version: 0.8.1
+        specifier: 'catalog:'
+        version: 0.9.0-rc4
       react:
         specifier: ^19.2.4
         version: 19.2.4
@@ -147,8 +147,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/sdk
       '@nervosnetwork/fiber-js':
-        specifier: ~0.8.1
-        version: 0.8.1
+        specifier: 'catalog:'
+        version: 0.9.0-rc4
       react:
         specifier: ^19.2.4
         version: 19.2.4
@@ -196,8 +196,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/react
       '@nervosnetwork/fiber-js':
-        specifier: ~0.8.1
-        version: 0.8.1
+        specifier: 'catalog:'
+        version: 0.9.0-rc4
       react:
         specifier: ^19.2.4
         version: 19.2.4

--- a/scripts/check-fiber-js-version.mjs
+++ b/scripts/check-fiber-js-version.mjs
@@ -42,12 +42,18 @@ if (!catalogMatch) {
 }
 const catalogVersion = catalogMatch[1].trim();
 if (catalogVersion !== sdkPeer) {
-  fail(`pnpm-workspace.yaml catalog (${catalogVersion}) does not match SDK peerDependency (${sdkPeer})`);
+  fail(
+    `pnpm-workspace.yaml catalog (${catalogVersion}) does not match SDK peerDependency (${sdkPeer})`,
+  );
 }
 ok(`Workspace catalog: ${catalogVersion}`);
 
 const consumers = [
   ['e2e/wasm-smoke/package.json', 'dependencies'],
+  ['e2e/wasm-dual-node/package.json', 'dependencies'],
+  ['examples/browser-sdk-playground/package.json', 'dependencies'],
+  ['examples/react-fiber-node-button-lab/package.json', 'dependencies'],
+  ['examples/react-min-connect/package.json', 'dependencies'],
   ['packages/react/package.json', 'devDependencies'],
 ];
 
@@ -55,7 +61,9 @@ for (const [pkgPath, depField] of consumers) {
   const pkg = readJson(pkgPath);
   const declared = pkg[depField]?.['@nervosnetwork/fiber-js'];
   if (declared !== 'catalog:') {
-    fail(`${pkgPath} must declare @nervosnetwork/fiber-js as "catalog:" in ${depField}, got ${declared}`);
+    fail(
+      `${pkgPath} must declare @nervosnetwork/fiber-js as "catalog:" in ${depField}, got ${declared}`,
+    );
   }
   ok(`${pkgPath} uses catalog:`);
 }


### PR DESCRIPTION
## Summary

Harden React UDT support, especially the high-level `FiberNodeButton` flow.

- validate UDT whitelist, script identity, invoice asset, and invoice network before RPC mutations
- fix StrictMode lifecycle/race issues and preserve panel/payment state across close/reopen and asset changes
- use exact UDT script matching for channel labels and expose asset-aware external funding context
- add canonical Molecule UDT script serialization/equality helpers in the SDK
- align Fiber JS versions across examples and add a runnable CKB/RUSD lab configuration
- document raw base-unit semantics, whitelist requirements, deposit QR limitations, and current bundle size

## Validation

- `pnpm format:check`
- `pnpm lint`
- `pnpm build`
- `pnpm typecheck`
- `pnpm test` — 35 files / 663 tests passed
- `pnpm check:fiber-js-version`
- `pnpm changeset:status`

Includes patch changesets for `@fiber-pay/react` and `@fiber-pay/sdk`.