### PR TITLE
feat(react): support multi-asset FiberNodeButton workflows

### DIFF
--- a/.changeset/bright-fibers-share.md
+++ b/.changeset/bright-fibers-share.md
@@ -1,0 +1,5 @@
+---
+"@fiber-pay/react": minor
+---
+
+Add multi-asset CKB/UDT selectors, asset-aware channel filtering and diagnostics, custom UDT scripts, and responsive FiberNodeButton panel layout.

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -322,6 +322,8 @@ When the node is connected, `FiberNodeButton` reads `nodeInfo.udt_cfg_infos` and
 
 The `asset` prop remains supported as the initial selection for all three actions. Users can later switch each action independently or choose `Custom` and paste a UDT type script JSON object. Selecting an asset does **not** configure the Fiber node: the same type script must be present in `nodeConfig.udtWhitelist`, including the token's official cell deps. Both channel peers must support the token.
 
+UDTs are keyed by their validated type script. If `nodeInfo.udt_cfg_infos` contains duplicate scripts, the first configured entry supplies the display name; an explicit valid `asset` prop with a non-empty name overrides that name. Invalid configured entries and invalid initial assets are ignored with a console warning, so they cannot become actionable selections.
+
 UDT amounts are raw integer base units. For a token with 8 decimals, `100000000` represents one display token.
 
 ```tsx

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -296,7 +296,7 @@ export function WalletEntry() {
 | `passkeyUsername` | `string` | `"User"` | Display name for passkey registration. |
 | `wasmFactory` | `FiberWasmFactory` | — | Optional WASM factory override. |
 | `nodeConfig` | `UseFiberNodeOptions["nodeConfig"]` | — | Additional node configuration. |
-| `asset` | `UdtAsset` | `{ kind: "ckb" }` | Asset used for channel funding, invoices, and payments. |
+| `asset` | `UdtAsset` | `{ kind: "ckb" }` | Initial asset for channel funding, invoices, and payments. |
 | `className` | `string` | — | Additional CSS class for the root container. |
 | `style` | `CSSProperties` | — | Inline styles for the root container. |
 | `dropdownStyle` | `CSSProperties` | — | Inline styles for the dropdown panel. |
@@ -308,7 +308,7 @@ export function WalletEntry() {
 | `initialPeerAddress` | `string` | `""` | Pre-filled peer address for the open-channel form. |
 | `initialFundingAmountCkb` | `string` | `"1000"` | Pre-filled funding amount (in CKB) for the open-channel form. |
 | `initialFundingAmount` | `string` | — | CKB display amount or raw integer UDT base units. Takes precedence over `initialFundingAmountCkb`. |
-| `invoiceAmount` | `string` | `"1"` | CKB display amount or raw integer UDT base units. |
+| `invoiceAmount` | `string` | `"1"` for CKB | CKB display amount or raw integer UDT base units. UDT invoices require an amount. |
 | `externalFunding` | `FiberNodeButtonExternalFundingConfig` | — | External funding resolver configuration. |
 | `renderConnectorSection` | `(context) => ReactNode` | — | Custom renderer for the connector section inside the panel. |
 | `tabs` | `FiberNodeButtonTabConfig[]` | — | Reorder, hide, or extend built-in tabs. |
@@ -318,7 +318,9 @@ export function WalletEntry() {
 
 ### UDT setup
 
-Passing `asset` selects the token for UI and RPC calls, but it does **not** configure the Fiber node. The same type script must be present in `nodeConfig.udtWhitelist`, including the token's official cell deps. Both channel peers must support the token.
+When the node is connected, `FiberNodeButton` reads `nodeInfo.udt_cfg_infos` and exposes CKB plus every configured UDT in independent selectors for opening channels, creating invoices, and paying invoices. Channels and graph diagnostics resolve the same configuration to show the correct asset name and unit. A CKB-only node keeps the compact CKB-only interface without additional selectors.
+
+The `asset` prop remains supported as the initial selection for all three actions. Users can later switch each action independently or choose `Custom` and paste a UDT type script JSON object. Selecting an asset does **not** configure the Fiber node: the same type script must be present in `nodeConfig.udtWhitelist`, including the token's official cell deps. Both channel peers must support the token.
 
 UDT amounts are raw integer base units. For a token with 8 decimals, `100000000` represents one display token.
 

--- a/packages/react/src/fiber-node-button/asset-select.tsx
+++ b/packages/react/src/fiber-node-button/asset-select.tsx
@@ -1,4 +1,4 @@
-import { CKB_ASSET_KEY, CUSTOM_ASSET_KEY, type PanelAssetOption } from './assets.js';
+import { CUSTOM_ASSET_KEY, localizeAssetLabel, type PanelAssetOption } from './assets.js';
 import { styles } from './styles.js';
 import type { FiberNodeButtonI18n } from './types.js';
 
@@ -35,11 +35,7 @@ export function AssetSelect({
         >
           {options.map((option) => (
             <option key={option.key} value={option.key}>
-              {option.key === CKB_ASSET_KEY
-                ? t('asset.ckb', 'CKB')
-                : option.label === 'UDT'
-                  ? t('asset.udt', 'UDT')
-                  : option.label}
+              {localizeAssetLabel(option.label, t)}
             </option>
           ))}
           <option value={CUSTOM_ASSET_KEY}>{t('asset.custom', 'Custom')}</option>

--- a/packages/react/src/fiber-node-button/asset-select.tsx
+++ b/packages/react/src/fiber-node-button/asset-select.tsx
@@ -1,0 +1,64 @@
+import { CKB_ASSET_KEY, CUSTOM_ASSET_KEY, type PanelAssetOption } from './assets.js';
+import { styles } from './styles.js';
+import type { FiberNodeButtonI18n } from './types.js';
+
+export interface AssetSelectProps {
+  label: string;
+  ariaLabel: string;
+  value: string;
+  options: ReadonlyArray<PanelAssetOption>;
+  customScript: string;
+  onChange: (key: string) => void;
+  onCustomScriptChange: (value: string) => void;
+  t: FiberNodeButtonI18n;
+}
+
+export function AssetSelect({
+  label,
+  ariaLabel,
+  value,
+  options,
+  customScript,
+  onChange,
+  onCustomScriptChange,
+  t,
+}: AssetSelectProps) {
+  return (
+    <>
+      <label style={styles.fieldLabel}>
+        {label}
+        <select
+          style={styles.input}
+          aria-label={ariaLabel}
+          value={value}
+          onChange={(event) => onChange(event.target.value)}
+        >
+          {options.map((option) => (
+            <option key={option.key} value={option.key}>
+              {option.key === CKB_ASSET_KEY
+                ? t('asset.ckb', 'CKB')
+                : option.label === 'UDT'
+                  ? t('asset.udt', 'UDT')
+                  : option.label}
+            </option>
+          ))}
+          <option value={CUSTOM_ASSET_KEY}>{t('asset.custom', 'Custom')}</option>
+        </select>
+      </label>
+
+      {value === CUSTOM_ASSET_KEY ? (
+        <label style={styles.fieldLabel}>
+          {t('asset.custom.script', 'Custom UDT Script (JSON)')}
+          <textarea
+            style={styles.textarea}
+            aria-label={`${ariaLabel} ${t('asset.custom.script', 'Custom UDT Script (JSON)')}`}
+            rows={4}
+            value={customScript}
+            onChange={(event) => onCustomScriptChange(event.target.value)}
+            placeholder='{"code_hash":"0x...","hash_type":"type","args":"0x..."}'
+          />
+        </label>
+      ) : null}
+    </>
+  );
+}

--- a/packages/react/src/fiber-node-button/assets.ts
+++ b/packages/react/src/fiber-node-button/assets.ts
@@ -4,6 +4,7 @@ import {
   parseUdtTypeScript,
   validateUdtTypeScript,
 } from '@fiber-pay/sdk/browser';
+import type { FiberNodeButtonI18n } from './types.js';
 
 export const CKB_ASSET_KEY = 'ckb';
 export const CUSTOM_ASSET_KEY = 'custom';
@@ -20,14 +21,18 @@ interface ConfiguredUdt {
 }
 
 function getRawScriptKey(script: unknown): string {
-  if (!script || typeof script !== 'object') {
-    return 'udt:invalid';
+  try {
+    const validated = validateUdtTypeScript(script);
+    return `udt:${validated.code_hash}:${validated.hash_type}:${validated.args}`.toLowerCase();
+  } catch {
+    let serialized: string;
+    try {
+      serialized = JSON.stringify(script) ?? String(script);
+    } catch {
+      serialized = String(script);
+    }
+    return `udt:invalid:${serialized}`.toLowerCase();
   }
-
-  const record = script as Record<string, unknown>;
-  return `udt:${String(record.code_hash ?? '')}:${String(record.hash_type ?? '')}:${String(
-    record.args ?? '',
-  )}`.toLowerCase();
 }
 
 export function getUdtAssetKey(script: unknown): string {
@@ -62,27 +67,45 @@ export function buildPanelAssetOptions(
         name: configured.name?.trim() || undefined,
       };
       const key = getAssetKey(asset);
-      options.set(key, {
-        key,
-        asset,
-        label: configured.name?.trim() || 'UDT',
-      });
-    } catch {
-      // Invalid node config entries cannot be used safely as an action asset.
+      if (!options.has(key)) {
+        options.set(key, {
+          key,
+          asset,
+          label: configured.name?.trim() || 'UDT',
+        });
+      }
+    } catch (error) {
+      console.warn(
+        '[FiberNodeButton] Ignoring invalid node UDT configuration.',
+        error instanceof Error ? error.message : String(error),
+      );
     }
   }
 
   if (initialAsset.kind === 'udt') {
-    const key = getAssetKey(initialAsset);
-    const existing = options.get(key);
-    const preferredAsset = initialAsset.name?.trim()
-      ? initialAsset
-      : (existing?.asset ?? initialAsset);
-    options.set(key, {
-      key,
-      asset: preferredAsset,
-      label: initialAsset.name?.trim() || existing?.label || 'UDT',
-    });
+    try {
+      const script = validateUdtTypeScript(initialAsset.script, 'initial UDT asset');
+      const validatedInitialAsset: UdtAsset = {
+        kind: 'udt',
+        script,
+        name: initialAsset.name?.trim() || undefined,
+      };
+      const key = getAssetKey(validatedInitialAsset);
+      const existing = options.get(key);
+      const preferredAsset = validatedInitialAsset.name
+        ? validatedInitialAsset
+        : (existing?.asset ?? validatedInitialAsset);
+      options.set(key, {
+        key,
+        asset: preferredAsset,
+        label: validatedInitialAsset.name || existing?.label || 'UDT',
+      });
+    } catch (error) {
+      console.warn(
+        '[FiberNodeButton] Ignoring invalid initial UDT asset.',
+        error instanceof Error ? error.message : String(error),
+      );
+    }
   }
 
   return Array.from(options.values());
@@ -94,6 +117,9 @@ export function resolvePanelAsset(
   options: ReadonlyArray<PanelAssetOption>,
 ): UdtAsset {
   if (key === CUSTOM_ASSET_KEY) {
+    if (!customScript.trim()) {
+      throw new Error('Custom UDT script is required.');
+    }
     const script = parseUdtTypeScript(customScript, 'custom UDT script');
     if (!script) {
       throw new Error('Custom UDT script is required.');
@@ -108,15 +134,20 @@ export function resolvePanelAsset(
   return option.asset;
 }
 
+export type PanelAssetResolution = { ok: true; asset: UdtAsset } | { ok: false; error: Error };
+
 export function tryResolvePanelAsset(
   key: string,
   customScript: string,
   options: ReadonlyArray<PanelAssetOption>,
-): UdtAsset | null {
+): PanelAssetResolution {
   try {
-    return resolvePanelAsset(key, customScript, options);
-  } catch {
-    return null;
+    return { ok: true, asset: resolvePanelAsset(key, customScript, options) };
+  } catch (error) {
+    return {
+      ok: false,
+      error: error instanceof Error ? error : new Error(String(error)),
+    };
   }
 }
 
@@ -132,9 +163,19 @@ export function getAssetLabelForScript(
 }
 
 export function formatRawUdtAmount(value: string): string {
+  if (value.length > 64 || !/^\d+$/.test(value)) {
+    return value;
+  }
+
   try {
     return BigInt(value).toLocaleString('en-US');
   } catch {
     return value;
   }
+}
+
+export function localizeAssetLabel(label: string, t: FiberNodeButtonI18n): string {
+  if (label === 'CKB') return t('asset.ckb', 'CKB');
+  if (label === 'UDT') return t('asset.udt', 'UDT');
+  return label;
 }

--- a/packages/react/src/fiber-node-button/assets.ts
+++ b/packages/react/src/fiber-node-button/assets.ts
@@ -1,0 +1,140 @@
+import type { Script, UdtAsset, UdtTypeScript } from '@fiber-pay/sdk/browser';
+import {
+  DEFAULT_CKB_ASSET,
+  parseUdtTypeScript,
+  validateUdtTypeScript,
+} from '@fiber-pay/sdk/browser';
+
+export const CKB_ASSET_KEY = 'ckb';
+export const CUSTOM_ASSET_KEY = 'custom';
+
+export interface PanelAssetOption {
+  key: string;
+  asset: UdtAsset;
+  label: string;
+}
+
+interface ConfiguredUdt {
+  name?: string;
+  script: unknown;
+}
+
+function getRawScriptKey(script: unknown): string {
+  if (!script || typeof script !== 'object') {
+    return 'udt:invalid';
+  }
+
+  const record = script as Record<string, unknown>;
+  return `udt:${String(record.code_hash ?? '')}:${String(record.hash_type ?? '')}:${String(
+    record.args ?? '',
+  )}`.toLowerCase();
+}
+
+export function getUdtAssetKey(script: unknown): string {
+  return getRawScriptKey(script);
+}
+
+export function getAssetKey(asset: UdtAsset): string {
+  return asset.kind === 'ckb' ? CKB_ASSET_KEY : getUdtAssetKey(asset.script);
+}
+
+export function getChannelAssetKey(script: Script | null | undefined): string {
+  return script ? getUdtAssetKey(script) : CKB_ASSET_KEY;
+}
+
+export function buildPanelAssetOptions(
+  configuredUdts: ReadonlyArray<ConfiguredUdt> | null | undefined,
+  initialAsset: UdtAsset,
+): PanelAssetOption[] {
+  const options = new Map<string, PanelAssetOption>();
+  options.set(CKB_ASSET_KEY, {
+    key: CKB_ASSET_KEY,
+    asset: DEFAULT_CKB_ASSET,
+    label: 'CKB',
+  });
+
+  for (const configured of configuredUdts ?? []) {
+    try {
+      const script = validateUdtTypeScript(configured.script, 'node UDT config');
+      const asset: UdtAsset = {
+        kind: 'udt',
+        script,
+        name: configured.name?.trim() || undefined,
+      };
+      const key = getAssetKey(asset);
+      options.set(key, {
+        key,
+        asset,
+        label: configured.name?.trim() || 'UDT',
+      });
+    } catch {
+      // Invalid node config entries cannot be used safely as an action asset.
+    }
+  }
+
+  if (initialAsset.kind === 'udt') {
+    const key = getAssetKey(initialAsset);
+    const existing = options.get(key);
+    const preferredAsset = initialAsset.name?.trim()
+      ? initialAsset
+      : (existing?.asset ?? initialAsset);
+    options.set(key, {
+      key,
+      asset: preferredAsset,
+      label: initialAsset.name?.trim() || existing?.label || 'UDT',
+    });
+  }
+
+  return Array.from(options.values());
+}
+
+export function resolvePanelAsset(
+  key: string,
+  customScript: string,
+  options: ReadonlyArray<PanelAssetOption>,
+): UdtAsset {
+  if (key === CUSTOM_ASSET_KEY) {
+    const script = parseUdtTypeScript(customScript, 'custom UDT script');
+    if (!script) {
+      throw new Error('Custom UDT script is required.');
+    }
+    return { kind: 'udt', script };
+  }
+
+  const option = options.find((candidate) => candidate.key === key);
+  if (!option) {
+    throw new Error('Selected asset is no longer available.');
+  }
+  return option.asset;
+}
+
+export function tryResolvePanelAsset(
+  key: string,
+  customScript: string,
+  options: ReadonlyArray<PanelAssetOption>,
+): UdtAsset | null {
+  try {
+    return resolvePanelAsset(key, customScript, options);
+  } catch {
+    return null;
+  }
+}
+
+export function getAssetLabelForScript(
+  script: UdtTypeScript | Script | null | undefined,
+  options: ReadonlyArray<PanelAssetOption>,
+): string {
+  if (!script) {
+    return 'CKB';
+  }
+  const key = getUdtAssetKey(script);
+  return options.find((option) => option.key === key)?.label || 'UDT';
+}
+
+export function formatRawUdtAmount(value: string): string {
+  try {
+    return BigInt(value).toLocaleString('en-US');
+  } catch {
+    return value;
+  }
+}

--- a/packages/react/src/fiber-node-button/channels-tab.tsx
+++ b/packages/react/src/fiber-node-button/channels-tab.tsx
@@ -1,11 +1,8 @@
-import type { FormattedChannelBalances, UdtAsset } from '@fiber-pay/sdk/browser';
-import {
-  areUdtTypeScriptsEqual,
-  formatAssetName,
-  formatChannelBalances,
-} from '@fiber-pay/sdk/browser';
+import type { FormattedChannelBalances } from '@fiber-pay/sdk/browser';
+import { formatChannelBalances } from '@fiber-pay/sdk/browser';
 import { useMemo } from 'react';
 import type { UseFiberNodeResult } from '../use-fiber-node.js';
+import { formatRawUdtAmount } from './assets.js';
 import { renderPanelAction } from './render-action.js';
 import { styles } from './styles.js';
 import {
@@ -17,48 +14,46 @@ import {
 import type { FiberNodeButtonPanelState } from './use-panel-state.js';
 import { shorten, withDisabledStyle } from './utils.js';
 
+function localizeAssetLabel(label: string, t: FiberNodeButtonTabContext['t']): string {
+  if (label === 'CKB') return t('asset.ckb', 'CKB');
+  if (label === 'UDT') return t('asset.udt', 'UDT');
+  return label;
+}
+
 function formatChannelBalanceValue(
   balances: FormattedChannelBalances,
   side: 'local' | 'remote',
 ): string {
-  const value = balances.kind === 'udt' ? balances[side] : balances[side].toFixed(4);
+  const value =
+    balances.kind === 'udt' ? formatRawUdtAmount(balances[side]) : balances[side].toFixed(4);
   return value;
 }
 
-function formatChannelBalanceUnit(balances: FormattedChannelBalances, asset?: UdtAsset): string {
-  if (balances.kind === 'udt') {
-    if (
-      asset?.kind === 'udt' &&
-      areUdtTypeScriptsEqual(balances.fundingUdtTypeScript, asset.script)
-    ) {
-      return formatAssetName(asset);
-    }
-    const codeHash = balances.fundingUdtTypeScript?.code_hash;
-    if (!codeHash) {
-      return 'UDT';
-    }
-    return `UDT · ${codeHash.slice(0, 10)}…${codeHash.slice(-6)}`;
-  }
-  return 'CKB';
+function formatChannelBalanceUnit(assetLabel: string): string {
+  return assetLabel;
 }
 
 function SelectedChannelBalance({
   balances,
   side,
-  asset,
+  assetLabel,
 }: {
   balances: FormattedChannelBalances | null;
   side: 'local' | 'remote';
-  asset?: UdtAsset;
+  assetLabel: string;
 }) {
   if (!balances) {
-    return <span style={styles.badge}>{side === 'local' ? 'Local' : 'Remote'} — CKB</span>;
+    return (
+      <span style={styles.badge}>
+        {side === 'local' ? 'Local' : 'Remote'} — {assetLabel}
+      </span>
+    );
   }
 
   return (
     <span style={styles.badge}>
       {side === 'local' ? 'Local' : 'Remote'} {formatChannelBalanceValue(balances, side)}{' '}
-      {formatChannelBalanceUnit(balances, asset)}
+      {formatChannelBalanceUnit(assetLabel)}
     </span>
   );
 }
@@ -66,19 +61,23 @@ function SelectedChannelBalance({
 export interface ChannelsTabProps {
   state: FiberNodeButtonPanelState;
   fiber: UseFiberNodeResult;
-  asset?: UdtAsset;
   onLog?: (message: string) => void;
   renderAction?: FiberNodeButtonRenderAction;
   t: FiberNodeButtonTabContext['t'];
 }
 
-export function ChannelsTab({ state, fiber, asset, onLog, renderAction, t }: ChannelsTabProps) {
+export function ChannelsTab({ state, fiber, onLog, renderAction, t }: ChannelsTabProps) {
   const {
     isRefreshingChannels,
     refreshChannels,
     channelCounts,
     channelFilter,
     setChannelFilter,
+    channelAssetFilter,
+    setChannelAssetFilter,
+    channelAssetCounts,
+    channelFilterCounts,
+    getChannelAssetLabel,
     visibleChannels,
     selectedChannelId,
     setSelectedChannelId,
@@ -101,6 +100,9 @@ export function ChannelsTab({ state, fiber, asset, onLog, renderAction, t }: Cha
   const selectedChannelBalances = selectedChannel
     ? (channelBalances.get(selectedChannel.channel_id) ?? formatChannelBalances(selectedChannel))
     : null;
+  const selectedChannelAssetLabel = selectedChannel
+    ? localizeAssetLabel(getChannelAssetLabel(selectedChannel), t)
+    : t('asset.ckb', 'CKB');
 
   return (
     <>
@@ -128,19 +130,58 @@ export function ChannelsTab({ state, fiber, asset, onLog, renderAction, t }: Cha
           {t('channels.summary.total', 'Total')} {channelCounts.all}
         </p>
 
-        <div style={styles.filterBar}>
-          {FILTER_ITEMS.map((filter) => (
-            <button
-              key={filter}
-              type="button"
-              style={channelFilter === filter ? styles.primaryButton : styles.actionButton}
-              onClick={() => setChannelFilter(filter)}
-            >
-              {filter === 'all'
-                ? `${t('channels.filter.all', 'All')} (${channelCounts.all})`
-                : `${filter} (${channelCounts[filter]})`}
-            </button>
-          ))}
+        {channelAssetCounts.length > 1 ? (
+          <p style={styles.summaryInline}>
+            {t('channels.summary.assets', 'Assets: {assets}', {
+              assets: channelAssetCounts
+                .map((entry) => `${localizeAssetLabel(entry.label, t)} ${entry.count}`)
+                .join(' · '),
+            })}
+          </p>
+        ) : null}
+
+        <div style={styles.filterStack}>
+          <div style={styles.filterBar}>
+            {FILTER_ITEMS.map((filter) => (
+              <button
+                key={filter}
+                type="button"
+                style={channelFilter === filter ? styles.primaryButton : styles.actionButton}
+                onClick={() => setChannelFilter(filter)}
+              >
+                {filter === 'all'
+                  ? `${t('channels.filter.all', 'All')} (${channelFilterCounts.all})`
+                  : `${filter} (${channelFilterCounts[filter]})`}
+              </button>
+            ))}
+          </div>
+
+          {channelAssetCounts.length > 1 ? (
+            <fieldset style={styles.filterFieldset}>
+              <legend style={styles.srOnly}>
+                {t('channels.filter.asset.aria', 'Channel asset filter')}
+              </legend>
+              <button
+                type="button"
+                style={channelAssetFilter === 'all' ? styles.primaryButton : styles.actionButton}
+                onClick={() => setChannelAssetFilter('all')}
+              >
+                {t('channels.filter.asset.all', 'All')}
+              </button>
+              {channelAssetCounts.map((entry) => (
+                <button
+                  key={entry.key}
+                  type="button"
+                  style={
+                    channelAssetFilter === entry.key ? styles.primaryButton : styles.actionButton
+                  }
+                  onClick={() => setChannelAssetFilter(entry.key)}
+                >
+                  {localizeAssetLabel(entry.label, t)} ({entry.count})
+                </button>
+              ))}
+            </fieldset>
+          ) : null}
         </div>
 
         <div style={styles.list}>
@@ -153,6 +194,7 @@ export function ChannelsTab({ state, fiber, asset, onLog, renderAction, t }: Cha
               const selected = channel.channel_id === selectedChannelId;
               const balances =
                 channelBalances.get(channel.channel_id) ?? formatChannelBalances(channel);
+              const assetLabel = localizeAssetLabel(getChannelAssetLabel(channel), t);
 
               return (
                 <button
@@ -176,7 +218,10 @@ export function ChannelsTab({ state, fiber, asset, onLog, renderAction, t }: Cha
                     <span style={styles.inlineCode}>
                       {t('channels.list.id', 'ID')}: {shorten(channel.channel_id, 12, 8)}
                     </span>
-                    <span style={styles.badge}>{channel.state.state_name}</span>
+                    <span style={styles.badgeGroup}>
+                      <span style={styles.badge}>{assetLabel}</span>
+                      <span style={styles.badge}>{channel.state.state_name}</span>
+                    </span>
                   </span>
                   <span style={styles.compactText}>
                     {t('channels.list.peer', 'Peer')}: {shorten(channel.pubkey, 16, 10)}
@@ -184,7 +229,7 @@ export function ChannelsTab({ state, fiber, asset, onLog, renderAction, t }: Cha
                   <span style={styles.compactText}>
                     L {formatChannelBalanceValue(balances, 'local')} / R{' '}
                     {formatChannelBalanceValue(balances, 'remote')}{' '}
-                    {formatChannelBalanceUnit(balances, asset)}
+                    {formatChannelBalanceUnit(assetLabel)}
                   </span>
                 </button>
               );
@@ -197,7 +242,10 @@ export function ChannelsTab({ state, fiber, asset, onLog, renderAction, t }: Cha
         <section style={styles.detailPanel}>
           <div style={styles.rowBetween}>
             <h4 style={styles.sectionTitle}>{t('channels.details.title', 'Channel Details')}</h4>
-            <span style={styles.badge}>{selectedChannel.state.state_name}</span>
+            <span style={styles.badgeGroup}>
+              <span style={styles.badge}>{selectedChannelAssetLabel}</span>
+              <span style={styles.badge}>{selectedChannel.state.state_name}</span>
+            </span>
           </div>
 
           <p style={styles.inlineCode}>
@@ -208,11 +256,15 @@ export function ChannelsTab({ state, fiber, asset, onLog, renderAction, t }: Cha
           </p>
 
           <div style={styles.row}>
-            <SelectedChannelBalance balances={selectedChannelBalances} side="local" asset={asset} />
+            <SelectedChannelBalance
+              balances={selectedChannelBalances}
+              side="local"
+              assetLabel={selectedChannelAssetLabel}
+            />
             <SelectedChannelBalance
               balances={selectedChannelBalances}
               side="remote"
-              asset={asset}
+              assetLabel={selectedChannelAssetLabel}
             />
             <span
               style={styles.badge}
@@ -221,6 +273,17 @@ export function ChannelsTab({ state, fiber, asset, onLog, renderAction, t }: Cha
               {t('channels.details.tlcs', 'TLCs')} {selectedChannel.pending_tlcs.length}
             </span>
           </div>
+
+          {selectedChannel.funding_udt_type_script ? (
+            <details>
+              <summary style={{ ...styles.compactText, cursor: 'pointer' }}>
+                {t('channels.details.udtScript', 'Funding UDT Script')}
+              </summary>
+              <pre style={styles.scriptCode}>
+                {JSON.stringify(selectedChannel.funding_udt_type_script, null, 2)}
+              </pre>
+            </details>
+          ) : null}
 
           {selectedChannel.failure_detail ? (
             <p style={styles.compactText}>

--- a/packages/react/src/fiber-node-button/channels-tab.tsx
+++ b/packages/react/src/fiber-node-button/channels-tab.tsx
@@ -2,7 +2,7 @@ import type { FormattedChannelBalances } from '@fiber-pay/sdk/browser';
 import { formatChannelBalances } from '@fiber-pay/sdk/browser';
 import { useMemo } from 'react';
 import type { UseFiberNodeResult } from '../use-fiber-node.js';
-import { formatRawUdtAmount } from './assets.js';
+import { formatRawUdtAmount, localizeAssetLabel } from './assets.js';
 import { renderPanelAction } from './render-action.js';
 import { styles } from './styles.js';
 import {
@@ -14,12 +14,6 @@ import {
 import type { FiberNodeButtonPanelState } from './use-panel-state.js';
 import { shorten, withDisabledStyle } from './utils.js';
 
-function localizeAssetLabel(label: string, t: FiberNodeButtonTabContext['t']): string {
-  if (label === 'CKB') return t('asset.ckb', 'CKB');
-  if (label === 'UDT') return t('asset.udt', 'UDT');
-  return label;
-}
-
 function formatChannelBalanceValue(
   balances: FormattedChannelBalances,
   side: 'local' | 'remote',
@@ -27,10 +21,6 @@ function formatChannelBalanceValue(
   const value =
     balances.kind === 'udt' ? formatRawUdtAmount(balances[side]) : balances[side].toFixed(4);
   return value;
-}
-
-function formatChannelBalanceUnit(assetLabel: string): string {
-  return assetLabel;
 }
 
 function SelectedChannelBalance({
@@ -53,7 +43,7 @@ function SelectedChannelBalance({
   return (
     <span style={styles.badge}>
       {side === 'local' ? 'Local' : 'Remote'} {formatChannelBalanceValue(balances, side)}{' '}
-      {formatChannelBalanceUnit(assetLabel)}
+      {assetLabel}
     </span>
   );
 }
@@ -228,8 +218,7 @@ export function ChannelsTab({ state, fiber, onLog, renderAction, t }: ChannelsTa
                   </span>
                   <span style={styles.compactText}>
                     L {formatChannelBalanceValue(balances, 'local')} / R{' '}
-                    {formatChannelBalanceValue(balances, 'remote')}{' '}
-                    {formatChannelBalanceUnit(assetLabel)}
+                    {formatChannelBalanceValue(balances, 'remote')} {assetLabel}
                   </span>
                 </button>
               );

--- a/packages/react/src/fiber-node-button/diagnostics-tab.tsx
+++ b/packages/react/src/fiber-node-button/diagnostics-tab.tsx
@@ -1,6 +1,7 @@
-import type { HexString } from '@fiber-pay/sdk/browser';
+import type { HexString, Script } from '@fiber-pay/sdk/browser';
 import { shannonsToCkb } from '@fiber-pay/sdk/browser';
 import { useMemo } from 'react';
+import { formatRawUdtAmount } from './assets.js';
 import { styles } from './styles.js';
 import type { FiberNodeButtonTabContext } from './types.js';
 import type { FiberNodeButtonPanelState } from './use-panel-state.js';
@@ -8,17 +9,14 @@ import { shorten, withDisabledStyle } from './utils.js';
 
 function formatGraphChannelCapacity(
   capacity: string,
-  udtTypeScript: { code_hash: string } | null | undefined,
+  udtTypeScript: Script | null | undefined,
+  assetLabel: string,
 ): string {
   if (udtTypeScript) {
-    try {
-      return `${BigInt(capacity).toString()} UDT`;
-    } catch {
-      return `${capacity} UDT`;
-    }
+    return `${formatRawUdtAmount(capacity)} ${assetLabel}`;
   }
   const ckb = shannonsToCkb(capacity as HexString);
-  return Number.isFinite(ckb) ? `${ckb.toFixed(4)} CKB` : `${capacity} shannons`;
+  return Number.isFinite(ckb) ? `${ckb.toFixed(4)} ${assetLabel}` : `${capacity} shannons`;
 }
 
 export interface DiagnosticsTabProps {
@@ -43,15 +41,29 @@ export function DiagnosticsTab({ state, t }: DiagnosticsTabProps) {
     graphNodes,
     graphChannels,
     channelOpenFlow,
+    getUdtAssetLabel,
   } = state;
 
   const formattedGraphChannels = useMemo(
     () =>
-      graphChannels.slice(0, 2).map((channel) => ({
-        ...channel,
-        displayCapacity: formatGraphChannelCapacity(channel.capacity, channel.udt_type_script),
-      })),
-    [graphChannels],
+      graphChannels.slice(0, 2).map((channel) => {
+        const rawAssetLabel = getUdtAssetLabel(channel.udt_type_script);
+        const assetLabel =
+          rawAssetLabel === 'CKB'
+            ? t('asset.ckb', 'CKB')
+            : rawAssetLabel === 'UDT'
+              ? t('asset.udt', 'UDT')
+              : rawAssetLabel;
+        return {
+          ...channel,
+          displayCapacity: formatGraphChannelCapacity(
+            channel.capacity,
+            channel.udt_type_script,
+            assetLabel,
+          ),
+        };
+      }),
+    [getUdtAssetLabel, graphChannels, t],
   );
 
   return (

--- a/packages/react/src/fiber-node-button/diagnostics-tab.tsx
+++ b/packages/react/src/fiber-node-button/diagnostics-tab.tsx
@@ -1,7 +1,7 @@
 import type { HexString, Script } from '@fiber-pay/sdk/browser';
 import { shannonsToCkb } from '@fiber-pay/sdk/browser';
 import { useMemo } from 'react';
-import { formatRawUdtAmount } from './assets.js';
+import { formatRawUdtAmount, localizeAssetLabel } from './assets.js';
 import { styles } from './styles.js';
 import type { FiberNodeButtonTabContext } from './types.js';
 import type { FiberNodeButtonPanelState } from './use-panel-state.js';
@@ -13,7 +13,11 @@ function formatGraphChannelCapacity(
   assetLabel: string,
 ): string {
   if (udtTypeScript) {
-    return `${formatRawUdtAmount(capacity)} ${assetLabel}`;
+    try {
+      return `${formatRawUdtAmount(BigInt(capacity).toString(10))} ${assetLabel}`;
+    } catch {
+      return `${capacity} ${assetLabel}`;
+    }
   }
   const ckb = shannonsToCkb(capacity as HexString);
   return Number.isFinite(ckb) ? `${ckb.toFixed(4)} ${assetLabel}` : `${capacity} shannons`;
@@ -47,13 +51,7 @@ export function DiagnosticsTab({ state, t }: DiagnosticsTabProps) {
   const formattedGraphChannels = useMemo(
     () =>
       graphChannels.slice(0, 2).map((channel) => {
-        const rawAssetLabel = getUdtAssetLabel(channel.udt_type_script);
-        const assetLabel =
-          rawAssetLabel === 'CKB'
-            ? t('asset.ckb', 'CKB')
-            : rawAssetLabel === 'UDT'
-              ? t('asset.udt', 'UDT')
-              : rawAssetLabel;
+        const assetLabel = localizeAssetLabel(getUdtAssetLabel(channel.udt_type_script), t);
         return {
           ...channel,
           displayCapacity: formatGraphChannelCapacity(
@@ -191,7 +189,7 @@ export function DiagnosticsTab({ state, t }: DiagnosticsTabProps) {
 
         {formattedGraphChannels.map((channel) => (
           <p
-            key={`${channel.node1}-${channel.node2}-${channel.channel_outpoint.tx_hash}`}
+            key={`${channel.node1}-${channel.node2}-${channel.channel_outpoint.tx_hash}-${channel.channel_outpoint.index}`}
             style={styles.inlineCode}
           >
             {shorten(channel.node1, 10, 6)} to {shorten(channel.node2, 10, 6)};{' '}

--- a/packages/react/src/fiber-node-button/index.tsx
+++ b/packages/react/src/fiber-node-button/index.tsx
@@ -128,7 +128,12 @@ export function FiberNodeButton(props: FiberNodeButtonProps) {
       onError={handleConnectButtonError}
       className={className}
       style={style}
-      dropdownStyle={{ maxWidth: 460, width: 'calc(100vw - 1rem)', ...dropdownStyle }}
+      dropdownStyle={{
+        maxWidth: 520,
+        width: 'calc(100vw - 1rem)',
+        boxSizing: 'border-box',
+        ...dropdownStyle,
+      }}
       renderConnectedDropdown={renderDropdown}
     />
   );

--- a/packages/react/src/fiber-node-button/panel.tsx
+++ b/packages/react/src/fiber-node-button/panel.tsx
@@ -187,8 +187,7 @@ export function FiberNodeButtonPanel(props: FiberNodeButtonPanelProps) {
   const tabListStyle = useMemo(
     () => ({
       ...styles.tabList,
-      gridTemplateColumns: `repeat(${Math.max(1, resolvedTabs.length)}, minmax(112px, 1fr))`,
-      overflowX: 'auto' as const,
+      gridTemplateColumns: `repeat(${Math.max(1, resolvedTabs.length)}, minmax(0, 1fr))`,
     }),
     [resolvedTabs.length],
   );
@@ -206,7 +205,6 @@ export function FiberNodeButtonPanel(props: FiberNodeButtonPanelProps) {
         <WorkbenchTab
           state={state}
           fiber={fiber}
-          asset={asset}
           externalFunding={externalFunding}
           renderConnectorSection={renderConnectorSection}
           renderAction={renderAction}
@@ -215,14 +213,7 @@ export function FiberNodeButtonPanel(props: FiberNodeButtonPanelProps) {
       );
     } else if (effectiveActiveTab === 'channels') {
       tabContent = (
-        <ChannelsTab
-          state={state}
-          fiber={fiber}
-          asset={asset}
-          onLog={onLog}
-          renderAction={renderAction}
-          t={t}
-        />
+        <ChannelsTab state={state} fiber={fiber} onLog={onLog} renderAction={renderAction} t={t} />
       );
     } else if (effectiveActiveTab === 'diagnostics') {
       tabContent = <DiagnosticsTab state={state} t={t} />;

--- a/packages/react/src/fiber-node-button/styles.ts
+++ b/packages/react/src/fiber-node-button/styles.ts
@@ -6,9 +6,11 @@ export const styles = {
     display: 'grid',
     gridTemplateRows: 'auto auto minmax(0, 1fr)',
     gap: '0.7rem',
-    minWidth: '280px',
-    width: 'min(460px, calc(100vw - 1rem))',
+    minWidth: 0,
+    width: '100%',
+    maxWidth: '100%',
     maxHeight: '72vh',
+    boxSizing: 'border-box',
   } satisfies CSSProperties,
 
   globalBar: {
@@ -18,14 +20,18 @@ export const styles = {
     padding: '0.52rem 0.56rem',
     display: 'grid',
     gap: '0.45rem',
+    minWidth: 0,
+    maxWidth: '100%',
+    boxSizing: 'border-box',
   } satisfies CSSProperties,
 
   globalRow: {
     display: 'flex',
-    alignItems: 'center',
+    alignItems: 'flex-start',
     justifyContent: 'space-between',
     gap: '0.35rem',
     flexWrap: 'wrap',
+    minWidth: 0,
   } satisfies CSSProperties,
 
   globalMetrics: {
@@ -34,6 +40,7 @@ export const styles = {
     gap: '0.5rem',
     flexWrap: 'wrap',
     minWidth: 0,
+    flex: '1 1 280px',
   } satisfies CSSProperties,
 
   metricInline: {
@@ -99,6 +106,9 @@ export const styles = {
     gap: '0.36rem',
     justifyContent: 'flex-end',
     flexWrap: 'wrap',
+    minWidth: 0,
+    maxWidth: '100%',
+    marginLeft: 'auto',
   } satisfies CSSProperties,
 
   globalActionButton: {
@@ -110,6 +120,9 @@ export const styles = {
     background: '#fff',
     color: 'var(--fpay-text-primary, #111827)',
     cursor: 'pointer',
+    maxWidth: '100%',
+    whiteSpace: 'normal',
+    overflowWrap: 'anywhere',
   } satisfies CSSProperties,
 
   tabList: {
@@ -121,6 +134,9 @@ export const styles = {
     gridTemplateColumns: 'repeat(3, minmax(0, 1fr))',
     gap: '0.14rem',
     boxShadow: 'inset 0 0 0 1px var(--fpay-border, #d8dee8)',
+    minWidth: 0,
+    maxWidth: '100%',
+    overflow: 'hidden',
   } satisfies CSSProperties,
 
   tabButton: {
@@ -132,6 +148,11 @@ export const styles = {
     fontWeight: 700,
     padding: '0.44rem 0.45rem',
     cursor: 'pointer',
+    minWidth: 0,
+    width: '100%',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
   } satisfies CSSProperties,
 
   tabButtonActive: {
@@ -144,6 +165,11 @@ export const styles = {
     padding: '0.44rem 0.45rem',
     cursor: 'pointer',
     boxShadow: 'none',
+    minWidth: 0,
+    width: '100%',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
   } satisfies CSSProperties,
 
   content: {
@@ -152,6 +178,9 @@ export const styles = {
     display: 'grid',
     gap: '0.7rem',
     minHeight: 0,
+    minWidth: 0,
+    maxWidth: '100%',
+    overflowX: 'hidden',
   } satisfies CSSProperties,
 
   section: {
@@ -162,6 +191,8 @@ export const styles = {
     background: 'transparent',
     display: 'grid',
     gap: '0.44rem',
+    minWidth: 0,
+    maxWidth: '100%',
   } satisfies CSSProperties,
 
   sectionTitle: {
@@ -177,6 +208,7 @@ export const styles = {
     alignItems: 'center',
     gap: '0.45rem',
     flexWrap: 'wrap',
+    minWidth: 0,
   } satisfies CSSProperties,
 
   rowBetween: {
@@ -185,6 +217,7 @@ export const styles = {
     justifyContent: 'space-between',
     gap: '0.45rem',
     flexWrap: 'wrap',
+    minWidth: 0,
   } satisfies CSSProperties,
 
   compactText: {
@@ -192,6 +225,9 @@ export const styles = {
     fontSize: '0.74rem',
     color: 'var(--fpay-text-secondary, #64748b)',
     lineHeight: 1.4,
+    minWidth: 0,
+    maxWidth: '100%',
+    overflowWrap: 'anywhere',
   } satisfies CSSProperties,
 
   inlineCode: {
@@ -200,6 +236,9 @@ export const styles = {
     fontSize: '0.72rem',
     color: 'var(--fpay-text-primary, #111827)',
     wordBreak: 'break-all',
+    overflowWrap: 'anywhere',
+    maxWidth: '100%',
+    minWidth: 0,
     lineHeight: 1.4,
   } satisfies CSSProperties,
 
@@ -210,6 +249,8 @@ export const styles = {
     fontWeight: 700,
     color: 'var(--fpay-text-secondary, #64748b)',
     textTransform: 'uppercase',
+    minWidth: 0,
+    maxWidth: '100%',
   } satisfies CSSProperties,
 
   input: {
@@ -220,6 +261,25 @@ export const styles = {
     fontSize: '0.8rem',
     background: '#fff',
     color: 'var(--fpay-text-primary, #0f172a)',
+    minWidth: 0,
+    maxWidth: '100%',
+    boxSizing: 'border-box',
+  } satisfies CSSProperties,
+
+  textarea: {
+    width: '100%',
+    border: '1px solid var(--fpay-border, #cbd5e1)',
+    borderRadius: '0.45rem',
+    padding: '0.38rem 0.48rem',
+    fontSize: '0.75rem',
+    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+    lineHeight: 1.4,
+    resize: 'vertical',
+    background: '#fff',
+    color: 'var(--fpay-text-primary, #0f172a)',
+    minWidth: 0,
+    maxWidth: '100%',
+    boxSizing: 'border-box',
   } satisfies CSSProperties,
 
   actionButton: {
@@ -231,6 +291,9 @@ export const styles = {
     background: '#fff',
     color: 'var(--fpay-text-primary, #111827)',
     cursor: 'pointer',
+    maxWidth: '100%',
+    whiteSpace: 'normal',
+    overflowWrap: 'anywhere',
   } satisfies CSSProperties,
 
   primaryButton: {
@@ -242,6 +305,9 @@ export const styles = {
     background: 'var(--fpay-accent, #1d4ed8)',
     color: '#fff',
     cursor: 'pointer',
+    maxWidth: '100%',
+    whiteSpace: 'normal',
+    overflowWrap: 'anywhere',
   } satisfies CSSProperties,
 
   ghostButton: {
@@ -253,6 +319,9 @@ export const styles = {
     background: 'transparent',
     color: 'var(--fpay-text-secondary, #475569)',
     cursor: 'pointer',
+    maxWidth: '100%',
+    whiteSpace: 'normal',
+    overflowWrap: 'anywhere',
   } satisfies CSSProperties,
 
   dangerButton: {
@@ -264,6 +333,9 @@ export const styles = {
     background: '#fff1f2',
     color: '#9f1239',
     cursor: 'pointer',
+    maxWidth: '100%',
+    whiteSpace: 'normal',
+    overflowWrap: 'anywhere',
   } satisfies CSSProperties,
 
   badge: {
@@ -278,6 +350,11 @@ export const styles = {
     fontSize: '0.66rem',
     fontWeight: 700,
     lineHeight: 1.1,
+    maxWidth: '100%',
+    minWidth: 0,
+    whiteSpace: 'normal',
+    wordBreak: 'break-all',
+    overflowWrap: 'anywhere',
   } satisfies CSSProperties,
 
   notice: {
@@ -342,12 +419,31 @@ export const styles = {
     gap: '0.28rem',
   } satisfies CSSProperties,
 
+  filterStack: {
+    display: 'grid',
+    gap: '0.34rem',
+    minWidth: 0,
+  } satisfies CSSProperties,
+
+  filterFieldset: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    gap: '0.28rem',
+    minWidth: 0,
+    margin: 0,
+    padding: 0,
+    border: 0,
+  } satisfies CSSProperties,
+
   list: {
     display: 'grid',
     gap: '0.34rem',
     maxHeight: '240px',
     overflowY: 'auto',
+    overflowX: 'hidden',
     paddingRight: '0.1rem',
+    minWidth: 0,
+    maxWidth: '100%',
   } satisfies CSSProperties,
 
   compactChannelRow: {
@@ -359,6 +455,11 @@ export const styles = {
     display: 'grid',
     gap: '0.22rem',
     textAlign: 'left',
+    width: '100%',
+    minWidth: 0,
+    maxWidth: '100%',
+    boxSizing: 'border-box',
+    overflow: 'hidden',
   } satisfies CSSProperties,
 
   compactChannelRowActive: {
@@ -369,9 +470,20 @@ export const styles = {
 
   compactChannelTop: {
     display: 'grid',
-    gridTemplateColumns: '1fr auto',
+    gridTemplateColumns: 'minmax(0, 1fr) minmax(0, auto)',
     alignItems: 'center',
     gap: '0.35rem',
+    minWidth: 0,
+  } satisfies CSSProperties,
+
+  badgeGroup: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'flex-end',
+    flexWrap: 'wrap',
+    gap: '0.24rem',
+    minWidth: 0,
+    maxWidth: '100%',
   } satisfies CSSProperties,
 
   detailPanel: {
@@ -381,6 +493,25 @@ export const styles = {
     padding: '0.6rem',
     display: 'grid',
     gap: '0.45rem',
+    minWidth: 0,
+    maxWidth: '100%',
+    boxSizing: 'border-box',
+  } satisfies CSSProperties,
+
+  scriptCode: {
+    margin: '0.42rem 0 0',
+    maxWidth: '100%',
+    maxHeight: '160px',
+    overflow: 'auto',
+    borderRadius: '0.45rem',
+    background: '#eef2f7',
+    padding: '0.45rem',
+    boxSizing: 'border-box',
+    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+    fontSize: '0.68rem',
+    lineHeight: 1.4,
+    whiteSpace: 'pre-wrap',
+    wordBreak: 'break-all',
   } satisfies CSSProperties,
 
   dialogBackdrop: {
@@ -401,6 +532,8 @@ export const styles = {
     padding: '0.72rem',
     display: 'grid',
     gap: '0.55rem',
+    maxWidth: '100%',
+    boxSizing: 'border-box',
   } satisfies CSSProperties,
 
   srOnly: {

--- a/packages/react/src/fiber-node-button/types.ts
+++ b/packages/react/src/fiber-node-button/types.ts
@@ -158,7 +158,7 @@ export interface FiberNodeButtonProps {
   passkeyUsername?: string;
   wasmFactory?: FiberWasmFactory;
   nodeConfig?: UseFiberNodeOptions['nodeConfig'];
-  /** Asset for channel funding, invoices, and payments. Defaults to CKB. */
+  /** Initial asset for channel funding, invoices, and payments. Defaults to CKB. */
   asset?: UdtAsset;
   className?: string;
   style?: CSSProperties;

--- a/packages/react/src/fiber-node-button/use-panel-state.ts
+++ b/packages/react/src/fiber-node-button/use-panel-state.ts
@@ -3,7 +3,9 @@ import type {
   Channel,
   GetPaymentResult,
   HexString,
+  Script,
   ShutdownChannelParams,
+  UdtAsset,
   UdtTypeScript,
 } from '@fiber-pay/sdk/browser';
 import {
@@ -25,6 +27,17 @@ import {
 import { buildNewInvoiceParams } from '../invoice-params.js';
 import { type UseChannelOpenFlowResult, useChannelOpenFlow } from '../use-channel-open-flow.js';
 import { useFiberPayment } from '../use-fiber-payment.js';
+import {
+  buildPanelAssetOptions,
+  CKB_ASSET_KEY,
+  getAssetKey,
+  getAssetLabelForScript,
+  getChannelAssetKey,
+  type PanelAssetOption,
+  resolvePanelAsset,
+  tryResolvePanelAsset,
+} from './assets.js';
+import { defaultFiberNodeButtonI18n } from './i18n.js';
 import type {
   ChannelFilter,
   FiberNodeButtonConnectorSectionContext,
@@ -54,6 +67,12 @@ export interface PanelChannelCounts {
   all: number;
 }
 
+export interface PanelChannelAssetCount {
+  key: string;
+  label: string;
+  count: number;
+}
+
 export interface FiberNodeButtonPanelState {
   activeTab: PanelTab;
   switchTab: (next: PanelTab) => void;
@@ -68,6 +87,23 @@ export interface FiberNodeButtonPanelState {
   fundingAmountCkb: string;
   invoiceAmount: string;
   setInvoiceAmount: Dispatch<SetStateAction<string>>;
+  availableAssets: PanelAssetOption[];
+  showAssetSelectors: boolean;
+  openChannelAssetKey: string;
+  selectOpenChannelAsset: (key: string) => void;
+  openChannelCustomUdt: string;
+  setOpenChannelCustomUdt: Dispatch<SetStateAction<string>>;
+  openChannelAsset: UdtAsset | null;
+  createInvoiceAssetKey: string;
+  selectCreateInvoiceAsset: (key: string) => void;
+  createInvoiceCustomUdt: string;
+  setCreateInvoiceCustomUdt: Dispatch<SetStateAction<string>>;
+  createInvoiceAsset: UdtAsset | null;
+  paymentAssetKey: string;
+  selectPaymentAsset: (key: string) => void;
+  paymentCustomUdt: string;
+  setPaymentCustomUdt: Dispatch<SetStateAction<string>>;
+  paymentAsset: UdtAsset | null;
   peerListId: string;
   connectedPeers: PeerInfo[];
   isRefreshingPeers: boolean;
@@ -81,6 +117,12 @@ export interface FiberNodeButtonPanelState {
   channels: Channel[];
   channelFilter: ChannelFilter;
   setChannelFilter: Dispatch<SetStateAction<ChannelFilter>>;
+  channelAssetFilter: string;
+  setChannelAssetFilter: Dispatch<SetStateAction<string>>;
+  channelAssetCounts: PanelChannelAssetCount[];
+  channelFilterCounts: PanelChannelCounts;
+  getChannelAssetLabel: (channel: Channel) => string;
+  getUdtAssetLabel: (script: Script | null | undefined) => string;
   isRefreshingChannels: boolean;
   refreshChannels: () => Promise<void>;
   closeChannel: (channelId: string, force?: boolean) => Promise<void>;
@@ -112,16 +154,6 @@ export interface FiberNodeButtonPanelState {
   connectorContext: FiberNodeButtonConnectorSectionContext;
 }
 
-function getAssetIdentity(asset: FiberNodeButtonPanelProps['asset']): string {
-  if (!asset || asset.kind === 'ckb') {
-    return 'ckb';
-  }
-  if (!asset.script) {
-    return 'udt:invalid';
-  }
-  return `${asset.script.code_hash}:${asset.script.hash_type}:${asset.script.args}`.toLowerCase();
-}
-
 export function useFiberNodeButtonPanelState(
   props: FiberNodeButtonPanelProps,
 ): FiberNodeButtonPanelState {
@@ -138,6 +170,8 @@ export function useFiberNodeButtonPanelState(
     invoiceAmount: initialInvoiceAmount,
     externalFunding,
   } = props;
+  const t = props.t ?? defaultFiberNodeButtonI18n;
+  const initialAssetKey = getAssetKey(asset);
 
   const [activeTab, setActiveTab] = useState<PanelTab>('workbench');
 
@@ -146,7 +180,15 @@ export function useFiberNodeButtonPanelState(
   const [fundingAmount, setFundingAmount] = useState(
     initialFundingAmount ?? initialFundingAmountCkb ?? '1000',
   );
-  const [invoiceAmount, setInvoiceAmount] = useState(initialInvoiceAmount ?? '1');
+  const [invoiceAmount, setInvoiceAmount] = useState(
+    initialInvoiceAmount ?? (asset.kind === 'ckb' ? '1' : ''),
+  );
+  const [openChannelAssetKey, setOpenChannelAssetKey] = useState(initialAssetKey);
+  const [openChannelCustomUdt, setOpenChannelCustomUdt] = useState('');
+  const [createInvoiceAssetKey, setCreateInvoiceAssetKey] = useState(initialAssetKey);
+  const [createInvoiceCustomUdt, setCreateInvoiceCustomUdt] = useState('');
+  const [paymentAssetKey, setPaymentAssetKey] = useState(initialAssetKey);
+  const [paymentCustomUdt, setPaymentCustomUdt] = useState('');
 
   const [connectedPeers, setConnectedPeers] = useState<PeerInfo[]>([]);
   const [isRefreshingPeers, setIsRefreshingPeers] = useState(false);
@@ -158,6 +200,7 @@ export function useFiberNodeButtonPanelState(
 
   const [channels, setChannels] = useState<Channel[]>([]);
   const [channelFilter, setChannelFilter] = useState<ChannelFilter>('active');
+  const [channelAssetFilter, setChannelAssetFilter] = useState('all');
   const [isRefreshingChannels, setIsRefreshingChannels] = useState(false);
   const [closingChannelId, setClosingChannelId] = useState<string | null>(null);
   const [selectedChannelId, setSelectedChannelId] = useState<string | null>(null);
@@ -172,7 +215,7 @@ export function useFiberNodeButtonPanelState(
 
   const statusTimerRef = useRef<number | null>(null);
   const mountedRef = useRef(true);
-  const previousAssetIdentityRef = useRef(getAssetIdentity(asset));
+  const previousAssetIdentityRef = useRef(initialAssetKey);
   const peerListId = useId();
   const tabPanelId = useId();
 
@@ -181,7 +224,29 @@ export function useFiberNodeButtonPanelState(
     onLog,
   });
 
-  const paymentOptions = useMemo(() => ({ asset, network }), [asset, network]);
+  const availableAssets = useMemo(
+    () => buildPanelAssetOptions(fiber.nodeInfo?.udt_cfg_infos, asset),
+    [asset, fiber.nodeInfo?.udt_cfg_infos],
+  );
+  const showAssetSelectors = availableAssets.some((option) => option.asset.kind === 'udt');
+
+  const openChannelAsset = useMemo(
+    () => tryResolvePanelAsset(openChannelAssetKey, openChannelCustomUdt, availableAssets),
+    [availableAssets, openChannelAssetKey, openChannelCustomUdt],
+  );
+  const createInvoiceAsset = useMemo(
+    () => tryResolvePanelAsset(createInvoiceAssetKey, createInvoiceCustomUdt, availableAssets),
+    [availableAssets, createInvoiceAssetKey, createInvoiceCustomUdt],
+  );
+  const paymentAsset = useMemo(
+    () => tryResolvePanelAsset(paymentAssetKey, paymentCustomUdt, availableAssets),
+    [availableAssets, paymentAssetKey, paymentCustomUdt],
+  );
+
+  const paymentOptions = useMemo(
+    () => ({ asset: paymentAsset ?? DEFAULT_CKB_ASSET, network }),
+    [network, paymentAsset],
+  );
 
   const {
     payInvoice,
@@ -202,15 +267,58 @@ export function useFiberNodeButtonPanelState(
     };
   }, []);
 
+  const selectOpenChannelAsset = useCallback(
+    (key: string) => {
+      setOpenChannelAssetKey(key);
+      const nextAmount =
+        key === initialAssetKey
+          ? (initialFundingAmount ?? initialFundingAmountCkb ?? '1000')
+          : key === CKB_ASSET_KEY
+            ? (initialFundingAmountCkb ?? '1000')
+            : '';
+      setFundingAmount(nextAmount);
+      setLatestError(null);
+    },
+    [initialAssetKey, initialFundingAmount, initialFundingAmountCkb],
+  );
+
+  const selectCreateInvoiceAsset = useCallback(
+    (key: string) => {
+      setCreateInvoiceAssetKey(key);
+      const nextAmount =
+        key === initialAssetKey && initialInvoiceAmount !== undefined
+          ? initialInvoiceAmount
+          : key === CKB_ASSET_KEY
+            ? '1'
+            : '';
+      setInvoiceAmount(nextAmount);
+      setCreatedInvoice('');
+      setLatestError(null);
+    },
+    [initialAssetKey, initialInvoiceAmount],
+  );
+
+  const selectPaymentAsset = useCallback((key: string) => {
+    setPaymentAssetKey(key);
+    setInvoiceInput('');
+    setLatestError(null);
+  }, []);
+
   useEffect(() => {
-    const nextIdentity = getAssetIdentity(asset);
+    const nextIdentity = getAssetKey(asset);
     if (previousAssetIdentityRef.current === nextIdentity) {
       return;
     }
 
     previousAssetIdentityRef.current = nextIdentity;
+    setOpenChannelAssetKey(nextIdentity);
+    setCreateInvoiceAssetKey(nextIdentity);
+    setPaymentAssetKey(nextIdentity);
+    setOpenChannelCustomUdt('');
+    setCreateInvoiceCustomUdt('');
+    setPaymentCustomUdt('');
     setFundingAmount(initialFundingAmount ?? initialFundingAmountCkb ?? '1000');
-    setInvoiceAmount(initialInvoiceAmount ?? '1');
+    setInvoiceAmount(initialInvoiceAmount ?? (asset.kind === 'ckb' ? '1' : ''));
     setInvoiceInput('');
     setCreatedInvoice('');
     setLatestError(null);
@@ -236,30 +344,52 @@ export function useFiberNodeButtonPanelState(
     [onError, onLog],
   );
 
-  const ensureAssetConfigured = useCallback(() => {
-    if (asset.kind !== 'udt') {
-      return true;
-    }
+  const resolveActionAsset = useCallback(
+    (key: string, customScript: string): UdtAsset | null => {
+      try {
+        return resolvePanelAsset(key, customScript, availableAssets);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        reportError(
+          t('asset.error.invalidSelection', 'Invalid asset selection: {message}', { message }),
+        );
+        return null;
+      }
+    },
+    [availableAssets, reportError, t],
+  );
 
-    let validatedScript: UdtTypeScript;
-    try {
-      validatedScript = validateUdtTypeScript(asset.script);
-    } catch (error) {
-      reportError(error instanceof Error ? error.message : String(error));
+  const ensureAssetConfigured = useCallback(
+    (selectedAsset: UdtAsset) => {
+      if (selectedAsset.kind !== 'udt') {
+        return true;
+      }
+
+      let validatedScript: UdtTypeScript;
+      try {
+        validatedScript = validateUdtTypeScript(selectedAsset.script);
+      } catch (error) {
+        reportError(error instanceof Error ? error.message : String(error));
+        return false;
+      }
+
+      const configuredUdts = fiber.nodeInfo?.udt_cfg_infos ?? [];
+
+      if (configuredUdts.some((entry) => areUdtTypeScriptsEqual(entry.script, validatedScript))) {
+        return true;
+      }
+
+      reportError(
+        t(
+          'asset.error.notConfigured',
+          'UDT asset {asset} is not present in the node whitelist. Configure nodeConfig.udtWhitelist with the same type script and cell deps before using it.',
+          { asset: selectedAsset.name?.trim() || t('asset.udt', 'UDT') },
+        ),
+      );
       return false;
-    }
-
-    const configuredUdts = fiber.nodeInfo?.udt_cfg_infos ?? [];
-
-    if (configuredUdts.some((entry) => areUdtTypeScriptsEqual(entry.script, validatedScript))) {
-      return true;
-    }
-
-    reportError(
-      `UDT asset ${asset.name?.trim() || 'UDT'} is not present in the node whitelist. Configure nodeConfig.udtWhitelist with the same type script and cell deps before using it.`,
-    );
-    return false;
-  }, [asset, fiber.nodeInfo?.udt_cfg_infos, reportError]);
+    },
+    [fiber.nodeInfo?.udt_cfg_infos, reportError, t],
+  );
 
   const refreshConnectedPeers = useCallback(async () => {
     if (!fiber.node) {
@@ -474,7 +604,8 @@ export function useFiberNodeButtonPanelState(
       return;
     }
 
-    if (!ensureAssetConfigured()) {
+    const selectedAsset = resolveActionAsset(openChannelAssetKey, openChannelCustomUdt);
+    if (!selectedAsset || !ensureAssetConfigured(selectedAsset)) {
       return;
     }
 
@@ -488,7 +619,7 @@ export function useFiberNodeButtonPanelState(
           pubkey,
           fundingAmount,
           externalWallet: false,
-          asset,
+          asset: selectedAsset,
         });
         if (!openResult) {
           return;
@@ -502,7 +633,7 @@ export function useFiberNodeButtonPanelState(
       const resolved = await externalFunding.resolve({
         node: fiber.node,
         pubkey,
-        asset,
+        asset: selectedAsset,
         fundingAmount,
         fundingAmountCkb: fundingAmount,
       });
@@ -511,7 +642,7 @@ export function useFiberNodeButtonPanelState(
         pubkey,
         fundingAmount,
         externalWallet: true,
-        asset,
+        asset: selectedAsset,
         shutdownScript: resolved.shutdownScript,
         fundingLockScript: resolved.fundingLockScript,
         fundingLockScriptCellDeps: resolved.fundingLockScriptCellDeps,
@@ -530,7 +661,6 @@ export function useFiberNodeButtonPanelState(
       onLog?.(`Open channel failed: ${message}`);
     }
   }, [
-    asset,
     channelOpenFlow,
     externalFunding,
     ensureAssetConfigured,
@@ -538,9 +668,12 @@ export function useFiberNodeButtonPanelState(
     flashStatus,
     fundingAmount,
     onLog,
+    openChannelAssetKey,
+    openChannelCustomUdt,
     peerPubkey,
     refreshChannels,
     reportError,
+    resolveActionAsset,
   ]);
 
   const createInvoice = useCallback(async () => {
@@ -549,7 +682,8 @@ export function useFiberNodeButtonPanelState(
       return;
     }
 
-    if (!ensureAssetConfigured()) {
+    const selectedAsset = resolveActionAsset(createInvoiceAssetKey, createInvoiceCustomUdt);
+    if (!selectedAsset || !ensureAssetConfigured(selectedAsset)) {
       return;
     }
 
@@ -559,7 +693,7 @@ export function useFiberNodeButtonPanelState(
       const amountInput = invoiceAmount.trim();
       const params = buildNewInvoiceParams({
         amountInput,
-        asset,
+        asset: selectedAsset,
         network,
         descriptionPrefix: 'FiberNodeButton invoice',
       });
@@ -575,7 +709,8 @@ export function useFiberNodeButtonPanelState(
       setIsCreatingInvoice(false);
     }
   }, [
-    asset,
+    createInvoiceAssetKey,
+    createInvoiceCustomUdt,
     ensureAssetConfigured,
     fiber.node,
     flashStatus,
@@ -583,6 +718,7 @@ export function useFiberNodeButtonPanelState(
     network,
     onLog,
     reportError,
+    resolveActionAsset,
   ]);
 
   const submitPayment = useCallback(async () => {
@@ -592,13 +728,24 @@ export function useFiberNodeButtonPanelState(
       return;
     }
 
-    if (!ensureAssetConfigured()) {
+    const selectedAsset = resolveActionAsset(paymentAssetKey, paymentCustomUdt);
+    if (!selectedAsset || !ensureAssetConfigured(selectedAsset)) {
       return;
     }
 
     onLog?.('fiber_panel_primary_action_clicked: pay_invoice');
-    await payInvoice(normalizedInvoice);
-  }, [ensureAssetConfigured, invoiceInput, onLog, payInvoice, reportError]);
+    await payInvoice(normalizedInvoice, { asset: selectedAsset, network });
+  }, [
+    ensureAssetConfigured,
+    invoiceInput,
+    network,
+    onLog,
+    payInvoice,
+    paymentAssetKey,
+    paymentCustomUdt,
+    reportError,
+    resolveActionAsset,
+  ]);
 
   useEffect(() => {
     if (!fiber.isRunning || !fiber.node) {
@@ -636,6 +783,16 @@ export function useFiberNodeButtonPanelState(
     onLog?.(`Payment status: ${paymentResult.status}`);
   }, [flashStatus, onLog, paymentResult]);
 
+  const getUdtAssetLabel = useCallback(
+    (script: Script | null | undefined) => getAssetLabelForScript(script, availableAssets),
+    [availableAssets],
+  );
+
+  const getChannelAssetLabel = useCallback(
+    (channel: Channel) => getUdtAssetLabel(channel.funding_udt_type_script),
+    [getUdtAssetLabel],
+  );
+
   const channelCounts = useMemo(() => {
     const counts = { active: 0, pending: 0, closed: 0, all: channels.length };
 
@@ -646,12 +803,63 @@ export function useFiberNodeButtonPanelState(
     return counts;
   }, [channels]);
 
+  const channelAssetCounts = useMemo(() => {
+    const counts = new Map<string, PanelChannelAssetCount>();
+    for (const channel of channels) {
+      const key = getChannelAssetKey(channel.funding_udt_type_script);
+      const existing = counts.get(key);
+      if (existing) {
+        existing.count += 1;
+      } else {
+        counts.set(key, {
+          key,
+          label: getChannelAssetLabel(channel),
+          count: 1,
+        });
+      }
+    }
+
+    const assetOrder = new Map(availableAssets.map((option, index) => [option.key, index]));
+    return Array.from(counts.values()).sort(
+      (left, right) =>
+        (assetOrder.get(left.key) ?? Number.MAX_SAFE_INTEGER) -
+        (assetOrder.get(right.key) ?? Number.MAX_SAFE_INTEGER),
+    );
+  }, [availableAssets, channels, getChannelAssetLabel]);
+
+  useEffect(() => {
+    if (
+      channelAssetFilter !== 'all' &&
+      !channelAssetCounts.some((entry) => entry.key === channelAssetFilter)
+    ) {
+      setChannelAssetFilter('all');
+    }
+  }, [channelAssetCounts, channelAssetFilter]);
+
+  const channelsForAsset = useMemo(
+    () =>
+      channelAssetFilter === 'all'
+        ? channels
+        : channels.filter(
+            (channel) => getChannelAssetKey(channel.funding_udt_type_script) === channelAssetFilter,
+          ),
+    [channelAssetFilter, channels],
+  );
+
+  const channelFilterCounts = useMemo(() => {
+    const counts = { active: 0, pending: 0, closed: 0, all: channelsForAsset.length };
+    for (const channel of channelsForAsset) {
+      counts[getChannelFilterState(channel)] += 1;
+    }
+    return counts;
+  }, [channelsForAsset]);
+
   const visibleChannels = useMemo(
     () =>
       channelFilter === 'all'
-        ? channels
-        : channels.filter((channel) => getChannelFilterState(channel) === channelFilter),
-    [channelFilter, channels],
+        ? channelsForAsset
+        : channelsForAsset.filter((channel) => getChannelFilterState(channel) === channelFilter),
+    [channelFilter, channelsForAsset],
   );
 
   const activeChannelCount = channelCounts.active;
@@ -695,11 +903,11 @@ export function useFiberNodeButtonPanelState(
   const connectorContext: FiberNodeButtonConnectorSectionContext = useMemo(
     () => ({
       fiber,
-      asset,
+      asset: openChannelAsset ?? asset,
       externalFundingEnabled: !!externalFunding?.enabled,
       isOpeningChannel: channelOpenFlow.isOpening,
     }),
-    [asset, channelOpenFlow.isOpening, externalFunding?.enabled, fiber],
+    [asset, channelOpenFlow.isOpening, externalFunding?.enabled, fiber, openChannelAsset],
   );
 
   const switchTab = useCallback(
@@ -730,6 +938,23 @@ export function useFiberNodeButtonPanelState(
     fundingAmountCkb: fundingAmount,
     invoiceAmount,
     setInvoiceAmount,
+    availableAssets,
+    showAssetSelectors,
+    openChannelAssetKey,
+    selectOpenChannelAsset,
+    openChannelCustomUdt,
+    setOpenChannelCustomUdt,
+    openChannelAsset,
+    createInvoiceAssetKey,
+    selectCreateInvoiceAsset,
+    createInvoiceCustomUdt,
+    setCreateInvoiceCustomUdt,
+    createInvoiceAsset,
+    paymentAssetKey,
+    selectPaymentAsset,
+    paymentCustomUdt,
+    setPaymentCustomUdt,
+    paymentAsset,
     peerListId,
     // peers
     connectedPeers,
@@ -746,6 +971,12 @@ export function useFiberNodeButtonPanelState(
     channels,
     channelFilter,
     setChannelFilter,
+    channelAssetFilter,
+    setChannelAssetFilter,
+    channelAssetCounts,
+    channelFilterCounts,
+    getChannelAssetLabel,
+    getUdtAssetLabel,
     isRefreshingChannels,
     refreshChannels,
     closeChannel,

--- a/packages/react/src/fiber-node-button/use-panel-state.ts
+++ b/packages/react/src/fiber-node-button/use-panel-state.ts
@@ -31,7 +31,6 @@ import {
   buildPanelAssetOptions,
   CKB_ASSET_KEY,
   getAssetKey,
-  getAssetLabelForScript,
   getChannelAssetKey,
   type PanelAssetOption,
   resolvePanelAsset,
@@ -71,6 +70,29 @@ export interface PanelChannelAssetCount {
   key: string;
   label: string;
   count: number;
+}
+
+function getDefaultFundingAmountForAsset(
+  key: string,
+  initialAssetKey: string,
+  initialFundingAmount: string | undefined,
+  initialFundingAmountCkb: string | undefined,
+): string {
+  if (key === initialAssetKey || key === CKB_ASSET_KEY) {
+    return initialFundingAmount ?? initialFundingAmountCkb ?? '1000';
+  }
+  return '';
+}
+
+function getDefaultInvoiceAmountForAsset(
+  key: string,
+  initialAssetKey: string,
+  initialInvoiceAmount: string | undefined,
+): string {
+  if (key === initialAssetKey && initialInvoiceAmount !== undefined) {
+    return initialInvoiceAmount;
+  }
+  return key === CKB_ASSET_KEY ? '1' : '';
 }
 
 export interface FiberNodeButtonPanelState {
@@ -171,7 +193,14 @@ export function useFiberNodeButtonPanelState(
     externalFunding,
   } = props;
   const t = props.t ?? defaultFiberNodeButtonI18n;
-  const initialAssetKey = getAssetKey(asset);
+  const requestedInitialAssetKey = getAssetKey(asset);
+  const availableAssets = useMemo(
+    () => buildPanelAssetOptions(fiber.nodeInfo?.udt_cfg_infos, asset),
+    [asset, fiber.nodeInfo?.udt_cfg_infos],
+  );
+  const initialAssetKey = availableAssets.some((option) => option.key === requestedInitialAssetKey)
+    ? requestedInitialAssetKey
+    : CKB_ASSET_KEY;
 
   const [activeTab, setActiveTab] = useState<PanelTab>('workbench');
 
@@ -181,7 +210,7 @@ export function useFiberNodeButtonPanelState(
     initialFundingAmount ?? initialFundingAmountCkb ?? '1000',
   );
   const [invoiceAmount, setInvoiceAmount] = useState(
-    initialInvoiceAmount ?? (asset.kind === 'ckb' ? '1' : ''),
+    initialInvoiceAmount ?? (initialAssetKey === CKB_ASSET_KEY ? '1' : ''),
   );
   const [openChannelAssetKey, setOpenChannelAssetKey] = useState(initialAssetKey);
   const [openChannelCustomUdt, setOpenChannelCustomUdt] = useState('');
@@ -224,24 +253,25 @@ export function useFiberNodeButtonPanelState(
     onLog,
   });
 
-  const availableAssets = useMemo(
-    () => buildPanelAssetOptions(fiber.nodeInfo?.udt_cfg_infos, asset),
-    [asset, fiber.nodeInfo?.udt_cfg_infos],
-  );
   const showAssetSelectors = availableAssets.some((option) => option.asset.kind === 'udt');
 
-  const openChannelAsset = useMemo(
+  const openChannelAssetResolution = useMemo(
     () => tryResolvePanelAsset(openChannelAssetKey, openChannelCustomUdt, availableAssets),
     [availableAssets, openChannelAssetKey, openChannelCustomUdt],
   );
-  const createInvoiceAsset = useMemo(
+  const openChannelAsset = openChannelAssetResolution.ok ? openChannelAssetResolution.asset : null;
+  const createInvoiceAssetResolution = useMemo(
     () => tryResolvePanelAsset(createInvoiceAssetKey, createInvoiceCustomUdt, availableAssets),
     [availableAssets, createInvoiceAssetKey, createInvoiceCustomUdt],
   );
-  const paymentAsset = useMemo(
+  const createInvoiceAsset = createInvoiceAssetResolution.ok
+    ? createInvoiceAssetResolution.asset
+    : null;
+  const paymentAssetResolution = useMemo(
     () => tryResolvePanelAsset(paymentAssetKey, paymentCustomUdt, availableAssets),
     [availableAssets, paymentAssetKey, paymentCustomUdt],
   );
+  const paymentAsset = paymentAssetResolution.ok ? paymentAssetResolution.asset : null;
 
   const paymentOptions = useMemo(
     () => ({ asset: paymentAsset ?? DEFAULT_CKB_ASSET, network }),
@@ -255,7 +285,7 @@ export function useFiberNodeButtonPanelState(
     error: paymentError,
   } = useFiberPayment(fiber.node, paymentOptions);
 
-  const isNodeReady = fiber.isRunning && !!fiber.node;
+  const isNodeReady = fiber.isRunning && !!fiber.node && !!fiber.nodeInfo;
 
   useEffect(() => {
     mountedRef.current = true;
@@ -270,13 +300,14 @@ export function useFiberNodeButtonPanelState(
   const selectOpenChannelAsset = useCallback(
     (key: string) => {
       setOpenChannelAssetKey(key);
-      const nextAmount =
-        key === initialAssetKey
-          ? (initialFundingAmount ?? initialFundingAmountCkb ?? '1000')
-          : key === CKB_ASSET_KEY
-            ? (initialFundingAmountCkb ?? '1000')
-            : '';
-      setFundingAmount(nextAmount);
+      setFundingAmount(
+        getDefaultFundingAmountForAsset(
+          key,
+          initialAssetKey,
+          initialFundingAmount,
+          initialFundingAmountCkb,
+        ),
+      );
       setLatestError(null);
     },
     [initialAssetKey, initialFundingAmount, initialFundingAmountCkb],
@@ -285,13 +316,7 @@ export function useFiberNodeButtonPanelState(
   const selectCreateInvoiceAsset = useCallback(
     (key: string) => {
       setCreateInvoiceAssetKey(key);
-      const nextAmount =
-        key === initialAssetKey && initialInvoiceAmount !== undefined
-          ? initialInvoiceAmount
-          : key === CKB_ASSET_KEY
-            ? '1'
-            : '';
-      setInvoiceAmount(nextAmount);
+      setInvoiceAmount(getDefaultInvoiceAmountForAsset(key, initialAssetKey, initialInvoiceAmount));
       setCreatedInvoice('');
       setLatestError(null);
     },
@@ -305,7 +330,7 @@ export function useFiberNodeButtonPanelState(
   }, []);
 
   useEffect(() => {
-    const nextIdentity = getAssetKey(asset);
+    const nextIdentity = initialAssetKey;
     if (previousAssetIdentityRef.current === nextIdentity) {
       return;
     }
@@ -318,11 +343,11 @@ export function useFiberNodeButtonPanelState(
     setCreateInvoiceCustomUdt('');
     setPaymentCustomUdt('');
     setFundingAmount(initialFundingAmount ?? initialFundingAmountCkb ?? '1000');
-    setInvoiceAmount(initialInvoiceAmount ?? (asset.kind === 'ckb' ? '1' : ''));
+    setInvoiceAmount(initialInvoiceAmount ?? (initialAssetKey === CKB_ASSET_KEY ? '1' : ''));
     setInvoiceInput('');
     setCreatedInvoice('');
     setLatestError(null);
-  }, [asset, initialFundingAmount, initialFundingAmountCkb, initialInvoiceAmount]);
+  }, [initialAssetKey, initialFundingAmount, initialFundingAmountCkb, initialInvoiceAmount]);
 
   const flashStatus = useCallback((text: string, tone: 'info' | 'success' = 'info') => {
     setStatusNotice({ tone, text });
@@ -375,7 +400,16 @@ export function useFiberNodeButtonPanelState(
 
       const configuredUdts = fiber.nodeInfo?.udt_cfg_infos ?? [];
 
-      if (configuredUdts.some((entry) => areUdtTypeScriptsEqual(entry.script, validatedScript))) {
+      if (
+        configuredUdts.some((entry) => {
+          try {
+            const configuredScript = validateUdtTypeScript(entry.script, 'node UDT config');
+            return areUdtTypeScriptsEqual(configuredScript, validatedScript);
+          } catch {
+            return false;
+          }
+        })
+      ) {
         return true;
       }
 
@@ -783,9 +817,19 @@ export function useFiberNodeButtonPanelState(
     onLog?.(`Payment status: ${paymentResult.status}`);
   }, [flashStatus, onLog, paymentResult]);
 
-  const getUdtAssetLabel = useCallback(
-    (script: Script | null | undefined) => getAssetLabelForScript(script, availableAssets),
+  const assetLabelsByKey = useMemo(
+    () => new Map(availableAssets.map((option) => [option.key, option.label])),
     [availableAssets],
+  );
+
+  const getUdtAssetLabel = useCallback(
+    (script: Script | null | undefined) => {
+      if (!script) {
+        return 'CKB';
+      }
+      return assetLabelsByKey.get(getChannelAssetKey(script)) ?? 'UDT';
+    },
+    [assetLabelsByKey],
   );
 
   const getChannelAssetLabel = useCallback(
@@ -813,7 +857,7 @@ export function useFiberNodeButtonPanelState(
       } else {
         counts.set(key, {
           key,
-          label: getChannelAssetLabel(channel),
+          label: assetLabelsByKey.get(key) ?? (key === CKB_ASSET_KEY ? 'CKB' : 'UDT'),
           count: 1,
         });
       }
@@ -825,7 +869,7 @@ export function useFiberNodeButtonPanelState(
         (assetOrder.get(left.key) ?? Number.MAX_SAFE_INTEGER) -
         (assetOrder.get(right.key) ?? Number.MAX_SAFE_INTEGER),
     );
-  }, [availableAssets, channels, getChannelAssetLabel]);
+  }, [assetLabelsByKey, availableAssets, channels]);
 
   useEffect(() => {
     if (

--- a/packages/react/src/fiber-node-button/workbench-tab.tsx
+++ b/packages/react/src/fiber-node-button/workbench-tab.tsx
@@ -1,5 +1,6 @@
-import type { UdtAsset } from '@fiber-pay/sdk/browser';
 import { formatAssetName } from '@fiber-pay/sdk/browser';
+import { AssetSelect } from './asset-select.js';
+import { CUSTOM_ASSET_KEY } from './assets.js';
 import { renderPanelAction } from './render-action.js';
 import { styles } from './styles.js';
 import type {
@@ -14,7 +15,6 @@ import { shorten } from './utils.js';
 export interface WorkbenchTabProps {
   state: FiberNodeButtonPanelState;
   fiber: FiberNodeButtonPanelProps['fiber'];
-  asset: UdtAsset;
   externalFunding: FiberNodeButtonPanelProps['externalFunding'];
   renderConnectorSection: FiberNodeButtonPanelProps['renderConnectorSection'];
   renderAction?: FiberNodeButtonRenderAction;
@@ -24,14 +24,11 @@ export interface WorkbenchTabProps {
 export function WorkbenchTab({
   state,
   fiber,
-  asset,
   externalFunding,
   renderConnectorSection,
   renderAction,
   t,
 }: WorkbenchTabProps) {
-  const assetName = formatAssetName(asset);
-  const amountUnit = asset.kind === 'udt' ? `${assetName} base units` : assetName;
   const {
     isNodeReady,
     connectorContext,
@@ -42,6 +39,22 @@ export function WorkbenchTab({
     connectedPeers,
     fundingAmount,
     setFundingAmount,
+    availableAssets,
+    showAssetSelectors,
+    openChannelAssetKey,
+    selectOpenChannelAsset,
+    openChannelCustomUdt,
+    setOpenChannelCustomUdt,
+    openChannelAsset,
+    createInvoiceAssetKey,
+    selectCreateInvoiceAsset,
+    createInvoiceCustomUdt,
+    setCreateInvoiceCustomUdt,
+    createInvoiceAsset,
+    paymentAssetKey,
+    selectPaymentAsset,
+    paymentCustomUdt,
+    setPaymentCustomUdt,
     openChannel,
     isCreatingInvoice,
     createInvoice,
@@ -54,6 +67,25 @@ export function WorkbenchTab({
     submitPayment,
     paymentResult,
   } = state;
+  const openChannelUsesUdt =
+    openChannelAssetKey === CUSTOM_ASSET_KEY || openChannelAsset?.kind === 'udt';
+  const createInvoiceUsesUdt =
+    createInvoiceAssetKey === CUSTOM_ASSET_KEY || createInvoiceAsset?.kind === 'udt';
+  const rawCreateInvoiceAssetName = createInvoiceAsset
+    ? formatAssetName(createInvoiceAsset)
+    : t('asset.udt', 'UDT');
+  const createInvoiceAssetName =
+    rawCreateInvoiceAssetName === 'CKB'
+      ? t('asset.ckb', 'CKB')
+      : rawCreateInvoiceAssetName === 'UDT'
+        ? t('asset.udt', 'UDT')
+        : rawCreateInvoiceAssetName;
+  const fundingAmountUnit = openChannelUsesUdt
+    ? t('asset.udt.rawUnits', 'UDT raw units')
+    : t('asset.ckb', 'CKB');
+  const invoiceAmountUnit = createInvoiceUsesUdt
+    ? t('asset.udt.rawUnits', 'UDT raw units')
+    : t('asset.ckb', 'CKB');
 
   return (
     <>
@@ -112,13 +144,28 @@ export function WorkbenchTab({
           </datalist>
         </label>
 
+        {showAssetSelectors ? (
+          <AssetSelect
+            label={t('workbench.openChannel.asset', 'Asset')}
+            ariaLabel={t('workbench.openChannel.asset.aria', 'Open Channel Asset')}
+            value={openChannelAssetKey}
+            options={availableAssets}
+            customScript={openChannelCustomUdt}
+            onChange={selectOpenChannelAsset}
+            onCustomScriptChange={setOpenChannelCustomUdt}
+            t={t}
+          />
+        ) : null}
+
         <label style={styles.fieldLabel}>
-          {t('workbench.openChannel.fundingAmount', `Funding Amount (${amountUnit})`)}
+          {t('workbench.openChannel.fundingAmount', `Funding Amount (${fundingAmountUnit})`)}
           <input
             style={styles.input}
             value={fundingAmount}
             onChange={(event) => setFundingAmount(event.target.value)}
-            placeholder="1000"
+            inputMode={openChannelUsesUdt ? 'numeric' : 'decimal'}
+            pattern={openChannelUsesUdt ? '[0-9]*' : '[0-9]+(?:\\.[0-9]{0,8})?'}
+            placeholder={openChannelUsesUdt ? '0' : '1000'}
           />
         </label>
 
@@ -159,13 +206,28 @@ export function WorkbenchTab({
       <section style={styles.section}>
         <h4 style={styles.sectionTitle}>{t('workbench.payments.title', 'Payments')}</h4>
 
+        {showAssetSelectors ? (
+          <AssetSelect
+            label={t('workbench.payments.asset', 'Asset')}
+            ariaLabel={t('workbench.payments.createAsset.aria', 'Create Invoice Asset')}
+            value={createInvoiceAssetKey}
+            options={availableAssets}
+            customScript={createInvoiceCustomUdt}
+            onChange={selectCreateInvoiceAsset}
+            onCustomScriptChange={setCreateInvoiceCustomUdt}
+            t={t}
+          />
+        ) : null}
+
         <label style={styles.fieldLabel}>
-          {t('workbench.payments.invoiceAmount', `Invoice Amount (${amountUnit})`)}
+          {t('workbench.payments.invoiceAmount', `Invoice Amount (${invoiceAmountUnit})`)}
           <input
             style={styles.input}
             value={invoiceAmount}
             onChange={(event) => setInvoiceAmount(event.target.value)}
-            placeholder="1"
+            inputMode={createInvoiceUsesUdt ? 'numeric' : 'decimal'}
+            pattern={createInvoiceUsesUdt ? '[0-9]*' : '[0-9]+(?:\\.[0-9]{0,8})?'}
+            placeholder={createInvoiceUsesUdt ? 'Required' : '1'}
           />
         </label>
 
@@ -180,7 +242,7 @@ export function WorkbenchTab({
               id: 'create-invoice',
               label: t(
                 'actions.createInvoice',
-                `Create Invoice (${invoiceAmount || '—'} ${assetName})`,
+                `Create Invoice (${invoiceAmount || '—'} ${createInvoiceAssetName})`,
               ),
               loadingLabel: t('actions.createInvoice.loading', 'Creating...'),
               disabled: isCreatingInvoice || !isNodeReady || !invoiceAmount.trim(),
@@ -192,6 +254,19 @@ export function WorkbenchTab({
             <span style={styles.compactText}>{shorten(createdInvoice, 20, 10)}</span>
           ) : null}
         </div>
+
+        {showAssetSelectors ? (
+          <AssetSelect
+            label={t('workbench.payments.asset', 'Asset')}
+            ariaLabel={t('workbench.payments.payAsset.aria', 'Pay Invoice Asset')}
+            value={paymentAssetKey}
+            options={availableAssets}
+            customScript={paymentCustomUdt}
+            onChange={selectPaymentAsset}
+            onCustomScriptChange={setPaymentCustomUdt}
+            t={t}
+          />
+        ) : null}
 
         <label style={styles.fieldLabel}>
           {t('workbench.payments.invoice', 'Invoice')}

--- a/packages/react/src/fiber-node-button/workbench-tab.tsx
+++ b/packages/react/src/fiber-node-button/workbench-tab.tsx
@@ -1,6 +1,6 @@
 import { formatAssetName } from '@fiber-pay/sdk/browser';
 import { AssetSelect } from './asset-select.js';
-import { CUSTOM_ASSET_KEY } from './assets.js';
+import { CUSTOM_ASSET_KEY, localizeAssetLabel } from './assets.js';
 import { renderPanelAction } from './render-action.js';
 import { styles } from './styles.js';
 import type {
@@ -52,6 +52,7 @@ export function WorkbenchTab({
     setCreateInvoiceCustomUdt,
     createInvoiceAsset,
     paymentAssetKey,
+    paymentAsset,
     selectPaymentAsset,
     paymentCustomUdt,
     setPaymentCustomUdt,
@@ -74,12 +75,7 @@ export function WorkbenchTab({
   const rawCreateInvoiceAssetName = createInvoiceAsset
     ? formatAssetName(createInvoiceAsset)
     : t('asset.udt', 'UDT');
-  const createInvoiceAssetName =
-    rawCreateInvoiceAssetName === 'CKB'
-      ? t('asset.ckb', 'CKB')
-      : rawCreateInvoiceAssetName === 'UDT'
-        ? t('asset.udt', 'UDT')
-        : rawCreateInvoiceAssetName;
+  const createInvoiceAssetName = localizeAssetLabel(rawCreateInvoiceAssetName, t);
   const fundingAmountUnit = openChannelUsesUdt
     ? t('asset.udt.rawUnits', 'UDT raw units')
     : t('asset.ckb', 'CKB');
@@ -181,7 +177,11 @@ export function WorkbenchTab({
               id: 'open-channel',
               label: t('actions.openChannel', 'Open Channel'),
               loadingLabel: t('actions.openChannel.loading', 'Opening...'),
-              disabled: !isNodeReady || channelOpenFlow.isOpening || !peerPubkey.trim(),
+              disabled:
+                !isNodeReady ||
+                channelOpenFlow.isOpening ||
+                !peerPubkey.trim() ||
+                !openChannelAsset,
               loading: channelOpenFlow.isOpening,
               onTrigger: openChannel,
             } satisfies FiberNodeButtonActionDefaultProps,
@@ -245,7 +245,8 @@ export function WorkbenchTab({
                 `Create Invoice (${invoiceAmount || '—'} ${createInvoiceAssetName})`,
               ),
               loadingLabel: t('actions.createInvoice.loading', 'Creating...'),
-              disabled: isCreatingInvoice || !isNodeReady || !invoiceAmount.trim(),
+              disabled:
+                isCreatingInvoice || !isNodeReady || !invoiceAmount.trim() || !createInvoiceAsset,
               loading: isCreatingInvoice,
               onTrigger: createInvoice,
             } satisfies FiberNodeButtonActionDefaultProps,
@@ -290,7 +291,7 @@ export function WorkbenchTab({
               id: 'pay-invoice',
               label: t('actions.payInvoice', 'Pay Invoice'),
               loadingLabel: t('actions.payInvoice.loading', 'Paying...'),
-              disabled: isPaying || !isNodeReady || !invoiceInput.trim(),
+              disabled: isPaying || !isNodeReady || !invoiceInput.trim() || !paymentAsset,
               loading: isPaying,
               onTrigger: submitPayment,
             } satisfies FiberNodeButtonActionDefaultProps,

--- a/packages/react/tests/fiber-node-button-assets.test.ts
+++ b/packages/react/tests/fiber-node-button-assets.test.ts
@@ -1,0 +1,141 @@
+import { DEFAULT_CKB_ASSET } from '@fiber-pay/sdk/browser';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  buildPanelAssetOptions,
+  CKB_ASSET_KEY,
+  CUSTOM_ASSET_KEY,
+  formatRawUdtAmount,
+  getAssetLabelForScript,
+  getUdtAssetKey,
+  localizeAssetLabel,
+  resolvePanelAsset,
+  tryResolvePanelAsset,
+} from '../src/fiber-node-button/assets.js';
+import { validUdtScript } from './fixtures/udt.js';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('FiberNodeButton asset helpers', () => {
+  it('always includes CKB for missing or empty node configuration', () => {
+    expect(buildPanelAssetOptions(undefined, DEFAULT_CKB_ASSET)).toEqual([
+      { key: CKB_ASSET_KEY, asset: DEFAULT_CKB_ASSET, label: 'CKB' },
+    ]);
+    expect(buildPanelAssetOptions(null, DEFAULT_CKB_ASSET)).toHaveLength(1);
+    expect(buildPanelAssetOptions([], DEFAULT_CKB_ASSET)).toHaveLength(1);
+  });
+
+  it('warns and drops invalid configured and initial UDT scripts', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const options = buildPanelAssetOptions(
+      [{ name: 'Broken config', script: { ...validUdtScript, args: 'broken' } }],
+      { kind: 'udt', name: 'Broken initial', script: { ...validUdtScript, code_hash: '0x00' } },
+    );
+
+    expect(options).toEqual([{ key: CKB_ASSET_KEY, asset: DEFAULT_CKB_ASSET, label: 'CKB' }]);
+    expect(warn).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps the first configured name for duplicate scripts', () => {
+    const options = buildPanelAssetOptions(
+      [
+        { name: 'First', script: validUdtScript },
+        { name: 'Second', script: validUdtScript },
+      ],
+      DEFAULT_CKB_ASSET,
+    );
+
+    expect(options).toHaveLength(2);
+    expect(options[1]?.label).toBe('First');
+  });
+
+  it('adds a valid initial UDT missing from node config and lets its name override config', () => {
+    const initialOnly = buildPanelAssetOptions([], {
+      kind: 'udt',
+      name: 'Initial',
+      script: validUdtScript,
+    });
+    expect(initialOnly.map((option) => option.label)).toEqual(['CKB', 'Initial']);
+
+    const namedOverride = buildPanelAssetOptions([{ name: 'Configured', script: validUdtScript }], {
+      kind: 'udt',
+      name: 'Explicit',
+      script: validUdtScript,
+    });
+    expect(namedOverride[1]?.label).toBe('Explicit');
+  });
+
+  it('generates distinct keys for different invalid scripts', () => {
+    expect(getUdtAssetKey({ code_hash: 'first' })).not.toBe(
+      getUdtAssetKey({ code_hash: 'second' }),
+    );
+  });
+
+  it('resolves CKB, configured UDT, and custom UDT selections', () => {
+    const options = buildPanelAssetOptions(
+      [{ name: 'RUSD', script: validUdtScript }],
+      DEFAULT_CKB_ASSET,
+    );
+    const udtKey = getUdtAssetKey(validUdtScript);
+
+    expect(resolvePanelAsset(CKB_ASSET_KEY, '', options)).toEqual(DEFAULT_CKB_ASSET);
+    expect(resolvePanelAsset(udtKey, '', options)).toEqual(options[1]?.asset);
+    expect(resolvePanelAsset(CUSTOM_ASSET_KEY, JSON.stringify(validUdtScript), options)).toEqual({
+      kind: 'udt',
+      script: validUdtScript,
+    });
+  });
+
+  it('reports resolution failures without discarding their errors', () => {
+    const options = buildPanelAssetOptions([], DEFAULT_CKB_ASSET);
+
+    expect(() => resolvePanelAsset(CUSTOM_ASSET_KEY, '', options)).toThrow(
+      'Custom UDT script is required.',
+    );
+    expect(() => resolvePanelAsset(CUSTOM_ASSET_KEY, '{', options)).toThrow();
+    expect(() => resolvePanelAsset('missing', '', options)).toThrow(
+      'Selected asset is no longer available.',
+    );
+
+    const success = tryResolvePanelAsset(CKB_ASSET_KEY, '', options);
+    expect(success).toEqual({ ok: true, asset: DEFAULT_CKB_ASSET });
+    const failure = tryResolvePanelAsset('missing', '', options);
+    expect(failure.ok).toBe(false);
+    if (!failure.ok) {
+      expect(failure.error.message).toBe('Selected asset is no longer available.');
+    }
+  });
+
+  it('labels CKB, matched scripts, unmatched scripts, and case variants', () => {
+    const options = buildPanelAssetOptions(
+      [{ name: 'RUSD', script: validUdtScript }],
+      DEFAULT_CKB_ASSET,
+    );
+    const caseVariant = {
+      ...validUdtScript,
+      code_hash: `0x${validUdtScript.code_hash.slice(2).toUpperCase()}`,
+      args: `0x${validUdtScript.args.slice(2).toUpperCase()}`,
+    };
+
+    expect(getAssetLabelForScript(null, options)).toBe('CKB');
+    expect(getAssetLabelForScript(undefined, options)).toBe('CKB');
+    expect(getAssetLabelForScript(caseVariant, options)).toBe('RUSD');
+    expect(getAssetLabelForScript({ ...validUdtScript, args: '0x01' }, options)).toBe('UDT');
+  });
+
+  it('formats only bounded unsigned decimal UDT values', () => {
+    expect(formatRawUdtAmount('0')).toBe('0');
+    expect(formatRawUdtAmount('100000000')).toBe('100,000,000');
+    for (const invalid of ['', ' ', '-1', '+1', '0x64', '1.5', '1'.repeat(65)]) {
+      expect(formatRawUdtAmount(invalid)).toBe(invalid);
+    }
+  });
+
+  it('localizes only generic asset labels', () => {
+    const t = vi.fn((key: string, fallback: string) => `${key}:${fallback}`);
+    expect(localizeAssetLabel('CKB', t)).toBe('asset.ckb:CKB');
+    expect(localizeAssetLabel('UDT', t)).toBe('asset.udt:UDT');
+    expect(localizeAssetLabel('RUSD', t)).toBe('RUSD');
+  });
+});

--- a/packages/react/tests/fiber-node-button.test.tsx
+++ b/packages/react/tests/fiber-node-button.test.tsx
@@ -1,7 +1,7 @@
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { afterEach, describe, expect, it, vi } from 'vitest';
 import { ChannelState, serializeUdtTypeScript } from '@fiber-pay/sdk/browser';
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { StrictMode } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { FiberNodeButton } from '../src/fiber-node-button.js';
 import type { UseFiberNodeResult } from '../src/use-fiber-node.js';
 import { validUdtScript } from './fixtures/udt.js';
@@ -72,6 +72,22 @@ function createUdtChannel(script = validUdtScript) {
     tlc_fee_proportional_millionths: '0x0',
     shutdown_transaction_hash: null,
   };
+}
+
+function createCkbChannel() {
+  return {
+    ...createUdtChannel(),
+    channel_id: '0xckb-channel',
+    funding_udt_type_script: null,
+    local_balance: '0x5f5e100',
+    remote_balance: '0xbebc200',
+  };
+}
+
+function selectAsset(label: string, optionName: string) {
+  const select = screen.getByLabelText(label);
+  const option = within(select).getByRole('option', { name: optionName });
+  fireEvent.change(select, { target: { value: option.getAttribute('value') } });
 }
 
 describe('FiberNodeButton', () => {
@@ -318,6 +334,103 @@ describe('FiberNodeButton', () => {
     });
   });
 
+  it('selects configured assets independently for opening, invoicing, and paying', async () => {
+    const node = createNodeMock();
+    node.parseInvoice = vi.fn(async () => ({
+      invoice: {
+        currency: 'Fibt',
+        data: {
+          payment_hash: '0x1',
+          attrs: [{ udt_script: serializeUdtTypeScript(validUdtScript) }],
+        },
+      },
+    }));
+    const fiber = createFiberMock({
+      state: 'running',
+      isRunning: true,
+      node: node as unknown as UseFiberNodeResult['node'],
+      nodeInfo: {
+        pubkey: '0x0123456789abcdef0123456789abcdef',
+        udt_cfg_infos: [{ name: 'RUSD', script: validUdtScript, cell_deps: [] }],
+      } as UseFiberNodeResult['nodeInfo'],
+    });
+
+    render(<FiberNodeButton fiber={fiber} strategy="passkey" initialPeerPubkey="0xpeer" />);
+    fireEvent.click(screen.getByRole('button', { name: /0x012345/i }));
+
+    selectAsset('Open Channel Asset', 'RUSD');
+    const fundingAmount = screen.getByLabelText('Funding Amount (UDT raw units)');
+    fireEvent.change(fundingAmount, { target: { value: '250' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Open Channel' }));
+
+    await waitFor(() => {
+      expect(node.openChannel).toHaveBeenCalledWith({
+        pubkey: '0xpeer',
+        funding_amount: '0xfa',
+        funding_udt_type_script: validUdtScript,
+      });
+    });
+
+    selectAsset('Create Invoice Asset', 'RUSD');
+    const invoiceAmount = screen.getByLabelText('Invoice Amount (UDT raw units)');
+    expect((invoiceAmount as HTMLInputElement).value).toBe('');
+    fireEvent.change(invoiceAmount, { target: { value: '25' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Create Invoice (25 RUSD)' }));
+
+    await waitFor(() => {
+      expect(node.newInvoice).toHaveBeenCalledWith(
+        expect.objectContaining({
+          amount: '0x19',
+          udt_type_script: validUdtScript,
+        }),
+      );
+    });
+
+    selectAsset('Pay Invoice Asset', 'RUSD');
+    fireEvent.change(screen.getByLabelText('Invoice'), { target: { value: 'ln-rusd' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Pay Invoice' }));
+
+    await waitFor(() => {
+      expect(node.sendPayment).toHaveBeenCalledWith({
+        invoice: 'ln-rusd',
+        udt_type_script: validUdtScript,
+      });
+    });
+  });
+
+  it('accepts a custom UDT script from the asset selector', async () => {
+    const node = createNodeMock();
+    const fiber = createFiberMock({
+      state: 'running',
+      isRunning: true,
+      node: node as unknown as UseFiberNodeResult['node'],
+      nodeInfo: {
+        pubkey: '0x0123456789abcdef0123456789abcdef',
+        udt_cfg_infos: [{ name: 'RUSD', script: validUdtScript, cell_deps: [] }],
+      } as UseFiberNodeResult['nodeInfo'],
+    });
+
+    render(<FiberNodeButton fiber={fiber} strategy="passkey" initialPeerPubkey="0xpeer" />);
+    fireEvent.click(screen.getByRole('button', { name: /0x012345/i }));
+
+    selectAsset('Open Channel Asset', 'Custom');
+    fireEvent.change(screen.getByLabelText('Open Channel Asset Custom UDT Script (JSON)'), {
+      target: { value: JSON.stringify(validUdtScript) },
+    });
+    fireEvent.change(screen.getByLabelText('Funding Amount (UDT raw units)'), {
+      target: { value: '500' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Open Channel' }));
+
+    await waitFor(() => {
+      expect(node.openChannel).toHaveBeenCalledWith({
+        pubkey: '0xpeer',
+        funding_amount: '0x1f4',
+        funding_udt_type_script: validUdtScript,
+      });
+    });
+  });
+
   it('recovers the Open Channel action after an invalid UDT script error', async () => {
     const node = createNodeMock();
     const onError = vi.fn();
@@ -446,6 +559,121 @@ describe('FiberNodeButton', () => {
     });
   });
 
+  it('splits mixed channels by asset and exposes the UDT script in details', async () => {
+    const udtChannel = { ...createUdtChannel(), channel_id: '0xudt-channel' };
+    const closedUdtChannel = {
+      ...createUdtChannel(),
+      channel_id: '0xclosed-udt',
+      state: { state_name: ChannelState.Closed },
+      local_balance: '0x3e8',
+    };
+    const node = createNodeMock();
+    node.listChannels = vi.fn(async () => ({
+      channels: [createCkbChannel(), udtChannel, closedUdtChannel],
+    }));
+    const fiber = createFiberMock({
+      state: 'running',
+      isRunning: true,
+      node: node as unknown as UseFiberNodeResult['node'],
+      nodeInfo: {
+        pubkey: '0x0123456789abcdef0123456789abcdef',
+        udt_cfg_infos: [{ name: 'RUSD', script: validUdtScript, cell_deps: [] }],
+      } as UseFiberNodeResult['nodeInfo'],
+    });
+
+    render(<FiberNodeButton fiber={fiber} strategy="passkey" />);
+    fireEvent.click(screen.getByRole('button', { name: /0x012345/i }));
+    fireEvent.click(screen.getByRole('tab', { name: 'Channels' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Assets: CKB 1 · RUSD 2')).toBeTruthy();
+    });
+
+    const assetFilters = screen.getByRole('group', { name: 'Channel asset filter' });
+    fireEvent.click(within(assetFilters).getByRole('button', { name: 'RUSD (2)' }));
+
+    await waitFor(() => {
+      expect(screen.getAllByText(/100 RUSD/).length).toBeGreaterThan(0);
+      expect(screen.getByText('Funding UDT Script')).toBeTruthy();
+      expect(screen.getByRole('button', { name: 'active (1)' })).toBeTruthy();
+      expect(screen.getByRole('button', { name: 'closed (1)' })).toBeTruthy();
+    });
+    expect(screen.queryByText(/1\.0000 CKB/)).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: 'closed (1)' }));
+    await waitFor(() => {
+      expect(screen.getAllByText(/0xclosed-udt/).length).toBeGreaterThan(0);
+    });
+
+    fireEvent.click(screen.getByText('Funding UDT Script'));
+    expect(screen.getByText(new RegExp(validUdtScript.code_hash.slice(0, 18)))).toBeTruthy();
+  });
+
+  it('uses configured UDT names in graph diagnostics', async () => {
+    const node = createNodeMock();
+    node.graphChannels = vi.fn(async () => ({
+      channels: [
+        {
+          node1: '0xnode1',
+          node2: '0xnode2',
+          channel_outpoint: { tx_hash: '0xtx', index: '0x0' },
+          capacity: '0x64',
+          udt_type_script: validUdtScript,
+        },
+      ],
+      last_cursor: '0x0',
+    }));
+    const fiber = createFiberMock({
+      state: 'running',
+      isRunning: true,
+      node: node as unknown as UseFiberNodeResult['node'],
+      nodeInfo: {
+        pubkey: '0x0123456789abcdef0123456789abcdef',
+        udt_cfg_infos: [{ name: 'RUSD', script: validUdtScript, cell_deps: [] }],
+      } as UseFiberNodeResult['nodeInfo'],
+    });
+
+    render(<FiberNodeButton fiber={fiber} strategy="passkey" />);
+    fireEvent.click(screen.getByRole('button', { name: /0x012345/i }));
+    fireEvent.click(screen.getByRole('tab', { name: 'Diagnostics' }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/100 RUSD/)).toBeTruthy();
+    });
+  });
+
+  it('keeps the CKB-only panel quiet and constrains the dropdown for narrow viewports', () => {
+    const node = createNodeMock();
+    const fiber = createFiberMock({
+      state: 'running',
+      isRunning: true,
+      node: node as unknown as UseFiberNodeResult['node'],
+      nodeInfo: {
+        pubkey: '0x0123456789abcdef0123456789abcdef',
+        udt_cfg_infos: [],
+      } as unknown as UseFiberNodeResult['nodeInfo'],
+    });
+
+    render(<FiberNodeButton fiber={fiber} strategy="passkey" />);
+    fireEvent.click(screen.getByRole('button', { name: /0x012345/i }));
+
+    expect(screen.queryByLabelText('Open Channel Asset')).toBeNull();
+    expect(screen.queryByLabelText('Create Invoice Asset')).toBeNull();
+    expect(screen.queryByLabelText('Pay Invoice Asset')).toBeNull();
+
+    const dialog = screen.getByRole('dialog', { name: 'Connection panel' });
+    expect(dialog.style.maxWidth).toBe('520px');
+    expect(dialog.style.width).toBe('calc(100vw - 1rem)');
+    expect(dialog.style.boxSizing).toBe('border-box');
+
+    const tabList = screen.getByRole('tablist', { name: 'Fiber panel tabs' });
+    expect(tabList.style.overflow).toBe('hidden');
+    for (const tab of screen.getAllByRole('tab')) {
+      expect(tab.style.minWidth).toBe('0');
+      expect(tab.style.whiteSpace).toBe('nowrap');
+    }
+  });
+
   it('shows UDT unit for channels with funding_udt_type_script', async () => {
     const udtChannel = createUdtChannel();
 
@@ -502,7 +730,7 @@ describe('FiberNodeButton', () => {
     fireEvent.click(screen.getByRole('tab', { name: 'Channels' }));
 
     await waitFor(() => {
-      expect(screen.getAllByText(/UDT · 0x114275/).length).toBeGreaterThan(0);
+      expect(screen.getAllByText('UDT').length).toBeGreaterThan(0);
     });
     expect(screen.queryByText(/100 RUSD/)).toBeNull();
   });

--- a/packages/react/tests/fiber-node-button.test.tsx
+++ b/packages/react/tests/fiber-node-button.test.tsx
@@ -8,6 +8,7 @@ import { validUdtScript } from './fixtures/udt.js';
 
 afterEach(() => {
   cleanup();
+  vi.restoreAllMocks();
 });
 
 function createNodeMock() {
@@ -431,9 +432,9 @@ describe('FiberNodeButton', () => {
     });
   });
 
-  it('recovers the Open Channel action after an invalid UDT script error', async () => {
+  it('ignores an invalid initial UDT asset and falls back to CKB', async () => {
     const node = createNodeMock();
-    const onError = vi.fn();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const fiber = createFiberMock({
       state: 'running',
       isRunning: true,
@@ -447,20 +448,174 @@ describe('FiberNodeButton', () => {
         strategy="passkey"
         asset={{ kind: 'udt', script: { ...validUdtScript, code_hash: '0x00' } }}
         initialPeerPubkey="0xpeer"
-        onError={onError}
       />,
     );
 
     fireEvent.click(screen.getByRole('button', { name: /0x012345/i }));
+    expect(screen.queryByLabelText('Open Channel Asset')).toBeNull();
     fireEvent.click(screen.getByRole('button', { name: 'Open Channel' }));
 
     await waitFor(() => {
-      expect(onError).toHaveBeenCalledWith(expect.stringContaining('code_hash must be 66'));
+      expect(warn).toHaveBeenCalledWith(
+        '[FiberNodeButton] Ignoring invalid initial UDT asset.',
+        expect.stringContaining('code_hash must be 66'),
+      );
+      expect(node.openChannel).toHaveBeenCalled();
+    });
+  });
+
+  it('disables asset actions until nodeInfo is available', async () => {
+    const node = createNodeMock();
+    const fiberWithoutInfo = createFiberMock({
+      state: 'running',
+      isRunning: true,
+      node: node as unknown as UseFiberNodeResult['node'],
+      nodeInfo: null,
+    });
+    const { rerender } = render(
+      <FiberNodeButton
+        fiber={fiberWithoutInfo}
+        strategy="passkey"
+        asset={{ kind: 'udt', script: validUdtScript, name: 'RUSD' }}
+        initialPeerPubkey="0xpeer"
+        initialFundingAmount="100"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Connected' }));
+    expect(screen.getByRole('button', { name: 'Open Channel' }).hasAttribute('disabled')).toBe(
+      true,
+    );
+
+    const fiberWithInfo = createFiberMock({
+      ...fiberWithoutInfo,
+      nodeInfo: {
+        pubkey: '0x0123456789abcdef0123456789abcdef',
+        udt_cfg_infos: [{ name: 'RUSD', script: validUdtScript, cell_deps: [] }],
+      } as UseFiberNodeResult['nodeInfo'],
+    });
+    rerender(
+      <FiberNodeButton
+        fiber={fiberWithInfo}
+        strategy="passkey"
+        asset={{ kind: 'udt', script: validUdtScript, name: 'RUSD' }}
+        initialPeerPubkey="0xpeer"
+        initialFundingAmount="100"
+      />,
+    );
+
+    await waitFor(() => {
       expect(screen.getByRole('button', { name: 'Open Channel' }).hasAttribute('disabled')).toBe(
         false,
       );
     });
-    expect(node.openChannel).not.toHaveBeenCalled();
+  });
+
+  it('restores the higher-priority initial funding amount when switching back to CKB', () => {
+    const node = createNodeMock();
+    const fiber = createFiberMock({
+      state: 'running',
+      isRunning: true,
+      node: node as unknown as UseFiberNodeResult['node'],
+      nodeInfo: {
+        pubkey: '0x0123456789abcdef0123456789abcdef',
+        udt_cfg_infos: [{ name: 'RUSD', script: validUdtScript, cell_deps: [] }],
+      } as UseFiberNodeResult['nodeInfo'],
+    });
+
+    render(
+      <FiberNodeButton
+        fiber={fiber}
+        strategy="passkey"
+        initialFundingAmount="42"
+        initialFundingAmountCkb="7"
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /0x012345/i }));
+
+    selectAsset('Open Channel Asset', 'RUSD');
+    expect(
+      (screen.getByLabelText('Funding Amount (UDT raw units)') as HTMLInputElement).value,
+    ).toBe('');
+    selectAsset('Open Channel Asset', 'CKB');
+    expect((screen.getByLabelText('Funding Amount (CKB)') as HTMLInputElement).value).toBe('42');
+  });
+
+  it('resets all action selectors and inputs when the asset prop changes', async () => {
+    const secondUdtScript = { ...validUdtScript, args: '0x01' };
+    const node = createNodeMock();
+    const fiber = createFiberMock({
+      state: 'running',
+      isRunning: true,
+      node: node as unknown as UseFiberNodeResult['node'],
+      nodeInfo: {
+        pubkey: '0x0123456789abcdef0123456789abcdef',
+        udt_cfg_infos: [
+          { name: 'RUSD', script: validUdtScript, cell_deps: [] },
+          { name: 'USDT', script: secondUdtScript, cell_deps: [] },
+        ],
+      } as UseFiberNodeResult['nodeInfo'],
+    });
+    const { rerender } = render(
+      <FiberNodeButton
+        fiber={fiber}
+        strategy="passkey"
+        asset={{ kind: 'udt', script: validUdtScript, name: 'RUSD' }}
+        initialFundingAmount="100"
+        invoiceAmount="10"
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /0x012345/i }));
+    selectAsset('Open Channel Asset', 'CKB');
+    selectAsset('Create Invoice Asset', 'CKB');
+    selectAsset('Pay Invoice Asset', 'CKB');
+    fireEvent.change(screen.getByLabelText('Invoice'), { target: { value: 'stale invoice' } });
+
+    rerender(
+      <FiberNodeButton
+        fiber={fiber}
+        strategy="passkey"
+        asset={{ kind: 'udt', script: secondUdtScript, name: 'USDT' }}
+        initialFundingAmount="200"
+        invoiceAmount="20"
+      />,
+    );
+
+    await waitFor(() => {
+      for (const label of ['Open Channel Asset', 'Create Invoice Asset', 'Pay Invoice Asset']) {
+        expect((screen.getByLabelText(label) as HTMLSelectElement).selectedOptions[0]?.text).toBe(
+          'USDT',
+        );
+      }
+      expect(
+        (screen.getByLabelText('Funding Amount (UDT raw units)') as HTMLInputElement).value,
+      ).toBe('200');
+      expect(
+        (screen.getByLabelText('Invoice Amount (UDT raw units)') as HTMLInputElement).value,
+      ).toBe('20');
+      expect((screen.getByLabelText('Invoice') as HTMLInputElement).value).toBe('');
+    });
+  });
+
+  it('disables actions for an unresolved custom asset', () => {
+    const node = createNodeMock();
+    const fiber = createFiberMock({
+      state: 'running',
+      isRunning: true,
+      node: node as unknown as UseFiberNodeResult['node'],
+      nodeInfo: {
+        pubkey: '0x0123456789abcdef0123456789abcdef',
+        udt_cfg_infos: [{ name: 'RUSD', script: validUdtScript, cell_deps: [] }],
+      } as UseFiberNodeResult['nodeInfo'],
+    });
+
+    render(<FiberNodeButton fiber={fiber} strategy="passkey" initialPeerPubkey="0xpeer" />);
+    fireEvent.click(screen.getByRole('button', { name: /0x012345/i }));
+    selectAsset('Open Channel Asset', 'Custom');
+
+    expect(screen.getByRole('button', { name: 'Open Channel' }).hasAttribute('disabled')).toBe(
+      true,
+    );
   });
 
   it('reports an actionable error when the UDT is absent from the node whitelist', async () => {
@@ -610,6 +765,7 @@ describe('FiberNodeButton', () => {
   });
 
   it('uses configured UDT names in graph diagnostics', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
     const node = createNodeMock();
     node.graphChannels = vi.fn(async () => ({
       channels: [
@@ -618,6 +774,13 @@ describe('FiberNodeButton', () => {
           node2: '0xnode2',
           channel_outpoint: { tx_hash: '0xtx', index: '0x0' },
           capacity: '0x64',
+          udt_type_script: validUdtScript,
+        },
+        {
+          node1: '0xnode1',
+          node2: '0xnode2',
+          channel_outpoint: { tx_hash: '0xtx', index: '0x1' },
+          capacity: '0xc8',
           udt_type_script: validUdtScript,
         },
       ],
@@ -639,7 +802,11 @@ describe('FiberNodeButton', () => {
 
     await waitFor(() => {
       expect(screen.getByText(/100 RUSD/)).toBeTruthy();
+      expect(screen.getByText(/200 RUSD/)).toBeTruthy();
     });
+    expect(consoleError.mock.calls.some((args) => String(args[0]).includes('same key'))).toBe(
+      false,
+    );
   });
 
   it('keeps the CKB-only panel quiet and constrains the dropdown for narrow viewports', () => {


### PR DESCRIPTION
## Summary

- discover configured UDTs from `nodeInfo.udt_cfg_infos` and add independent asset selectors for opening channels, creating invoices, and paying invoices, including custom script JSON
- split channel summaries and filters by asset, resolve channel and graph units correctly, and expose UDT funding scripts in channel details
- harden the panel for 375px layouts and long identifiers, balances, badges, tabs, and force-close content while keeping the CKB-only path compact
- preserve the existing `asset` prop as the initial selection and pass the selected asset through external funding contexts

## Validation

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` (668 tests)
- `pnpm build`
- React regression coverage for configured/custom UDT actions, combined status and asset filtering, graph units, CKB-only fallback, and responsive style constraints

Closes #188