### PR TITLE
chore(examples): add FiberNodeButton live preview

### DIFF
--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,33 @@
+# Product
+
+## Register
+
+brand
+
+## Users
+
+Developers and product teams evaluating Fiber Network browser payments. They need to see the real `FiberNodeButton` running against testnet before deciding how to integrate `@fiber-pay/react` into an application.
+
+## Product Purpose
+
+Make Fiber browser payments tangible through a deployable, always-available example. Success means a visitor can open the page, understand that the demo uses current workspace packages, connect a real testnet browser node, and inspect the complete `FiberNodeButton` workflow without first reading a long guide.
+
+## Brand Personality
+
+Direct, technical, trustworthy. The page should feel like a maintained reference implementation rather than a campaign or a simulated product screenshot.
+
+## Anti-references
+
+Avoid generic SaaS landing-page sections, decorative crypto imagery, fake balances or mocked interactions, dense developer dashboards, and visual effects that compete with the component under evaluation.
+
+## Design Principles
+
+1. Show the real component first.
+2. Practice what the package promises by using current workspace source and a live testnet flow.
+3. Keep setup context close to the action, but subordinate to the component.
+4. Make operational constraints explicit so failures are understandable.
+5. Prefer a credible reference implementation over promotional copy.
+
+## Accessibility & Inclusion
+
+Target WCAG AA contrast, complete keyboard navigation, visible focus states, semantic controls and status text, responsive use down to mobile widths, and reduced-motion support. Do not rely on color alone to communicate state.

--- a/examples/README.md
+++ b/examples/README.md
@@ -8,7 +8,7 @@ This folder contains the canonical demos grouped by SDK integration layer.
 
 2. react-fiber-node-button-lab
 - Layer: React component
-- Focus: FiberNodeButton default panel and custom extension points
+- Focus: deployable, real-testnet FiberNodeButton live preview built from workspace packages
 
 3. browser-sdk-playground
 - Layer: Browser SDK

--- a/examples/react-fiber-node-button-lab/README.md
+++ b/examples/react-fiber-node-button-lab/README.md
@@ -1,48 +1,39 @@
-# React FiberNodeButton Lab
+# FiberNodeButton Live Preview
 
-Layer: React component layer (FiberNodeButton)
+A deployable, component-first preview of the current `FiberNodeButton` from `@fiber-pay/react`.
 
-Audience:
+The page runs a real browser Fiber node on testnet. It supports Passkey and password credentials, exposes the complete built-in management panel, and reads CKB plus the configured RUSD testnet asset from the node. No node state, balance, channel or payment is mocked.
 
-- Teams integrating FiberNodeButton into application UI and extending panel behavior.
+## Workspace source
 
-You will learn:
+This example depends on `@fiber-pay/react` through `workspace:*`. Building from the repository root compiles the current package source before Vite bundles the preview, so a deployment tracks the exact code in its Git commit rather than an older npm release.
 
-1. useFiberNode plus FiberNodeButton default management panel flow.
-2. Custom tabs configuration (add/hide/reorder tabs).
-3. renderAction override for selected actions.
-4. t callback for lightweight i18n overrides.
-5. externalFunding.resolve integration path with CCC signer handoff.
-6. CKB/RUSD asset switching with an explicit UDT whitelist and raw base-unit amounts.
+## Run locally
 
-Out of scope:
-
-1. Minimal connection-only integration (see react-min-connect).
-2. Direct browser SDK client/helper usage without React wrappers.
-3. Node-side recipe scripting.
-
-## Run
+From the repository root:
 
 ```bash
-pnpm -C examples/react-fiber-node-button-lab dev
+pnpm install
+pnpm --filter example-react-fiber-node-button-lab... build
+pnpm --filter example-react-fiber-node-button-lab dev
 ```
 
-Build:
+Open <http://localhost:5174>.
 
-```bash
-pnpm -C examples/react-fiber-node-button-lab build
-```
+The preview requires cross-origin isolation for threaded WASM. The Vite development and preview servers set the required headers automatically.
 
-Then open http://localhost:5174.
+## Deploy with Vercel
 
-## API Index
+Import the repository root as a Vercel project. The root [`vercel.json`](../../vercel.json) provides:
 
-- useFiberNode
-- FiberNodeButton
-- FiberNodeButton tabs prop
-- FiberNodeButton renderAction prop
-- FiberNodeButton t prop
+- the workspace-aware install and build commands;
+- `examples/react-fiber-node-button-lab/dist` as the output directory;
+- the COOP, COEP and CORP response headers required by Fiber WASM.
 
-## Next Step
+No environment variables are required for the default testnet preview.
 
-If you need direct browser RPC and helper operations without React helper components, continue to examples/browser-sdk-playground.
+## Safety
+
+- Use testnet funds only.
+- Passwords and credential material stay in browser storage and are not sent to the preview host.
+- Passkey mode requires HTTPS or localhost and an authenticator with WebAuthn PRF support.

--- a/examples/react-fiber-node-button-lab/README.md
+++ b/examples/react-fiber-node-button-lab/README.md
@@ -24,13 +24,17 @@ The preview requires cross-origin isolation for threaded WASM. The Vite developm
 
 ## Deploy with Vercel
 
-Import the repository root as a Vercel project. The root [`vercel.json`](../../vercel.json) provides:
+Import the repository as a Vercel project, leave **Root Directory** at the repository root (`./`),
+and click **Deploy**. Do not select this example directory as the project root because the build
+needs access to the workspace packages and the root [`vercel.json`](../../vercel.json).
+
+The checked-in configuration provides:
 
 - the workspace-aware install and build commands;
 - `examples/react-fiber-node-button-lab/dist` as the output directory;
 - the COOP, COEP and CORP response headers required by Fiber WASM.
 
-No environment variables are required for the default testnet preview.
+No dashboard overrides or environment variables are required for the default testnet preview.
 
 ## Safety
 

--- a/examples/react-fiber-node-button-lab/index.html
+++ b/examples/react-fiber-node-button-lab/index.html
@@ -3,7 +3,12 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Fiber Pay Quick Card</title>
+    <meta
+      name="description"
+      content="Run the current FiberNodeButton component against Fiber testnet in a browser."
+    />
+    <meta name="theme-color" content="#3158c9" />
+    <title>FiberNodeButton Live Preview</title>
   </head>
   <body>
     <div id="root"></div>

--- a/examples/react-fiber-node-button-lab/package.json
+++ b/examples/react-fiber-node-button-lab/package.json
@@ -10,10 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@ckb-ccc/connector-react": "^1.0.34",
-    "@ckb-ccc/core": "^1.12.5",
     "@fiber-pay/react": "workspace:*",
-    "@fiber-pay/sdk": "workspace:*",
     "@nervosnetwork/fiber-js": "catalog:",
     "react": "^19.2.4",
     "react-dom": "^19.2.4"

--- a/examples/react-fiber-node-button-lab/src/App.tsx
+++ b/examples/react-fiber-node-button-lab/src/App.tsx
@@ -1,17 +1,5 @@
-import { ccc } from '@ckb-ccc/connector-react';
-import {
-  FiberNodeButton,
-  type FiberNodeButtonRenderAction,
-  type FiberNodeButtonTabConfig,
-  type UdtAsset,
-  type UseFiberNodeOptions,
-  useFiberNode,
-} from '@fiber-pay/react';
-import {
-  createCccExternalFundingResolver,
-  type CccRecommendedAddressObjLike,
-} from '@fiber-pay/sdk/browser';
-import { type CSSProperties, useCallback, useEffect, useMemo, useState } from 'react';
+import { FiberNodeButton, type UseFiberNodeOptions, useFiberNode } from '@fiber-pay/react';
+import { type CSSProperties, useCallback, useState } from 'react';
 
 type ConnectStrategy = 'password' | 'passkey';
 
@@ -20,14 +8,12 @@ interface EventLogEntry {
   text: string;
 }
 
-const TESTNET_CKB_RPC_URL = 'https://testnet.ckbapp.dev/';
 const RUSD_SCRIPT = {
   code_hash: '0x1142755a044bf2ee358cba9f2da187ce928c91cd4dc8692ded0337efa677d21a',
   hash_type: 'type',
   args: '0x878fcc6f1f08d48e87bb1c3b3d5083f23f8a39c5d5c764f253b55b998526439b',
 } as const;
-const RUSD_ASSET: UdtAsset = { kind: 'udt', name: 'RUSD', script: RUSD_SCRIPT };
-const CKB_ASSET: UdtAsset = { kind: 'ckb' };
+
 const RUSD_NODE_CONFIG = {
   udtWhitelist: [
     {
@@ -47,743 +33,240 @@ const RUSD_NODE_CONFIG = {
   ],
 } satisfies NonNullable<UseFiberNodeOptions['nodeConfig']>;
 
-const integrationSnippet = `const fiber = useFiberNode({
-  network: 'testnet',
-  walletId: 'my-app-fiber-session',
-  externalWallet,
-  nodeConfig: { udtWhitelist: [RUSD_WHITELIST_ENTRY] },
-});
+const componentTheme = {
+  '--fpay-accent': 'oklch(0.52 0.2 260)',
+  '--fpay-accent-fg': 'oklch(0.98 0.005 260)',
+  '--fpay-accent-subtle': 'oklch(0.94 0.035 260)',
+  '--fpay-accent-border': 'oklch(0.78 0.09 260)',
+  '--fpay-bg-elevated': 'oklch(0.99 0.004 260)',
+  '--fpay-bg-secondary': 'oklch(0.96 0.01 260)',
+  '--fpay-border': 'oklch(0.86 0.018 260)',
+  '--fpay-text-primary': 'oklch(0.24 0.035 260)',
+  '--fpay-text-secondary': 'oklch(0.49 0.03 260)',
+  '--fpay-error': 'oklch(0.55 0.2 25)',
+} as CSSProperties;
 
-<FiberNodeButton
-  fiber={fiber}
-  asset={selectedAsset}
-  strategy={strategy}
-  password={strategy === 'password' ? password : undefined}
-  externalFunding={{ enabled: externalWallet, resolve: resolveExternalFunding }}
-  onConnect={(_, info) => log('connected', info.pubkey)}
-  onDisconnect={() => log('disconnected')}
-  onError={(msg) => log('error', msg)}
-  onLog={(msg) => log('fiber', msg)}
-/>`;
-
-function shorten(value: string, head = 10, tail = 8): string {
+function shorten(value: string, head = 12, tail = 10): string {
   if (!value || value.length <= head + tail + 3) {
     return value;
   }
   return `${value.slice(0, head)}...${value.slice(-tail)}`;
 }
 
-const styles = {
-  page: {
-    minHeight: '100vh',
-    padding: '28px 18px 36px',
-    background:
-      'radial-gradient(circle at 4% -12%, rgba(29,78,216,0.2), transparent 42%), radial-gradient(circle at 92% -8%, rgba(14,116,144,0.16), transparent 38%), #f3f6fb',
-    color: '#0f172a',
-    fontFamily: 'IBM Plex Sans, Avenir Next, Segoe UI, sans-serif',
-  } satisfies CSSProperties,
-
-  shell: {
-    maxWidth: '1120px',
-    margin: '0 auto',
-    display: 'grid',
-    gap: '16px',
-  } satisfies CSSProperties,
-
-  hero: {
-    border: '1px solid #d6e0f0',
-    borderRadius: '18px',
-    padding: '18px 18px 16px',
-    background: 'linear-gradient(180deg, rgba(255,255,255,0.96) 0%, rgba(249,251,255,0.95) 100%)',
-    boxShadow: '0 14px 30px -28px rgba(15, 23, 42, 0.45)',
-  } satisfies CSSProperties,
-
-  title: {
-    margin: 0,
-    fontSize: '1.55rem',
-    letterSpacing: '-0.02em',
-  } satisfies CSSProperties,
-
-  subtitle: {
-    margin: '8px 0 0',
-    fontSize: '0.9rem',
-    color: '#475569',
-    maxWidth: '68ch',
-    lineHeight: 1.4,
-  } satisfies CSSProperties,
-
-  layout: {
-    display: 'flex',
-    flexWrap: 'wrap',
-    gap: '14px',
-    alignItems: 'flex-start',
-  } satisfies CSSProperties,
-
-  panel: {
-    flex: '1 1 520px',
-    border: '1px solid #d6e0f0',
-    borderRadius: '16px',
-    padding: '14px',
-    background: 'rgba(255,255,255,0.95)',
-    boxShadow: '0 12px 28px -26px rgba(15, 23, 42, 0.5)',
-    display: 'grid',
-    gap: '12px',
-  } satisfies CSSProperties,
-
-  panelTitle: {
-    margin: 0,
-    fontSize: '1rem',
-    letterSpacing: '-0.01em',
-  } satisfies CSSProperties,
-
-  panelLead: {
-    margin: 0,
-    fontSize: '0.8rem',
-    color: '#64748b',
-  } satisfies CSSProperties,
-
-  row: {
-    display: 'flex',
-    alignItems: 'center',
-    flexWrap: 'wrap',
-    gap: '8px',
-  } satisfies CSSProperties,
-
-  modeButton: {
-    borderWidth: '1px',
-    borderStyle: 'solid',
-    borderColor: '#cfd8ea',
-    borderRadius: '999px',
-    padding: '6px 12px',
-    fontSize: '0.82rem',
-    fontWeight: 700,
-    background: '#fff',
-    color: '#334155',
-    cursor: 'pointer',
-  } satisfies CSSProperties,
-
-  modeButtonActive: {
-    borderColor: '#1d4ed8',
-    background: '#1d4ed8',
-    color: '#fff',
-  } satisfies CSSProperties,
-
-  passwordInput: {
-    border: '1px solid #cfd8ea',
-    borderRadius: '10px',
-    padding: '7px 9px',
-    fontSize: '0.84rem',
-    minWidth: '230px',
-  } satisfies CSSProperties,
-
-  fundingCard: {
-    border: '1px solid #d7e0ee',
-    borderRadius: '12px',
-    padding: '10px',
-    display: 'grid',
-    gap: '7px',
-    background: '#f8fbff',
-  } satisfies CSSProperties,
-
-  checkboxLabel: {
-    display: 'flex',
-    alignItems: 'center',
-    gap: '8px',
-    fontWeight: 700,
-    color: '#1e293b',
-    cursor: 'pointer',
-    fontSize: '0.84rem',
-  } satisfies CSSProperties,
-
-  helperText: {
-    margin: 0,
-    fontSize: '0.78rem',
-    color: '#64748b',
-    lineHeight: 1.35,
-  } satisfies CSSProperties,
-
-  warningText: {
-    margin: 0,
-    fontSize: '0.78rem',
-    color: '#b45309',
-    lineHeight: 1.35,
-  } satisfies CSSProperties,
-
-  compactMeta: {
-    margin: 0,
-    fontSize: '0.78rem',
-    color: '#475569',
-    lineHeight: 1.35,
-  } satisfies CSSProperties,
-
-  statusGrid: {
-    display: 'grid',
-    gridTemplateColumns: 'repeat(auto-fit, minmax(170px, 1fr))',
-    gap: '7px',
-  } satisfies CSSProperties,
-
-  statusItem: {
-    border: '1px solid #dbe4f3',
-    borderRadius: '10px',
-    padding: '7px 9px',
-    fontSize: '0.78rem',
-    color: '#334155',
-    background: '#fff',
-  } satisfies CSSProperties,
-
-  statusLabel: {
-    display: 'block',
-    fontSize: '0.67rem',
-    color: '#64748b',
-    textTransform: 'uppercase',
-    letterSpacing: '0.02em',
-  } satisfies CSSProperties,
-
-  statusValue: {
-    display: 'block',
-    marginTop: '2px',
-    fontWeight: 700,
-    color: '#0f172a',
-    wordBreak: 'break-all',
-  } satisfies CSSProperties,
-
-  stepList: {
-    margin: 0,
-    padding: 0,
-    listStyle: 'none',
-    display: 'grid',
-    gap: '8px',
-  } satisfies CSSProperties,
-
-  stepItem: {
-    border: '1px solid #dbe4f3',
-    borderRadius: '10px',
-    padding: '8px 10px',
-    background: '#fff',
-    display: 'grid',
-    gap: '3px',
-  } satisfies CSSProperties,
-
-  stepTitle: {
-    margin: 0,
-    fontSize: '0.82rem',
-    fontWeight: 700,
-    color: '#0f172a',
-  } satisfies CSSProperties,
-
-  stepDesc: {
-    margin: 0,
-    fontSize: '0.76rem',
-    color: '#64748b',
-    lineHeight: 1.35,
-  } satisfies CSSProperties,
-
-  codeBlock: {
-    margin: 0,
-    border: '1px solid #cdd8ea',
-    borderRadius: '10px',
-    padding: '10px',
-    background: '#0f172a',
-    color: '#cbd5e1',
-    fontFamily: 'IBM Plex Mono, Menlo, monospace',
-    fontSize: '0.74rem',
-    lineHeight: 1.45,
-    whiteSpace: 'pre-wrap',
-    wordBreak: 'break-word',
-  } satisfies CSSProperties,
-
-  eventBox: {
-    border: '1px solid #cdd8ea',
-    borderRadius: '10px',
-    padding: '10px',
-    background: '#0f172a',
-    color: '#e2e8f0',
-    fontFamily: 'IBM Plex Mono, Menlo, monospace',
-    fontSize: '0.72rem',
-    minHeight: '126px',
-    maxHeight: '220px',
-    overflowY: 'auto',
-  } satisfies CSSProperties,
-
-  actionButton: {
-    border: '1px solid #cfd8ea',
-    borderRadius: '8px',
-    padding: '6px 10px',
-    background: '#fff',
-    color: '#0f172a',
-    fontSize: '0.78rem',
-    fontWeight: 700,
-    cursor: 'pointer',
-  } satisfies CSSProperties,
-
-  errorBox: {
-    border: '1px solid #fecaca',
-    borderRadius: '10px',
-    padding: '8px 10px',
-    color: '#991b1b',
-    background: '#fef2f2',
-    fontSize: '0.78rem',
-  } satisfies CSSProperties,
-};
-
 export function App() {
-  const {
-    open: openExternalWalletConnectModal,
-    wallet: connectedExternalWallet,
-    disconnect: disconnectExternalWallet,
-  } = ccc.useCcc();
-  const cccSigner = ccc.useSigner();
-
-  const [strategy, setStrategy] = useState<ConnectStrategy>('password');
-  const [externalWallet, setExternalWallet] = useState(false);
-  const [assetKind, setAssetKind] = useState<'ckb' | 'rusd'>('ckb');
-  const [customTabMode, setCustomTabMode] = useState(false);
-  const [password, setPassword] = useState('demo-secret');
-  const [externalWalletAddress, setExternalWalletAddress] = useState<string | null>(null);
+  const [strategy, setStrategy] = useState<ConnectStrategy>('passkey');
+  const [password, setPassword] = useState('fiber-testnet-demo');
   const [eventLogs, setEventLogs] = useState<EventLogEntry[]>([]);
 
   const fiber = useFiberNode({
     network: 'testnet',
-    walletId: 'quick-card-connect-demo',
-    externalWallet,
+    walletId: 'fiber-node-button-live-preview',
     nodeConfig: RUSD_NODE_CONFIG,
   });
-  const selectedAsset = assetKind === 'rusd' ? RUSD_ASSET : CKB_ASSET;
 
   const addLog = useCallback((message: string) => {
     const now = new Date();
-    const ts = now.toISOString().slice(11, 19);
-    const entry = {
-      id: `${now.getTime()}-${crypto.randomUUID()}`,
-      text: `[${ts}] ${message}`,
-    };
-    setEventLogs((prev) => [entry, ...prev].slice(0, 18));
-  }, []);
-
-  const clearLogs = useCallback(() => {
-    setEventLogs([]);
-  }, []);
-
-  useEffect(() => {
-    if (!externalWallet || !cccSigner) {
-      return;
-    }
-
-    let cancelled = false;
-
-    const loadAddress = async () => {
-      try {
-        const addressObj = await cccSigner.getRecommendedAddressObj();
-        if (!cancelled) {
-          setExternalWalletAddress(addressObj.toString());
-        }
-      } catch (error) {
-        if (cancelled) {
-          return;
-        }
-        const message = error instanceof Error ? error.message : String(error);
-        addLog(`External wallet address load failed: ${message}`);
-      }
-    };
-
-    void loadAddress();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [addLog, cccSigner, externalWallet]);
-
-  const resolveExternalFunding = useMemo(() => {
-    if (!cccSigner) {
-      return async () => {
-        throw new Error('External wallet mode requires a connected CCC wallet signer.');
-      };
-    }
-
-    return createCccExternalFundingResolver({
-      signer: cccSigner,
-      knownScripts: Object.values(ccc.KnownScript),
-      ckbRpcUrl: TESTNET_CKB_RPC_URL,
-      onKnownScriptResolved: (knownScript: string) => {
-        addLog(`Using CCC known script deps: ${knownScript}.`);
-      },
-      onAddressResolved: (addressObj: CccRecommendedAddressObjLike) => {
-        setExternalWalletAddress(addressObj.toString?.() ?? null);
-      },
-    });
-  }, [addLog, cccSigner]);
-
-  const externalWalletToggleLocked = fiber.isRunning || fiber.isStarting;
-
-  const customI18n = useCallback((key: string, fallback: string) => {
-    const dictionary: Record<string, string> = {
-      'tabs.workbench': '操作台',
-      'tabs.channels': '通道',
-      'actions.payInvoice': '立即支付',
-      'actions.payInvoice.loading': '支付中...',
-      'workbench.payments.title': '支付操作',
-      'workbench.openChannel.title': '开通道',
-      'workbench.connectionPrep.title': '连接准备',
-    };
-
-    return dictionary[key] ?? fallback;
-  }, []);
-
-  const customTabs = useMemo<ReadonlyArray<FiberNodeButtonTabConfig>>(
-    () => [
-      { id: 'workbench' },
-      {
-        id: 'my-stats',
-        label: (t) => t('demo.customTab.title', 'My Stats'),
-        render: ({ state, t }) => (
-          <section style={{ border: '1px solid #dbe4f3', borderRadius: 10, padding: 10 }}>
-            <h4 style={{ margin: 0, fontSize: '0.86rem' }}>
-              {t('demo.customTab.heading', 'Custom Runtime Stats')}
-            </h4>
-            <p style={{ margin: '8px 0 0', fontSize: '0.78rem', color: '#475569' }}>
-              {t('demo.customTab.peerCount', 'Connected peers')}: {state.connectedPeers.length}
-            </p>
-            <p style={{ margin: '6px 0 0', fontSize: '0.78rem', color: '#475569' }}>
-              {t('demo.customTab.activeChannels', 'Active channels')}: {state.activeChannelCount}
-            </p>
-            <p style={{ margin: '6px 0 0', fontSize: '0.78rem', color: '#475569' }}>
-              {t('demo.customTab.paymentStatus', 'Payment status')}:{' '}
-              {state.paymentResult?.status ?? 'Idle'}
-            </p>
-          </section>
-        ),
-      },
-      { id: 'channels' },
-      { id: 'diagnostics', hidden: true },
-    ],
-    [],
-  );
-
-  const customRenderAction = useCallback<FiberNodeButtonRenderAction>(({ id, defaultProps }) => {
-    if (id !== 'pay-invoice') {
-      return undefined;
-    }
-
-    return (
-      <button
-        type="button"
-        style={{
-          border: '1px solid #0f766e',
-          borderRadius: 8,
-          padding: '6px 10px',
-          background: '#0f766e',
-          color: '#fff',
-          fontSize: '0.78rem',
-          fontWeight: 700,
-          cursor: defaultProps.disabled ? 'not-allowed' : 'pointer',
-          opacity: defaultProps.disabled ? 0.6 : 1,
-        }}
-        disabled={defaultProps.disabled}
-        onClick={() => {
-          void defaultProps.onTrigger();
-        }}
-      >
-        {defaultProps.loading ? '支付中...' : '立即支付（自定义）'}
-      </button>
+    setEventLogs((previous) =>
+      [
+        {
+          id: `${now.getTime()}-${crypto.randomUUID()}`,
+          text: `${now.toLocaleTimeString([], { hour12: false })}  ${message}`,
+        },
+        ...previous,
+      ].slice(0, 24),
     );
   }, []);
 
-  const hookStateItems = [
-    { label: 'Node state', value: fiber.state },
-    { label: 'Connected', value: fiber.isRunning ? 'Yes' : 'No' },
-    {
-      label: 'Funding mode',
-      value: externalWallet ? 'External wallet (CCC signer)' : 'Internal wallet (node managed)',
-    },
-  ];
+  const interactionLocked = fiber.isRunning || fiber.isStarting;
+  const nodeStatus = fiber.isRunning ? 'Running' : fiber.isStarting ? 'Starting' : 'Ready';
 
   return (
-    <div style={styles.page}>
-      <div style={styles.shell}>
-        <header style={styles.hero}>
-          <h1 style={styles.title}>FiberNodeButton Developer Demo</h1>
-          <p style={styles.subtitle}>
-            One component, one page: learn FiberNodeButton integration fast, then verify behavior in
-            the live panel and runtime logs.
+    <main className="site-shell">
+      <header className="site-header">
+        <a className="wordmark" href="https://github.com/RetricSu/fiber-pay">
+          <span className="wordmark-mark" aria-hidden="true">
+            F
+          </span>
+          <span>fiber-pay</span>
+        </a>
+
+        <nav className="header-links" aria-label="Project links">
+          <a href="https://retricsu.github.io/fiber-pay/">Docs</a>
+          <a href="https://github.com/RetricSu/fiber-pay/tree/master/examples/react-fiber-node-button-lab">
+            Source
+          </a>
+        </nav>
+      </header>
+
+      <section className="intro" aria-labelledby="page-title">
+        <div>
+          <p className="eyebrow">
+            <span className="live-dot" aria-hidden="true" />
+            Live on Fiber testnet
           </p>
-        </header>
+          <h1 id="page-title">
+            <code>FiberNodeButton</code>, running for real.
+          </h1>
+          <p className="intro-copy">
+            Start a browser Fiber node, manage channels, create invoices and send payments from the
+            component shipped by the current workspace packages.
+          </p>
+        </div>
 
-        <div style={styles.layout}>
-          <aside style={styles.panel}>
-            <h2 style={styles.panelTitle}>Integration Guide</h2>
-            <p style={styles.panelLead}>
-              Copy this wiring model and replace wallet/session config with your app values.
-            </p>
+        <dl className="build-facts">
+          <div>
+            <dt>Package</dt>
+            <dd>@fiber-pay/react</dd>
+          </div>
+          <div>
+            <dt>Network</dt>
+            <dd>Testnet</dd>
+          </div>
+          <div>
+            <dt>Runtime</dt>
+            <dd>Browser WASM</dd>
+          </div>
+        </dl>
+      </section>
 
-            <ol style={styles.stepList}>
-              <li style={styles.stepItem}>
-                <p style={styles.stepTitle}>Step 1. Create one shared fiber hook</p>
-                <p style={styles.stepDesc}>
-                  Keep useFiberNode in your page or provider and pass the same fiber object into
-                  FiberNodeButton.
-                </p>
-              </li>
-              <li style={styles.stepItem}>
-                <p style={styles.stepTitle}>Step 2. Choose auth strategy at runtime</p>
-                <p style={styles.stepDesc}>
-                  Password and passkey can share one component, switch via strategy prop.
-                </p>
-              </li>
-              <li style={styles.stepItem}>
-                <p style={styles.stepTitle}>Step 3. Plug external funding only when needed</p>
-                <p style={styles.stepDesc}>
-                  Use externalFunding.enabled plus resolve callback for CCC signer handoff.
-                </p>
-              </li>
-              <li style={styles.stepItem}>
-                <p style={styles.stepTitle}>Step 4. Subscribe to callback events</p>
-                <p style={styles.stepDesc}>
-                  onConnect, onDisconnect, onError, onLog cover most app-level telemetry needs.
-                </p>
-              </li>
-            </ol>
+      <section className="demo" aria-labelledby="demo-title">
+        <div className="demo-context">
+          <p className="section-index">01 / LIVE COMPONENT</p>
+          <h2 id="demo-title">The package is the preview.</h2>
+          <p>
+            Nothing below is mocked. Credentials and node data stay in this browser. Network calls
+            use the public Fiber and CKB testnet services configured by the SDK.
+          </p>
 
-            <pre style={styles.codeBlock}>{integrationSnippet}</pre>
+          <ol className="run-sequence">
+            <li>
+              <span>1</span>
+              Choose Passkey or a local password.
+            </li>
+            <li>
+              <span>2</span>
+              Start the node with FiberNodeButton.
+            </li>
+            <li>
+              <span>3</span>
+              Open the panel to inspect every workflow.
+            </li>
+          </ol>
 
-            <div>
-              <div style={styles.row}>
-                <h3 style={{ ...styles.panelTitle, fontSize: '0.92rem' }}>Runtime Events</h3>
-                <button type="button" onClick={clearLogs} style={styles.actionButton}>
-                  Clear Logs
-                </button>
-              </div>
-              <div style={styles.eventBox}>
-                {eventLogs.length === 0
-                  ? 'No events yet. Connect the node and interact with the tabbed panel.'
-                  : eventLogs.map((entry) => <div key={entry.id}>{entry.text}</div>)}
-              </div>
-            </div>
-          </aside>
+          <p className="testnet-note">
+            Use testnet funds only. CKB and the configured RUSD asset are available inside the
+            component after the node starts.
+          </p>
+        </div>
 
-          <section style={styles.panel}>
-            <h2 style={styles.panelTitle}>Live Playground</h2>
-            <p style={styles.panelLead}>
-              Choose strategy, toggle funding mode, then open FiberNodeButton.
-            </p>
-
-            <div style={styles.row}>
-              <button
-                type="button"
-                onClick={() => setCustomTabMode(false)}
-                style={{
-                  ...styles.modeButton,
-                  ...(customTabMode ? {} : styles.modeButtonActive),
-                }}
-              >
-                Default Panel
-              </button>
-              <button
-                type="button"
-                onClick={() => setCustomTabMode(true)}
-                style={{
-                  ...styles.modeButton,
-                  ...(customTabMode ? styles.modeButtonActive : {}),
-                }}
-              >
-                Custom Tab Mode
-              </button>
+        <div className="component-workbench">
+          <div className="workbench-header">
+            <div className="runtime-status" aria-live="polite">
+              <span
+                className={`status-light status-light-${fiber.isRunning ? 'running' : 'idle'}`}
+                aria-hidden="true"
+              />
+              <span>{nodeStatus}</span>
+              {fiber.nodeInfo?.pubkey ? <code>{shorten(fiber.nodeInfo.pubkey)}</code> : null}
             </div>
 
-            <p style={styles.helperText}>
-              {customTabMode
-                ? 'Custom mode enabled: adds a My Stats tab, hides Diagnostics, localizes labels, and overrides Pay action button.'
-                : 'Default mode enabled: built-in tabs and default actions.'}
-            </p>
-
-            <div style={styles.row}>
+            <fieldset className="strategy-switch">
+              <legend className="sr-only">Node authentication method</legend>
               <button
                 type="button"
-                onClick={() => setStrategy('password')}
-                style={{
-                  ...styles.modeButton,
-                  ...(strategy === 'password' ? styles.modeButtonActive : {}),
-                }}
-              >
-                Password
-              </button>
-              <button
-                type="button"
+                aria-pressed={strategy === 'passkey'}
+                disabled={interactionLocked}
                 onClick={() => setStrategy('passkey')}
-                style={{
-                  ...styles.modeButton,
-                  ...(strategy === 'passkey' ? styles.modeButtonActive : {}),
-                }}
               >
                 Passkey
               </button>
-              {strategy === 'password' ? (
-                <input
-                  type="password"
-                  value={password}
-                  onChange={(event) => setPassword(event.target.value)}
-                  style={styles.passwordInput}
-                  placeholder="Password for node unlock"
-                />
-              ) : null}
-            </div>
-
-            <div style={styles.row}>
               <button
                 type="button"
-                onClick={() => setAssetKind('ckb')}
-                disabled={externalWalletToggleLocked}
-                style={{
-                  ...styles.modeButton,
-                  ...(assetKind === 'ckb' ? styles.modeButtonActive : {}),
-                }}
+                aria-pressed={strategy === 'password'}
+                disabled={interactionLocked}
+                onClick={() => setStrategy('password')}
               >
-                CKB
+                Password
               </button>
-              <button
-                type="button"
-                onClick={() => setAssetKind('rusd')}
-                disabled={externalWalletToggleLocked}
-                style={{
-                  ...styles.modeButton,
-                  ...(assetKind === 'rusd' ? styles.modeButtonActive : {}),
+            </fieldset>
+          </div>
+
+          {strategy === 'password' ? (
+            <label className="password-field">
+              <span>Local node password</span>
+              <input
+                type="password"
+                autoComplete="current-password"
+                value={password}
+                disabled={interactionLocked}
+                onChange={(event) => setPassword(event.target.value)}
+              />
+              <small>Used to encrypt this browser node. It is never sent to the demo host.</small>
+            </label>
+          ) : (
+            <p className="passkey-note">
+              Passkey uses WebAuthn PRF in a secure browser context. Password remains available as a
+              fallback.
+            </p>
+          )}
+
+          <div className="component-stage">
+            <div className="stage-label">
+              <span>Workspace component</span>
+              <code>testnet</code>
+            </div>
+
+            <div className="component-anchor">
+              <FiberNodeButton
+                fiber={fiber}
+                network="testnet"
+                strategy={strategy}
+                password={strategy === 'password' ? password : undefined}
+                asset={{ kind: 'ckb' }}
+                initialFundingAmount="1000"
+                invoiceAmount="1"
+                style={componentTheme}
+                dropdownStyle={{
+                  width: 'min(520px, calc(100vw - 2rem))',
+                  maxHeight: 'min(760px, calc(100vh - 7rem))',
                 }}
-              >
-                RUSD (base units)
-              </button>
+                onConnect={(_node, info) => addLog(`Connected ${shorten(info.pubkey)}`)}
+                onDisconnect={() => addLog('Disconnected')}
+                onError={(message) => addLog(`Error: ${message}`)}
+                onLog={addLog}
+              />
             </div>
+          </div>
 
-            <p style={styles.helperText}>
-              {assetKind === 'rusd'
-                ? 'RUSD mode uses the explicit testnet whitelist above. Amounts are raw integer base units.'
-                : 'CKB mode uses human-readable CKB amounts.'}
+          {fiber.error ? (
+            <p className="runtime-error" role="alert">
+              {fiber.error}
             </p>
-
-            <FiberNodeButton
-              fiber={fiber}
-              asset={selectedAsset}
-              initialFundingAmount={assetKind === 'rusd' ? '1000000000' : '1000'}
-              invoiceAmount={assetKind === 'rusd' ? '100000000' : '1'}
-              strategy={strategy}
-              password={strategy === 'password' ? password : undefined}
-              onLog={addLog}
-              onConnect={(_node, info) => {
-                addLog(`FiberNodeButton connected: ${shorten(info.pubkey, 12, 10)}`);
-              }}
-              onDisconnect={() => {
-                addLog('FiberNodeButton disconnected.');
-              }}
-              onError={(msg) => {
-                addLog(`FiberNodeButton error: ${msg}`);
-              }}
-              externalFunding={{
-                enabled: externalWallet,
-                resolve: resolveExternalFunding,
-              }}
-              tabs={customTabMode ? customTabs : undefined}
-              t={customTabMode ? customI18n : undefined}
-              renderAction={customTabMode ? customRenderAction : undefined}
-              renderConnectorSection={
-                externalWallet
-                  ? () => (
-                      <div style={{ display: 'grid', gap: 6 }}>
-                        <div style={{ fontSize: 12, color: '#475569' }}>
-                          CCC wallet:{' '}
-                          <strong>{connectedExternalWallet?.name ?? 'Not connected'}</strong>
-                          {connectedExternalWallet && externalWalletAddress
-                            ? ` | address: ${shorten(externalWalletAddress, 20, 10)}`
-                            : ''}
-                        </div>
-                        <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
-                          <button
-                            type="button"
-                            onClick={() => {
-                              void openExternalWalletConnectModal();
-                            }}
-                            style={{
-                              border: '1px solid #1d4ed8',
-                              borderRadius: 8,
-                              padding: '6px 10px',
-                              background: '#2563eb',
-                              color: '#fff',
-                              cursor: 'pointer',
-                              fontWeight: 700,
-                            }}
-                          >
-                            {connectedExternalWallet
-                              ? 'Switch External Wallet'
-                              : 'Connect External Wallet'}
-                          </button>
-                          <button
-                            type="button"
-                            onClick={() => {
-                              void disconnectExternalWallet();
-                            }}
-                            disabled={!connectedExternalWallet}
-                            style={{
-                              border: '1px solid #cbd5e1',
-                              borderRadius: 8,
-                              padding: '6px 10px',
-                              background: '#fff',
-                              color: '#111827',
-                              cursor: connectedExternalWallet ? 'pointer' : 'not-allowed',
-                              opacity: connectedExternalWallet ? 1 : 0.65,
-                              fontWeight: 700,
-                            }}
-                          >
-                            Disconnect External Wallet
-                          </button>
-                        </div>
-                      </div>
-                    )
-                  : undefined
-              }
-            />
-
-            <div style={styles.fundingCard}>
-              <label style={styles.checkboxLabel}>
-                <input
-                  type="checkbox"
-                  checked={externalWallet}
-                  disabled={externalWalletToggleLocked}
-                  onChange={(event) => {
-                    const checked = event.target.checked;
-                    setExternalWallet(checked);
-                    if (!checked) {
-                      setExternalWalletAddress(null);
-                    }
-                  }}
-                  style={{ width: 16, height: 16 }}
-                />
-                Use External Wallet (CCC Signer)
-              </label>
-
-              <p style={styles.helperText}>
-                {externalWallet ? 'External mode enabled.' : 'Internal mode enabled.'}
-              </p>
-
-              {externalWalletToggleLocked ? (
-                <p style={styles.warningText}>Disconnect the node before switching funding mode.</p>
-              ) : null}
-            </div>
-
-            <p style={styles.compactMeta}>
-              Node:{' '}
-              {fiber.nodeInfo?.pubkey ? shorten(fiber.nodeInfo.pubkey, 18, 12) : 'Not connected'}
-            </p>
-
-            <div style={styles.statusGrid}>
-              {hookStateItems.map((item) => (
-                <div key={item.label} style={styles.statusItem}>
-                  <span style={styles.statusLabel}>{item.label}</span>
-                  <span style={styles.statusValue}>{item.value}</span>
-                </div>
-              ))}
-            </div>
-
-            {fiber.error ? <div style={styles.errorBox}>Hook error: {fiber.error}</div> : null}
-          </section>
+          ) : null}
         </div>
-      </div>
-    </div>
+      </section>
+
+      <details className="event-console">
+        <summary>
+          <span>Runtime events</span>
+          <span>{eventLogs.length || 'None yet'}</span>
+        </summary>
+        <div className="event-console-body">
+          <button type="button" onClick={() => setEventLogs([])} disabled={eventLogs.length === 0}>
+            Clear
+          </button>
+          <pre aria-live="polite">
+            {eventLogs.length > 0
+              ? eventLogs.map((entry) => entry.text).join('\n')
+              : 'Start the node and component events will appear here.'}
+          </pre>
+        </div>
+      </details>
+
+      <footer>
+        <span>Built from workspace packages</span>
+        <span>Real testnet, no simulated state</span>
+      </footer>
+    </main>
   );
 }

--- a/examples/react-fiber-node-button-lab/src/App.tsx
+++ b/examples/react-fiber-node-button-lab/src/App.tsx
@@ -1,5 +1,5 @@
 import { FiberNodeButton, type UseFiberNodeOptions, useFiberNode } from '@fiber-pay/react';
-import { type CSSProperties, useCallback, useState } from 'react';
+import { type CSSProperties, useCallback, useEffect, useState } from 'react';
 
 type ConnectStrategy = 'password' | 'passkey';
 
@@ -46,6 +46,15 @@ const componentTheme = {
   '--fpay-error': 'oklch(0.55 0.2 25)',
 } as CSSProperties;
 
+const DEFAULT_ASSET = { kind: 'ckb' } as const;
+
+const DROPDOWN_STYLE = {
+  width: 'min(520px, calc(100vw - 2rem))',
+  maxHeight: 'min(760px, calc(100vh - 7rem))',
+} as CSSProperties;
+
+let logIdCounter = 0;
+
 function shorten(value: string, head = 12, tail = 10): string {
   if (!value || value.length <= head + tail + 3) {
     return value;
@@ -64,12 +73,18 @@ export function App() {
     nodeConfig: RUSD_NODE_CONFIG,
   });
 
+  useEffect(() => {
+    if (fiber.passkeySupportReason && !fiber.isPasskeySupported) {
+      setStrategy('password');
+    }
+  }, [fiber.isPasskeySupported, fiber.passkeySupportReason]);
+
   const addLog = useCallback((message: string) => {
     const now = new Date();
     setEventLogs((previous) =>
       [
         {
-          id: `${now.getTime()}-${crypto.randomUUID()}`,
+          id: `${now.getTime()}-${logIdCounter++}`,
           text: `${now.toLocaleTimeString([], { hour12: false })}  ${message}`,
         },
         ...previous,
@@ -175,7 +190,10 @@ export function App() {
               <button
                 type="button"
                 aria-pressed={strategy === 'passkey'}
-                disabled={interactionLocked}
+                disabled={
+                  interactionLocked ||
+                  (fiber.passkeySupportReason !== null && !fiber.isPasskeySupported)
+                }
                 onClick={() => setStrategy('passkey')}
               >
                 Passkey
@@ -219,17 +237,13 @@ export function App() {
             <div className="component-anchor">
               <FiberNodeButton
                 fiber={fiber}
-                network="testnet"
                 strategy={strategy}
                 password={strategy === 'password' ? password : undefined}
-                asset={{ kind: 'ckb' }}
+                asset={DEFAULT_ASSET}
                 initialFundingAmount="1000"
                 invoiceAmount="1"
                 style={componentTheme}
-                dropdownStyle={{
-                  width: 'min(520px, calc(100vw - 2rem))',
-                  maxHeight: 'min(760px, calc(100vh - 7rem))',
-                }}
+                dropdownStyle={DROPDOWN_STYLE}
                 onConnect={(_node, info) => addLog(`Connected ${shorten(info.pubkey)}`)}
                 onDisconnect={() => addLog('Disconnected')}
                 onError={(message) => addLog(`Error: ${message}`)}

--- a/examples/react-fiber-node-button-lab/src/app.css
+++ b/examples/react-fiber-node-button-lab/src/app.css
@@ -1,0 +1,638 @@
+:root {
+  color: oklch(0.24 0.035 260);
+  background: oklch(0.97 0.008 82);
+  font-family: "Avenir Next", "Segoe UI Variable", "Segoe UI", ui-sans-serif, system-ui, sans-serif;
+  font-synthesis: none;
+  text-rendering: optimizeLegibility;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  min-width: 320px;
+  background: oklch(0.97 0.008 82);
+}
+
+body {
+  margin: 0;
+  min-width: 320px;
+  min-height: 100vh;
+}
+
+button,
+input {
+  font: inherit;
+}
+
+a {
+  color: inherit;
+}
+
+button:focus-visible,
+input:focus-visible,
+a:focus-visible,
+summary:focus-visible {
+  outline: 3px solid oklch(0.72 0.14 255);
+  outline-offset: 3px;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.site-shell {
+  width: min(1240px, calc(100% - 40px));
+  margin: 0 auto;
+  padding: 24px 0 32px;
+}
+
+.site-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding-bottom: 22px;
+  border-bottom: 1px solid oklch(0.84 0.018 260);
+}
+
+.wordmark {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  color: oklch(0.2 0.045 260);
+  font-size: 0.95rem;
+  font-weight: 750;
+  letter-spacing: -0.02em;
+  text-decoration: none;
+}
+
+.wordmark-mark {
+  display: grid;
+  width: 30px;
+  height: 30px;
+  place-items: center;
+  border-radius: 8px;
+  background: oklch(0.52 0.2 260);
+  color: oklch(0.98 0.005 260);
+  font-size: 0.82rem;
+  letter-spacing: -0.06em;
+}
+
+.header-links {
+  display: flex;
+  gap: 22px;
+  color: oklch(0.42 0.035 260);
+  font-size: 0.82rem;
+  font-weight: 650;
+}
+
+.header-links a {
+  text-underline-offset: 4px;
+  text-decoration-color: transparent;
+  transition:
+    color 160ms ease-out,
+    text-decoration-color 160ms ease-out;
+}
+
+.header-links a:hover {
+  color: oklch(0.48 0.18 260);
+  text-decoration-color: currentColor;
+}
+
+.intro {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: clamp(40px, 8vw, 120px);
+  align-items: end;
+  padding: clamp(46px, 6vw, 76px) 0 clamp(38px, 5vw, 56px);
+}
+
+.intro > * {
+  min-width: 0;
+}
+
+.eyebrow,
+.section-index {
+  margin: 0 0 20px;
+  color: oklch(0.48 0.16 260);
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.13em;
+  text-transform: uppercase;
+}
+
+.eyebrow {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+}
+
+.live-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: oklch(0.66 0.18 150);
+  box-shadow: 0 0 0 5px oklch(0.91 0.06 150);
+}
+
+h1,
+h2,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  max-width: 860px;
+  margin-bottom: 20px;
+  font-size: clamp(2.7rem, 5.4vw, 5rem);
+  font-weight: 760;
+  letter-spacing: -0.065em;
+  line-height: 0.94;
+}
+
+h1 code {
+  color: oklch(0.48 0.2 260);
+  font-family: inherit;
+  font-weight: inherit;
+}
+
+.intro-copy {
+  max-width: 65ch;
+  margin-bottom: 0;
+  color: oklch(0.43 0.028 260);
+  font-size: clamp(1rem, 1.5vw, 1.15rem);
+  line-height: 1.65;
+}
+
+.build-facts {
+  width: min(100%, 260px);
+  margin: 0;
+}
+
+.build-facts div {
+  display: grid;
+  grid-template-columns: 80px 1fr;
+  gap: 20px;
+  padding: 13px 0;
+  border-bottom: 1px solid oklch(0.84 0.018 260);
+}
+
+.build-facts dt {
+  color: oklch(0.52 0.025 260);
+  font-size: 0.72rem;
+}
+
+.build-facts dd {
+  margin: 0;
+  color: oklch(0.27 0.04 260);
+  font-family: ui-monospace, "SFMono-Regular", Consolas, monospace;
+  font-size: 0.72rem;
+  font-weight: 650;
+  text-align: right;
+}
+
+.demo {
+  display: grid;
+  grid-template-columns: minmax(250px, 0.68fr) minmax(560px, 1.32fr);
+  min-height: 760px;
+  border: 1px solid oklch(0.79 0.028 260);
+  background: oklch(0.985 0.006 82);
+  box-shadow: 0 24px 70px -55px oklch(0.22 0.06 260 / 0.8);
+}
+
+.demo-context {
+  padding: clamp(30px, 5vw, 62px);
+  border-right: 1px solid oklch(0.79 0.028 260);
+}
+
+.demo-context h2 {
+  max-width: 10ch;
+  margin-bottom: 24px;
+  font-size: clamp(2rem, 4vw, 3.7rem);
+  font-weight: 730;
+  letter-spacing: -0.055em;
+  line-height: 1;
+}
+
+.demo-context > p:not(.section-index, .testnet-note) {
+  max-width: 40ch;
+  color: oklch(0.43 0.028 260);
+  font-size: 0.93rem;
+  line-height: 1.65;
+}
+
+.run-sequence {
+  margin: 44px 0;
+  padding: 0;
+  list-style: none;
+}
+
+.run-sequence li {
+  display: grid;
+  grid-template-columns: 28px 1fr;
+  gap: 12px;
+  align-items: baseline;
+  padding: 16px 0;
+  border-top: 1px solid oklch(0.85 0.016 260);
+  color: oklch(0.33 0.035 260);
+  font-size: 0.84rem;
+  line-height: 1.45;
+}
+
+.run-sequence li:last-child {
+  border-bottom: 1px solid oklch(0.85 0.016 260);
+}
+
+.run-sequence span {
+  color: oklch(0.48 0.18 260);
+  font-family: ui-monospace, "SFMono-Regular", Consolas, monospace;
+  font-size: 0.72rem;
+  font-weight: 800;
+}
+
+.testnet-note {
+  max-width: 40ch;
+  margin: 0;
+  color: oklch(0.42 0.09 62);
+  font-size: 0.76rem;
+  line-height: 1.55;
+}
+
+.component-workbench {
+  min-width: 0;
+  padding: 18px;
+  background-color: oklch(0.94 0.018 260);
+  background-image:
+    linear-gradient(oklch(0.82 0.025 260 / 0.38) 1px, transparent 1px),
+    linear-gradient(90deg, oklch(0.82 0.025 260 / 0.38) 1px, transparent 1px);
+  background-size: 32px 32px;
+}
+
+.workbench-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  min-height: 52px;
+  padding: 9px 10px 9px 16px;
+  border: 1px solid oklch(0.8 0.028 260);
+  background: oklch(0.98 0.008 260);
+}
+
+.runtime-status {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 9px;
+  color: oklch(0.31 0.035 260);
+  font-size: 0.74rem;
+  font-weight: 750;
+}
+
+.runtime-status code {
+  overflow: hidden;
+  color: oklch(0.51 0.03 260);
+  font-family: ui-monospace, "SFMono-Regular", Consolas, monospace;
+  font-size: 0.66rem;
+  text-overflow: ellipsis;
+}
+
+.status-light {
+  flex: 0 0 auto;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+}
+
+.status-light-idle {
+  background: oklch(0.69 0.025 260);
+}
+
+.status-light-running {
+  background: oklch(0.62 0.19 150);
+  box-shadow: 0 0 0 4px oklch(0.9 0.07 150);
+}
+
+.strategy-switch {
+  display: inline-flex;
+  margin: 0;
+  padding: 3px;
+  border: 1px solid oklch(0.82 0.025 260);
+  border-radius: 9px;
+  background: oklch(0.94 0.012 260);
+}
+
+.strategy-switch button {
+  border: 0;
+  border-radius: 6px;
+  padding: 7px 11px;
+  background: transparent;
+  color: oklch(0.47 0.03 260);
+  font-size: 0.7rem;
+  font-weight: 750;
+  cursor: pointer;
+}
+
+.strategy-switch button[aria-pressed="true"] {
+  background: oklch(0.99 0.004 260);
+  color: oklch(0.28 0.05 260);
+  box-shadow: 0 1px 4px oklch(0.3 0.04 260 / 0.14);
+}
+
+.strategy-switch button:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+.password-field,
+.passkey-note {
+  display: grid;
+  margin: 14px 0 0;
+  border: 1px solid oklch(0.81 0.03 260);
+  background: oklch(0.98 0.008 260);
+}
+
+.password-field {
+  grid-template-columns: auto minmax(170px, 1fr);
+  gap: 7px 16px;
+  align-items: center;
+  padding: 12px 14px;
+}
+
+.password-field > span {
+  color: oklch(0.34 0.035 260);
+  font-size: 0.74rem;
+  font-weight: 720;
+}
+
+.password-field input {
+  min-width: 0;
+  border: 1px solid oklch(0.77 0.035 260);
+  border-radius: 7px;
+  padding: 8px 10px;
+  background: oklch(0.995 0.003 260);
+  color: oklch(0.25 0.035 260);
+  font-family: ui-monospace, "SFMono-Regular", Consolas, monospace;
+  font-size: 0.74rem;
+}
+
+.password-field small {
+  grid-column: 1 / -1;
+  color: oklch(0.51 0.026 260);
+  font-size: 0.67rem;
+  line-height: 1.45;
+}
+
+.passkey-note {
+  padding: 12px 14px;
+  color: oklch(0.44 0.03 260);
+  font-size: 0.72rem;
+  line-height: 1.5;
+}
+
+.component-stage {
+  position: relative;
+  min-height: 620px;
+  margin-top: 14px;
+  border: 1px solid oklch(0.78 0.035 260);
+  background: oklch(0.975 0.009 82);
+}
+
+.stage-label {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 14px;
+  border-bottom: 1px solid oklch(0.83 0.022 260);
+  color: oklch(0.52 0.03 260);
+  font-size: 0.67rem;
+  font-weight: 720;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.stage-label code {
+  color: oklch(0.46 0.17 260);
+  font-family: ui-monospace, "SFMono-Regular", Consolas, monospace;
+  font-size: inherit;
+}
+
+.component-anchor {
+  display: flex;
+  justify-content: flex-end;
+  padding: 42px 30px;
+}
+
+.runtime-error {
+  margin: 14px 0 0;
+  border: 1px solid oklch(0.78 0.12 25);
+  padding: 10px 12px;
+  background: oklch(0.94 0.035 25);
+  color: oklch(0.44 0.16 25);
+  font-size: 0.76rem;
+  line-height: 1.5;
+}
+
+.event-console {
+  margin-top: 20px;
+  border-top: 1px solid oklch(0.82 0.02 260);
+  border-bottom: 1px solid oklch(0.82 0.02 260);
+}
+
+.event-console summary {
+  display: flex;
+  justify-content: space-between;
+  padding: 17px 4px;
+  color: oklch(0.34 0.04 260);
+  font-size: 0.78rem;
+  font-weight: 750;
+  cursor: pointer;
+  list-style: none;
+}
+
+.event-console summary::-webkit-details-marker {
+  display: none;
+}
+
+.event-console summary span:last-child {
+  color: oklch(0.53 0.03 260);
+  font-family: ui-monospace, "SFMono-Regular", Consolas, monospace;
+  font-size: 0.7rem;
+  font-weight: 600;
+}
+
+.event-console-body {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 12px;
+  padding: 0 4px 18px;
+}
+
+.event-console-body button {
+  align-self: start;
+  border: 1px solid oklch(0.77 0.03 260);
+  border-radius: 7px;
+  padding: 7px 10px;
+  background: oklch(0.97 0.009 82);
+  color: oklch(0.34 0.04 260);
+  font-size: 0.7rem;
+  font-weight: 720;
+  cursor: pointer;
+}
+
+.event-console-body button:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.event-console pre {
+  min-width: 0;
+  max-height: 230px;
+  margin: 0;
+  overflow: auto;
+  border-radius: 8px;
+  padding: 14px;
+  background: oklch(0.22 0.035 260);
+  color: oklch(0.88 0.025 260);
+  font-family: ui-monospace, "SFMono-Regular", Consolas, monospace;
+  font-size: 0.7rem;
+  line-height: 1.55;
+  white-space: pre-wrap;
+}
+
+footer {
+  display: flex;
+  justify-content: space-between;
+  gap: 24px;
+  padding-top: 24px;
+  color: oklch(0.53 0.025 260);
+  font-size: 0.7rem;
+}
+
+@media (max-width: 940px) {
+  .intro {
+    grid-template-columns: 1fr;
+  }
+
+  .build-facts {
+    width: 100%;
+    max-width: 420px;
+  }
+
+  .demo {
+    grid-template-columns: 1fr;
+  }
+
+  .demo-context {
+    border-right: 0;
+    border-bottom: 1px solid oklch(0.79 0.028 260);
+  }
+
+  .demo-context h2,
+  .demo-context > p:not(.section-index, .testnet-note),
+  .testnet-note {
+    max-width: 62ch;
+  }
+
+  .run-sequence {
+    margin-bottom: 30px;
+  }
+}
+
+@media (max-width: 620px) {
+  .site-shell {
+    width: min(100% - 20px, 1240px);
+    padding-top: 14px;
+  }
+
+  .site-header {
+    padding-bottom: 14px;
+  }
+
+  .header-links {
+    gap: 14px;
+  }
+
+  .intro {
+    gap: 34px;
+    padding: 54px 4px 42px;
+  }
+
+  h1 {
+    font-size: clamp(2.45rem, 11vw, 3.2rem);
+  }
+
+  .demo-context {
+    padding: 28px 22px 34px;
+  }
+
+  .component-workbench {
+    padding: 8px;
+    background-size: 24px 24px;
+  }
+
+  .workbench-header {
+    align-items: flex-start;
+    flex-direction: column;
+    padding: 12px;
+  }
+
+  .runtime-status {
+    width: 100%;
+  }
+
+  .strategy-switch {
+    width: 100%;
+  }
+
+  .strategy-switch button {
+    flex: 1;
+  }
+
+  .password-field {
+    grid-template-columns: 1fr;
+  }
+
+  .password-field small {
+    grid-column: auto;
+  }
+
+  .component-stage {
+    min-height: 760px;
+  }
+
+  .component-anchor {
+    padding: 34px 8px;
+  }
+
+  .event-console-body {
+    grid-template-columns: 1fr;
+  }
+
+  .event-console-body button {
+    justify-self: start;
+  }
+
+  footer {
+    flex-direction: column;
+    gap: 7px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+
+  .header-links a {
+    transition: none;
+  }
+}

--- a/examples/react-fiber-node-button-lab/src/main.tsx
+++ b/examples/react-fiber-node-button-lab/src/main.tsx
@@ -1,7 +1,7 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
-import { ccc } from '@ckb-ccc/connector-react';
 import { App } from './App.tsx';
+import './app.css';
 
 const rootElement = document.getElementById('root');
 if (!rootElement) {
@@ -10,8 +10,6 @@ if (!rootElement) {
 
 createRoot(rootElement).render(
   <StrictMode>
-    <ccc.Provider defaultClient={new ccc.ClientPublicTestnet()}>
-      <App />
-    </ccc.Provider>
+    <App />
   </StrictMode>,
 );

--- a/examples/react-fiber-node-button-lab/vite.config.ts
+++ b/examples/react-fiber-node-button-lab/vite.config.ts
@@ -1,6 +1,6 @@
 import type { IncomingMessage, ServerResponse } from 'node:http';
-import { defineConfig, type Plugin } from 'vite';
 import react from '@vitejs/plugin-react';
+import { defineConfig, type Plugin } from 'vite';
 
 /**
  * Vite plugin to set Cross-Origin Isolation headers on all responses.
@@ -23,6 +23,14 @@ export default defineConfig({
   plugins: [react(), crossOriginIsolation()],
   server: {
     port: 5174,
+  },
+  preview: {
+    port: 4174,
+    headers: {
+      'Cross-Origin-Opener-Policy': 'same-origin',
+      'Cross-Origin-Embedder-Policy': 'require-corp',
+      'Cross-Origin-Resource-Policy': 'same-origin',
+    },
   },
   build: {
     // Browser Fiber WASM artifacts are intentionally large in this demo app.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -134,18 +134,9 @@ importers:
 
   examples/react-fiber-node-button-lab:
     dependencies:
-      '@ckb-ccc/connector-react':
-        specifier: ^1.0.34
-        version: 1.0.34(@types/react@19.2.14)(react@19.2.4)(typescript@5.9.3)
-      '@ckb-ccc/core':
-        specifier: ^1.12.5
-        version: 1.12.5(typescript@5.9.3)
       '@fiber-pay/react':
         specifier: workspace:*
         version: link:../../packages/react
-      '@fiber-pay/sdk':
-        specifier: workspace:*
-        version: link:../../packages/sdk
       '@nervosnetwork/fiber-js':
         specifier: 'catalog:'
         version: 0.9.0-rc4
@@ -375,9 +366,6 @@ importers:
 
 packages:
 
-  '@adraffy/ens-normalize@1.10.1':
-    resolution: {integrity: sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==}
-
   '@asamuzakjp/css-color@3.2.0':
     resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
 
@@ -600,56 +588,6 @@ packages:
 
   '@changesets/write@0.4.0':
     resolution: {integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==}
-
-  '@ckb-ccc/ccc@1.1.25':
-    resolution: {integrity: sha512-WcaW3yP7q8FzvicekP8y3tikSOy/NMfYdmViQev5v0zLrBfAygH/L6ZxsWHu1XFMgxlAzXm6m0Av0lqVwbNE6Q==}
-
-  '@ckb-ccc/connector-react@1.0.34':
-    resolution: {integrity: sha512-njYFGmqdYvHaX9WwozF5CBGEFuQN3OaSW4rF72uIZpJ34+1dkIptJ764EQcRO9h7vbEu+AXHATADESQKb3+sSw==}
-    peerDependencies:
-      react: '>=16'
-
-  '@ckb-ccc/connector@1.0.33':
-    resolution: {integrity: sha512-B8BQ9LcW1fBAIsW32GhJdm7MY3+Rd/rQWCLiBqTML9enOHGUU/nbgt8oE7AO3g7seTEAoddCx8HyChMNW1OF/w==}
-
-  '@ckb-ccc/core@1.12.5':
-    resolution: {integrity: sha512-iJxv/R9O2xrcyOpZZbfxMlokl6rI9o7iz+4wdB4L0kqW8nEuXgsTqJxJgpM2uECBUlOfRZb7ljpW/7i6CBs4eQ==}
-
-  '@ckb-ccc/eip6963@1.0.32':
-    resolution: {integrity: sha512-vOpZrL69Z2WVcuXgSpcc/4aAJp0K8KklrkgQmUxMI0UtWkUWgdF40Uv/MsfJiR87vXArkeP6UYtO30dmdq31uQ==}
-
-  '@ckb-ccc/joy-id@1.0.32':
-    resolution: {integrity: sha512-7yBU7qnQVCeR8jRZLpxtUqRRcBHw8FwEiAwwdpeYWN50BRZjBtSck+N+rC2qkI+XeKxtluVjpLpObzWJ2XhKbA==}
-
-  '@ckb-ccc/nip07@1.0.32':
-    resolution: {integrity: sha512-D+CUra4FfOXu98pLyRsBcgjAE1LC1BBj2yBDDECcsb+oCALX2I8tWFDZGOTQ795WFyP8f4OU5D2hswnF82kANw==}
-
-  '@ckb-ccc/okx@1.0.32':
-    resolution: {integrity: sha512-iRX1hYQ8biHAZtw5zfSWGhYYcBoTxqDnvi01Feosb/acMnT3kfnHnZiIvsJ7sO+oBCk1zQm9Jtlxl00VuTiotg==}
-
-  '@ckb-ccc/rei@1.0.32':
-    resolution: {integrity: sha512-ZZDTsTewaYtFUS5dBy+Sq4lTd81RTq6JgLH/yzVgY39r/aNzjZujOKmz7KHqAznwdmMFMWqzz3S7BGkPT6clcg==}
-
-  '@ckb-ccc/shell@1.1.25':
-    resolution: {integrity: sha512-Wf3l0gifasRzB9HJjtPt0kIUmWTqMx+cbNQjw/cGaTUxcEJ6JzEebXDZ/2+a+Xr/5cFKMN8A1PzlLNM2j+we+w==}
-
-  '@ckb-ccc/spore@1.5.17':
-    resolution: {integrity: sha512-VaZG2DoyBytHMkN6eNiD6xBVhzgUxcV5lL8KMGyNLcvzcPAVccXzLA62LIDXWPCCKdTAZu70ydn11jTOwFuKqA==}
-
-  '@ckb-ccc/ssri@0.2.22':
-    resolution: {integrity: sha512-E0+OWY14ZhteSI6R2ilCoSFiclq3B5x7svrzhKSi4ePa5Zl3nk4Ioc7BXqciFAUzuFEce2M6eCJu5T9aTHMFLw==}
-
-  '@ckb-ccc/udt@0.1.24':
-    resolution: {integrity: sha512-XeyfB5gD6XdFVV8GL8IeS2S8NbEhom+Jhkae0nq4K3CyRbh9+4OgLaI+/0/7+BoxxOawHQPxI6MAj4h2P02MBg==}
-
-  '@ckb-ccc/uni-sat@1.0.32':
-    resolution: {integrity: sha512-vcxbwr3hwBGE+Aa8IfCr5SCff2x5XDmSwaxxh/SuC21E6kt0prx6RPs8fAdkIAMG1EP5DpWoSvk3P43Pz0PnWw==}
-
-  '@ckb-ccc/utxo-global@1.0.32':
-    resolution: {integrity: sha512-GlkcmSG60IHh2NyrQxKkMc/NDv4SH7/zIz9YW+BdQklctJJ+aZSM7Menf9cKhriddO38nKUF/V5nmVjUB4FBoA==}
-
-  '@ckb-ccc/xverse@1.0.32':
-    resolution: {integrity: sha512-B8L/6y8dq5U5y+TDaV2n0LWXuJViiMJrUkIvQvodA8LcVFuXT/nOtKKNRHxUJ5tiz82eTYq3NBR9vhsBiohAQQ==}
 
   '@csstools/color-helpers@5.1.0':
     resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
@@ -1054,12 +992,6 @@ packages:
       '@types/node':
         optional: true
 
-  '@joyid/ckb@1.1.4':
-    resolution: {integrity: sha512-8WqcfFd/kfttuaIf2/XsRcmQkEwYLUnZc9UZRcGSVX6GkwzpOLVY5S6Hq+fDXY82lQo9upJGjjudrtcPKYPx3g==}
-
-  '@joyid/common@0.2.2':
-    resolution: {integrity: sha512-Sh9cBlbL+WgcKJ7jngELg5oY0qAO1trHm4iq1Ao0drWwi4biF8p3cb5mAEoO36UxXOy3CYSDbECWLGIP9lWNgg==}
-
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -1076,52 +1008,14 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@lit-labs/ssr-dom-shim@1.6.0':
-    resolution: {integrity: sha512-VHb0ALPMTlgKjM6yIxxoQNnpKyUKLD04VzeQdsiXkMqkvYlAHxq9glGLmgbb889/1GsohSOAjvQYoiBppXFqrQ==}
-
-  '@lit/react@1.0.8':
-    resolution: {integrity: sha512-p2+YcF+JE67SRX3mMlJ1TKCSTsgyOVdAwd/nxp3NuV1+Cb6MWALbN6nT7Ld4tpmYofcE5kcaSY1YBB9erY+6fw==}
-    peerDependencies:
-      '@types/react': 17 || 18 || 19
-
-  '@lit/reactive-element@2.1.2':
-    resolution: {integrity: sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==}
-
   '@manypkg/find-root@1.1.0':
     resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
 
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
 
-  '@nervosnetwork/ckb-sdk-utils@0.109.5':
-    resolution: {integrity: sha512-Tx642hcJWbN8W3KzCIhIo49yzJ8LMqWopQCSBDKuRmwHesO/bvJqYojCVwfrOyROtFOPhgjyiGm5RXBuxm0KpQ==}
-
-  '@nervosnetwork/ckb-types@0.109.5':
-    resolution: {integrity: sha512-5jQNjFw76YCd+Ppl+0RvBWzxwvWaKfWC5wjVFFdNAieX7xksCHfZFIeow8je7AF8uVypwe56WlLBlblxw9NBBQ==}
-
-  '@nervosnetwork/fiber-js@0.8.1':
-    resolution: {integrity: sha512-T37qCsvrcVGeX1fjv6FrgwhfwiWPqvVmJfil5tirdYevvoZCcfigqrknMdl1lDar4l1HypDswD4szbD0b3Nz/w==}
-
   '@nervosnetwork/fiber-js@0.9.0-rc4':
     resolution: {integrity: sha512-JSM5Qt59UN0likBP+ZMaWlJ5WcATtUriplG9hp/0tLHbm41lF71i5R/cJMbiIgCozN9BMgi9+ReVJH/0YrD85Q==}
-
-  '@noble/ciphers@0.5.3':
-    resolution: {integrity: sha512-B0+6IIHiqEs3BPMT0hcRmHvEj2QHOLu+uwt+tqDDeVd0oyVzh7BPrDcPjRnV1PV/5LaknXJJQvOuRGR0zQJz+w==}
-
-  '@noble/curves@1.2.0':
-    resolution: {integrity: sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==}
-
-  '@noble/curves@1.9.7':
-    resolution: {integrity: sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==}
-    engines: {node: ^14.21.3 || >=16}
-
-  '@noble/hashes@1.3.2':
-    resolution: {integrity: sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==}
-    engines: {node: '>= 16'}
-
-  '@noble/hashes@1.8.0':
-    resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
-    engines: {node: ^14.21.3 || >=16}
 
   '@noble/hashes@2.0.1':
     resolution: {integrity: sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==}
@@ -1359,9 +1253,6 @@ packages:
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
 
-  '@types/node@22.7.5':
-    resolution: {integrity: sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==}
-
   '@types/node@24.12.0':
     resolution: {integrity: sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==}
 
@@ -1393,9 +1284,6 @@ packages:
 
   '@types/serve-static@2.2.0':
     resolution: {integrity: sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==}
-
-  '@types/trusted-types@2.0.7':
-    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
   '@typescript-eslint/eslint-plugin@8.58.0':
     resolution: {integrity: sha512-RLkVSiNuUP1C2ROIWfqX+YcUfLaSnxGE/8M+Y57lopVwg9VTYYfhuz15Yf1IzCKgZj6/rIbYTmJCUSqr76r0Wg==}
@@ -1491,15 +1379,6 @@ packages:
   '@vitest/utils@4.1.0':
     resolution: {integrity: sha512-XfPXT6a8TZY3dcGY8EdwsBulFCIw+BeeX0RZn2x/BtiY/75YGh8FeWGG8QISN/WhaqSrE2OrlDgtF8q5uhOTmw==}
 
-  abitype@0.8.7:
-    resolution: {integrity: sha512-wQ7hV8Yg/yKmGyFpqrNZufCxbszDe5es4AZGYPBitocfSqXtjrTG9JMWFcc4N30ukl2ve48aBTwt7NJxVQdU3w==}
-    peerDependencies:
-      typescript: '>=5.0.4'
-      zod: ^3 >=3.19.1
-    peerDependenciesMeta:
-      zod:
-        optional: true
-
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
@@ -1513,13 +1392,6 @@ packages:
     resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
     engines: {node: '>=0.4.0'}
     hasBin: true
-
-  aes-js@4.0.0-beta.5:
-    resolution: {integrity: sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==}
-
-  agent-base@6.0.2:
-    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
-    engines: {node: '>= 6.0.0'}
 
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
@@ -1579,21 +1451,12 @@ packages:
   async-mutex@0.5.0:
     resolution: {integrity: sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==}
 
-  asynckit@0.4.0:
-    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
-
-  axios@1.16.1:
-    resolution: {integrity: sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==}
-
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
-
-  base-x@5.0.1:
-    resolution: {integrity: sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg==}
 
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
@@ -1602,9 +1465,6 @@ packages:
     resolution: {integrity: sha512-BL2sTuHOdy0YT1lYieUxTw/QMtPBC3pmlJC6xk8BBYVv6vcw3SGdKemQ+Xsx9ik2F/lYDO9tqsFQH1r9PFuHKw==}
     engines: {node: '>=6.0.0'}
     hasBin: true
-
-  bech32@2.0.0:
-    resolution: {integrity: sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg==}
 
   better-path-resolve@1.0.0:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
@@ -1619,9 +1479,6 @@ packages:
 
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
-
-  bn.js@4.12.3:
-    resolution: {integrity: sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==}
 
   body-parser@2.2.2:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
@@ -1638,25 +1495,13 @@ packages:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
-  brorand@1.1.0:
-    resolution: {integrity: sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==}
-
   browserslist@4.28.2:
     resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
-  bs58@6.0.0:
-    resolution: {integrity: sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw==}
-
-  bs58check@4.0.0:
-    resolution: {integrity: sha512-FsGDOnFg9aVI9erdriULkd/JjEWONV/lQE5aYziB5PoBsXRind56lh8doIZIc9X4HoxT5x4bLjMWN1/NB8Zp5g==}
-
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
-
-  buffer@6.0.3:
-    resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
 
   bundle-require@5.1.0:
     resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
@@ -1734,10 +1579,6 @@ packages:
   colorette@2.0.20:
     resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
 
-  combined-stream@1.0.8:
-    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
-    engines: {node: '>= 0.8'}
-
   commander@13.1.0:
     resolution: {integrity: sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==}
     engines: {node: '>=18'}
@@ -1783,9 +1624,6 @@ packages:
     resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
     engines: {node: '>= 0.10'}
 
-  cross-fetch@4.0.0:
-    resolution: {integrity: sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==}
-
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -1828,10 +1666,6 @@ packages:
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
-  delayed-stream@1.0.0:
-    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
-    engines: {node: '>=0.4.0'}
-
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
@@ -1867,9 +1701,6 @@ packages:
 
   electron-to-chromium@1.5.331:
     resolution: {integrity: sha512-IbxXrsTlD3hRodkLnbxAPP4OuJYdWCeM3IOdT+CpcMoIwIoDfCmRpEtSPfwBXxVkg9xmBeY7Lz2Eo2TDn/HC3Q==}
-
-  elliptic@6.6.1:
-    resolution: {integrity: sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==}
 
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
@@ -1909,10 +1740,6 @@ packages:
 
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
-    engines: {node: '>= 0.4'}
-
-  es-set-tostringtag@2.1.0:
-    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
 
   esbuild@0.25.12:
@@ -2005,10 +1832,6 @@ packages:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
 
-  ethers@6.16.0:
-    resolution: {integrity: sha512-U1wulmetNymijEhpSEQ7Ct/P/Jw9/e7R1j5XIbPRydgV2DjLVMsULDlNksq3RQnFgKoLlZf88ijYtWEXcPa07A==}
-    engines: {node: '>=14.0.0'}
-
   eventemitter3@4.0.7:
     resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
 
@@ -2096,10 +1919,6 @@ packages:
     peerDependenciesMeta:
       debug:
         optional: true
-
-  form-data@4.0.6:
-    resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
-    engines: {node: '>= 6'}
 
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
@@ -2194,19 +2013,8 @@ packages:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
     engines: {node: '>= 0.4'}
 
-  has-tostringtag@1.0.2:
-    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
-    engines: {node: '>= 0.4'}
-
-  hash.js@1.1.7:
-    resolution: {integrity: sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==}
-
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
-    engines: {node: '>= 0.4'}
-
-  hasown@2.0.4:
-    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
   hermes-estree@0.25.1:
@@ -2214,9 +2022,6 @@ packages:
 
   hermes-parser@0.25.1:
     resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
-
-  hmac-drbg@1.0.1:
-    resolution: {integrity: sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==}
 
   html-encoding-sniffer@4.0.0:
     resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
@@ -2237,10 +2042,6 @@ packages:
   http-proxy@1.18.1:
     resolution: {integrity: sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==}
     engines: {node: '>=8.0.0'}
-
-  https-proxy-agent@5.0.1:
-    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
-    engines: {node: '>= 6'}
 
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
@@ -2333,11 +2134,6 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
-  isomorphic-ws@5.0.0:
-    resolution: {integrity: sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==}
-    peerDependencies:
-      ws: '>=8.21.0'
-
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
     engines: {node: '>=10'}
@@ -2352,9 +2148,6 @@ packages:
   js-yaml@4.3.0:
     resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
     hasBin: true
-
-  jsbi@3.1.3:
-    resolution: {integrity: sha512-nBJqA0C6Qns+ZxurbEoIR56wyjiUszpNy70FHvxO5ervMoCbZVE3z3kxr5nKGhlxr/9MhKTSUBs7cAwwuf3g9w==}
 
   jsdom@26.1.0:
     resolution: {integrity: sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==}
@@ -2409,15 +2202,6 @@ packages:
   listr2@9.0.5:
     resolution: {integrity: sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==}
     engines: {node: '>=20.0.0'}
-
-  lit-element@4.2.2:
-    resolution: {integrity: sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==}
-
-  lit-html@3.3.3:
-    resolution: {integrity: sha512-el8M6jK2o3RXBnrSHX3ZKrsN8zEV63pSExTO1wYJz7QndGYZ8353e2a5PPX+qHe2aGayfnchQmkAojaWAREOIA==}
-
-  lit@3.3.3:
-    resolution: {integrity: sha512-fycuvZg/hkpozL00lm1pEJH5nN/lr9ZXd6mJI2HSN4+Bzc+LDNdEApJ6HFbPkdFNHLvOplIIuJvxkS4XUxqirw==}
 
   load-tsconfig@0.2.5:
     resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
@@ -2477,16 +2261,8 @@ packages:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
 
-  mime-db@1.52.0:
-    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
-    engines: {node: '>= 0.6'}
-
   mime-db@1.54.0:
     resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
-    engines: {node: '>= 0.6'}
-
-  mime-types@2.1.35:
-    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
 
   mime-types@3.0.2:
@@ -2500,12 +2276,6 @@ packages:
   mimic-response@3.1.0:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
     engines: {node: '>=10'}
-
-  minimalistic-assert@1.0.1:
-    resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
-
-  minimalistic-crypto-utils@1.0.1:
-    resolution: {integrity: sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==}
 
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
@@ -2555,15 +2325,6 @@ packages:
   node-abi@3.87.0:
     resolution: {integrity: sha512-+CGM1L1CgmtheLcBuleyYOn7NWPVu0s0EJH2C4puxgEZb9h8QpR9G2dBfZJOAUhi7VQxuBPMd0hiISWcTyiYyQ==}
     engines: {node: '>=10'}
-
-  node-fetch@2.7.0:
-    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
-    engines: {node: 4.x || >=6.0.0}
-    peerDependencies:
-      encoding: ^0.1.0
-    peerDependenciesMeta:
-      encoding:
-        optional: true
 
   node-releases@2.0.36:
     resolution: {integrity: sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==}
@@ -2746,10 +2507,6 @@ packages:
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
-
-  proxy-from-env@2.1.0:
-    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
-    engines: {node: '>=10'}
 
   pump@3.0.3:
     resolution: {integrity: sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==}
@@ -3086,9 +2843,6 @@ packages:
     resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
     engines: {node: '>=16'}
 
-  tr46@0.0.3:
-    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
-
   tr46@5.1.1:
     resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
     engines: {node: '>=18'}
@@ -3105,12 +2859,6 @@ packages:
 
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
-
-  tslib@2.3.1:
-    resolution: {integrity: sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==}
-
-  tslib@2.7.0:
-    resolution: {integrity: sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -3152,10 +2900,6 @@ packages:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
 
-  type-fest@4.6.0:
-    resolution: {integrity: sha512-rLjWJzQFOq4xw7MgJrCZ6T1jIOvvYElXT12r+y0CC6u67hegDHaxcPqb2fZHOGlqxugGQPNB1EnTezjBetkwkw==}
-    engines: {node: '>=16'}
-
   type-is@2.0.1:
     resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
     engines: {node: '>= 0.6'}
@@ -3174,12 +2918,6 @@ packages:
 
   ufo@1.6.3:
     resolution: {integrity: sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==}
-
-  uncrypto@0.1.3:
-    resolution: {integrity: sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==}
-
-  undici-types@6.19.8:
-    resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
 
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
@@ -3206,14 +2944,6 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
-
-  valibot@1.4.0:
-    resolution: {integrity: sha512-iC/x7fVcSyOwlm/VSt7RlHnzNGLGvR9GnxdifUeWoCJo0q4ZZvrVkIHC6faTlkxG47I2Y4UrFquPuVHCrOnrLg==}
-    peerDependencies:
-      typescript: '>=5'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
 
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
@@ -3298,9 +3028,6 @@ packages:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
     engines: {node: '>=18'}
 
-  webidl-conversions@3.0.1:
-    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
-
   webidl-conversions@7.0.0:
     resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
     engines: {node: '>=12'}
@@ -3317,9 +3044,6 @@ packages:
   whatwg-url@14.2.0:
     resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
     engines: {node: '>=18'}
-
-  whatwg-url@5.0.0:
-    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
   which-module@2.0.1:
     resolution: {integrity: sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==}
@@ -3401,8 +3125,6 @@ packages:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
 snapshots:
-
-  '@adraffy/ens-normalize@1.10.1': {}
 
   '@asamuzakjp/css-color@3.2.0':
     dependencies:
@@ -3720,207 +3442,6 @@ snapshots:
       human-id: 4.1.3
       prettier: 2.8.8
 
-  '@ckb-ccc/ccc@1.1.25(typescript@5.9.3)':
-    dependencies:
-      '@ckb-ccc/eip6963': 1.0.32(typescript@5.9.3)
-      '@ckb-ccc/joy-id': 1.0.32(typescript@5.9.3)
-      '@ckb-ccc/nip07': 1.0.32(typescript@5.9.3)
-      '@ckb-ccc/okx': 1.0.32(typescript@5.9.3)
-      '@ckb-ccc/rei': 1.0.32(typescript@5.9.3)
-      '@ckb-ccc/shell': 1.1.25(typescript@5.9.3)
-      '@ckb-ccc/uni-sat': 1.0.32(typescript@5.9.3)
-      '@ckb-ccc/utxo-global': 1.0.32(typescript@5.9.3)
-      '@ckb-ccc/xverse': 1.0.32(typescript@5.9.3)
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - encoding
-      - supports-color
-      - typescript
-      - utf-8-validate
-      - zod
-
-  '@ckb-ccc/connector-react@1.0.34(@types/react@19.2.14)(react@19.2.4)(typescript@5.9.3)':
-    dependencies:
-      '@ckb-ccc/connector': 1.0.33(typescript@5.9.3)
-      '@lit/react': 1.0.8(@types/react@19.2.14)
-      react: 19.2.4
-    transitivePeerDependencies:
-      - '@types/react'
-      - bufferutil
-      - debug
-      - encoding
-      - supports-color
-      - typescript
-      - utf-8-validate
-      - zod
-
-  '@ckb-ccc/connector@1.0.33(typescript@5.9.3)':
-    dependencies:
-      '@ckb-ccc/ccc': 1.1.25(typescript@5.9.3)
-      lit: 3.3.3
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - encoding
-      - supports-color
-      - typescript
-      - utf-8-validate
-      - zod
-
-  '@ckb-ccc/core@1.12.5(typescript@5.9.3)':
-    dependencies:
-      '@joyid/ckb': 1.1.4(typescript@5.9.3)
-      '@noble/ciphers': 0.5.3
-      '@noble/curves': 1.9.7
-      '@noble/hashes': 1.8.0
-      bech32: 2.0.0
-      bs58check: 4.0.0
-      buffer: 6.0.3
-      ethers: 6.16.0
-      isomorphic-ws: 5.0.0(ws@8.21.0)
-      ws: 8.21.0
-    transitivePeerDependencies:
-      - bufferutil
-      - encoding
-      - typescript
-      - utf-8-validate
-      - zod
-
-  '@ckb-ccc/eip6963@1.0.32(typescript@5.9.3)':
-    dependencies:
-      '@ckb-ccc/core': 1.12.5(typescript@5.9.3)
-    transitivePeerDependencies:
-      - bufferutil
-      - encoding
-      - typescript
-      - utf-8-validate
-      - zod
-
-  '@ckb-ccc/joy-id@1.0.32(typescript@5.9.3)':
-    dependencies:
-      '@ckb-ccc/core': 1.12.5(typescript@5.9.3)
-      '@joyid/ckb': 1.1.4(typescript@5.9.3)
-      '@joyid/common': 0.2.2(typescript@5.9.3)
-    transitivePeerDependencies:
-      - bufferutil
-      - encoding
-      - typescript
-      - utf-8-validate
-      - zod
-
-  '@ckb-ccc/nip07@1.0.32(typescript@5.9.3)':
-    dependencies:
-      '@ckb-ccc/core': 1.12.5(typescript@5.9.3)
-    transitivePeerDependencies:
-      - bufferutil
-      - encoding
-      - typescript
-      - utf-8-validate
-      - zod
-
-  '@ckb-ccc/okx@1.0.32(typescript@5.9.3)':
-    dependencies:
-      '@ckb-ccc/core': 1.12.5(typescript@5.9.3)
-      '@ckb-ccc/nip07': 1.0.32(typescript@5.9.3)
-      '@ckb-ccc/uni-sat': 1.0.32(typescript@5.9.3)
-    transitivePeerDependencies:
-      - bufferutil
-      - encoding
-      - typescript
-      - utf-8-validate
-      - zod
-
-  '@ckb-ccc/rei@1.0.32(typescript@5.9.3)':
-    dependencies:
-      '@ckb-ccc/core': 1.12.5(typescript@5.9.3)
-    transitivePeerDependencies:
-      - bufferutil
-      - encoding
-      - typescript
-      - utf-8-validate
-      - zod
-
-  '@ckb-ccc/shell@1.1.25(typescript@5.9.3)':
-    dependencies:
-      '@ckb-ccc/core': 1.12.5(typescript@5.9.3)
-      '@ckb-ccc/spore': 1.5.17(typescript@5.9.3)
-      '@ckb-ccc/ssri': 0.2.22(typescript@5.9.3)
-      '@ckb-ccc/udt': 0.1.24(typescript@5.9.3)
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - encoding
-      - supports-color
-      - typescript
-      - utf-8-validate
-      - zod
-
-  '@ckb-ccc/spore@1.5.17(typescript@5.9.3)':
-    dependencies:
-      '@ckb-ccc/core': 1.12.5(typescript@5.9.3)
-      axios: 1.16.1
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - encoding
-      - supports-color
-      - typescript
-      - utf-8-validate
-      - zod
-
-  '@ckb-ccc/ssri@0.2.22(typescript@5.9.3)':
-    dependencies:
-      '@ckb-ccc/core': 1.12.5(typescript@5.9.3)
-    transitivePeerDependencies:
-      - bufferutil
-      - encoding
-      - typescript
-      - utf-8-validate
-      - zod
-
-  '@ckb-ccc/udt@0.1.24(typescript@5.9.3)':
-    dependencies:
-      '@ckb-ccc/core': 1.12.5(typescript@5.9.3)
-      '@ckb-ccc/ssri': 0.2.22(typescript@5.9.3)
-    transitivePeerDependencies:
-      - bufferutil
-      - encoding
-      - typescript
-      - utf-8-validate
-      - zod
-
-  '@ckb-ccc/uni-sat@1.0.32(typescript@5.9.3)':
-    dependencies:
-      '@ckb-ccc/core': 1.12.5(typescript@5.9.3)
-    transitivePeerDependencies:
-      - bufferutil
-      - encoding
-      - typescript
-      - utf-8-validate
-      - zod
-
-  '@ckb-ccc/utxo-global@1.0.32(typescript@5.9.3)':
-    dependencies:
-      '@ckb-ccc/core': 1.12.5(typescript@5.9.3)
-    transitivePeerDependencies:
-      - bufferutil
-      - encoding
-      - typescript
-      - utf-8-validate
-      - zod
-
-  '@ckb-ccc/xverse@1.0.32(typescript@5.9.3)':
-    dependencies:
-      '@ckb-ccc/core': 1.12.5(typescript@5.9.3)
-      valibot: 1.4.0(typescript@5.9.3)
-    transitivePeerDependencies:
-      - bufferutil
-      - encoding
-      - typescript
-      - utf-8-validate
-      - zod
-
   '@csstools/color-helpers@5.1.0': {}
 
   '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
@@ -4161,25 +3682,6 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.1.0
 
-  '@joyid/ckb@1.1.4(typescript@5.9.3)':
-    dependencies:
-      '@joyid/common': 0.2.2(typescript@5.9.3)
-      '@nervosnetwork/ckb-sdk-utils': 0.109.5
-      cross-fetch: 4.0.0
-      uncrypto: 0.1.3
-    transitivePeerDependencies:
-      - encoding
-      - typescript
-      - zod
-
-  '@joyid/common@0.2.2(typescript@5.9.3)':
-    dependencies:
-      abitype: 0.8.7(typescript@5.9.3)
-      type-fest: 4.6.0
-    transitivePeerDependencies:
-      - typescript
-      - zod
-
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -4199,16 +3701,6 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@lit-labs/ssr-dom-shim@1.6.0': {}
-
-  '@lit/react@1.0.8(@types/react@19.2.14)':
-    dependencies:
-      '@types/react': 19.2.14
-
-  '@lit/reactive-element@2.1.2':
-    dependencies:
-      '@lit-labs/ssr-dom-shim': 1.6.0
-
   '@manypkg/find-root@1.1.0':
     dependencies:
       '@babel/runtime': 7.28.6
@@ -4225,39 +3717,10 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
-  '@nervosnetwork/ckb-sdk-utils@0.109.5':
-    dependencies:
-      '@nervosnetwork/ckb-types': 0.109.5
-      bech32: 2.0.0
-      elliptic: 6.6.1
-      jsbi: 3.1.3
-      tslib: 2.3.1
-
-  '@nervosnetwork/ckb-types@0.109.5': {}
-
-  '@nervosnetwork/fiber-js@0.8.1':
-    dependencies:
-      async-mutex: 0.5.0
-      stream-browserify: 3.0.0
-
   '@nervosnetwork/fiber-js@0.9.0-rc4':
     dependencies:
       async-mutex: 0.5.0
       stream-browserify: 3.0.0
-
-  '@noble/ciphers@0.5.3': {}
-
-  '@noble/curves@1.2.0':
-    dependencies:
-      '@noble/hashes': 1.3.2
-
-  '@noble/curves@1.9.7':
-    dependencies:
-      '@noble/hashes': 1.8.0
-
-  '@noble/hashes@1.3.2': {}
-
-  '@noble/hashes@1.8.0': {}
 
   '@noble/hashes@2.0.1': {}
 
@@ -4447,10 +3910,6 @@ snapshots:
 
   '@types/node@12.20.55': {}
 
-  '@types/node@22.7.5':
-    dependencies:
-      undici-types: 6.19.8
-
   '@types/node@24.12.0':
     dependencies:
       undici-types: 7.16.0
@@ -4488,8 +3947,6 @@ snapshots:
     dependencies:
       '@types/http-errors': 2.0.5
       '@types/node': 25.1.0
-
-  '@types/trusted-types@2.0.7': {}
 
   '@typescript-eslint/eslint-plugin@8.58.0(@typescript-eslint/parser@8.58.0(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3)':
     dependencies:
@@ -4647,10 +4104,6 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
-  abitype@0.8.7(typescript@5.9.3):
-    dependencies:
-      typescript: 5.9.3
-
   accepts@2.0.0:
     dependencies:
       mime-types: 3.0.2
@@ -4661,14 +4114,6 @@ snapshots:
       acorn: 8.15.0
 
   acorn@8.15.0: {}
-
-  aes-js@4.0.0-beta.5: {}
-
-  agent-base@6.0.2:
-    dependencies:
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
 
   agent-base@7.1.4: {}
 
@@ -4717,29 +4162,13 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  asynckit@0.4.0: {}
-
-  axios@1.16.1:
-    dependencies:
-      follow-redirects: 1.16.0(debug@4.4.3)
-      form-data: 4.0.6
-      https-proxy-agent: 5.0.1
-      proxy-from-env: 2.1.0
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-
   balanced-match@1.0.2: {}
 
   balanced-match@4.0.4: {}
 
-  base-x@5.0.1: {}
-
   base64-js@1.5.1: {}
 
   baseline-browser-mapping@2.10.13: {}
-
-  bech32@2.0.0: {}
 
   better-path-resolve@1.0.0:
     dependencies:
@@ -4759,8 +4188,6 @@ snapshots:
       buffer: 5.7.1
       inherits: 2.0.4
       readable-stream: 3.6.2
-
-  bn.js@4.12.3: {}
 
   body-parser@2.2.2:
     dependencies:
@@ -4789,8 +4216,6 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
-  brorand@1.1.0: {}
-
   browserslist@4.28.2:
     dependencies:
       baseline-browser-mapping: 2.10.13
@@ -4799,21 +4224,7 @@ snapshots:
       node-releases: 2.0.36
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
 
-  bs58@6.0.0:
-    dependencies:
-      base-x: 5.0.1
-
-  bs58check@4.0.0:
-    dependencies:
-      '@noble/hashes': 1.8.0
-      bs58: 6.0.0
-
   buffer@5.7.1:
-    dependencies:
-      base64-js: 1.5.1
-      ieee754: 1.2.1
-
-  buffer@6.0.3:
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
@@ -4883,10 +4294,6 @@ snapshots:
 
   colorette@2.0.20: {}
 
-  combined-stream@1.0.8:
-    dependencies:
-      delayed-stream: 1.0.0
-
   commander@13.1.0: {}
 
   commander@14.0.3: {}
@@ -4913,12 +4320,6 @@ snapshots:
     dependencies:
       object-assign: 4.1.1
       vary: 1.1.2
-
-  cross-fetch@4.0.0:
-    dependencies:
-      node-fetch: 2.7.0
-    transitivePeerDependencies:
-      - encoding
 
   cross-spawn@7.0.6:
     dependencies:
@@ -4954,8 +4355,6 @@ snapshots:
 
   deep-is@0.1.4: {}
 
-  delayed-stream@1.0.0: {}
-
   depd@2.0.0: {}
 
   dequal@2.0.3: {}
@@ -4981,16 +4380,6 @@ snapshots:
   ee-first@1.1.1: {}
 
   electron-to-chromium@1.5.331: {}
-
-  elliptic@6.6.1:
-    dependencies:
-      bn.js: 4.12.3
-      brorand: 1.1.0
-      hash.js: 1.1.7
-      hmac-drbg: 1.0.1
-      inherits: 2.0.4
-      minimalistic-assert: 1.0.1
-      minimalistic-crypto-utils: 1.0.1
 
   emoji-regex@10.6.0: {}
 
@@ -5020,13 +4409,6 @@ snapshots:
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
-
-  es-set-tostringtag@2.1.0:
-    dependencies:
-      es-errors: 1.3.0
-      get-intrinsic: 1.3.0
-      has-tostringtag: 1.0.2
-      hasown: 2.0.4
 
   esbuild@0.25.12:
     optionalDependencies:
@@ -5183,19 +4565,6 @@ snapshots:
 
   etag@1.8.1: {}
 
-  ethers@6.16.0:
-    dependencies:
-      '@adraffy/ens-normalize': 1.10.1
-      '@noble/curves': 1.2.0
-      '@noble/hashes': 1.3.2
-      '@types/node': 22.7.5
-      aes-js: 4.0.0-beta.5
-      tslib: 2.7.0
-      ws: 8.21.0
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-
   eventemitter3@4.0.7: {}
 
   eventemitter3@5.0.4: {}
@@ -5309,14 +4678,6 @@ snapshots:
     optionalDependencies:
       debug: 4.4.3
 
-  form-data@4.0.6:
-    dependencies:
-      asynckit: 0.4.0
-      combined-stream: 1.0.8
-      es-set-tostringtag: 2.1.0
-      hasown: 2.0.4
-      mime-types: 2.1.35
-
   forwarded@0.2.0: {}
 
   fresh@2.0.0: {}
@@ -5402,20 +4763,7 @@ snapshots:
 
   has-symbols@1.1.0: {}
 
-  has-tostringtag@1.0.2:
-    dependencies:
-      has-symbols: 1.1.0
-
-  hash.js@1.1.7:
-    dependencies:
-      inherits: 2.0.4
-      minimalistic-assert: 1.0.1
-
   hasown@2.0.2:
-    dependencies:
-      function-bind: 1.1.2
-
-  hasown@2.0.4:
     dependencies:
       function-bind: 1.1.2
 
@@ -5424,12 +4772,6 @@ snapshots:
   hermes-parser@0.25.1:
     dependencies:
       hermes-estree: 0.25.1
-
-  hmac-drbg@1.0.1:
-    dependencies:
-      hash.js: 1.1.7
-      minimalistic-assert: 1.0.1
-      minimalistic-crypto-utils: 1.0.1
 
   html-encoding-sniffer@4.0.0:
     dependencies:
@@ -5468,13 +4810,6 @@ snapshots:
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug
-
-  https-proxy-agent@5.0.1:
-    dependencies:
-      agent-base: 6.0.2
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
 
   https-proxy-agent@7.0.6:
     dependencies:
@@ -5542,10 +4877,6 @@ snapshots:
 
   isexe@2.0.0: {}
 
-  isomorphic-ws@5.0.0(ws@8.21.0):
-    dependencies:
-      ws: 8.21.0
-
   joycon@3.1.1: {}
 
   js-tokens@4.0.0: {}
@@ -5558,8 +4889,6 @@ snapshots:
   js-yaml@4.3.0:
     dependencies:
       argparse: 2.0.1
-
-  jsbi@3.1.3: {}
 
   jsdom@26.1.0:
     dependencies:
@@ -5634,22 +4963,6 @@ snapshots:
       rfdc: 1.4.1
       wrap-ansi: 9.0.2
 
-  lit-element@4.2.2:
-    dependencies:
-      '@lit-labs/ssr-dom-shim': 1.6.0
-      '@lit/reactive-element': 2.1.2
-      lit-html: 3.3.3
-
-  lit-html@3.3.3:
-    dependencies:
-      '@types/trusted-types': 2.0.7
-
-  lit@3.3.3:
-    dependencies:
-      '@lit/reactive-element': 2.1.2
-      lit-element: 4.2.2
-      lit-html: 3.3.3
-
   load-tsconfig@0.2.5: {}
 
   locate-path@5.0.0:
@@ -5703,13 +5016,7 @@ snapshots:
       braces: 3.0.3
       picomatch: 2.3.2
 
-  mime-db@1.52.0: {}
-
   mime-db@1.54.0: {}
-
-  mime-types@2.1.35:
-    dependencies:
-      mime-db: 1.52.0
 
   mime-types@3.0.2:
     dependencies:
@@ -5718,10 +5025,6 @@ snapshots:
   mimic-function@5.0.1: {}
 
   mimic-response@3.1.0: {}
-
-  minimalistic-assert@1.0.1: {}
-
-  minimalistic-crypto-utils@1.0.1: {}
 
   minimatch@10.2.5:
     dependencies:
@@ -5765,10 +5068,6 @@ snapshots:
   node-abi@3.87.0:
     dependencies:
       semver: 7.7.4
-
-  node-fetch@2.7.0:
-    dependencies:
-      whatwg-url: 5.0.0
 
   node-releases@2.0.36: {}
 
@@ -5922,8 +5221,6 @@ snapshots:
     dependencies:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
-
-  proxy-from-env@2.1.0: {}
 
   pump@3.0.3:
     dependencies:
@@ -6293,8 +5590,6 @@ snapshots:
     dependencies:
       tldts: 6.1.86
 
-  tr46@0.0.3: {}
-
   tr46@5.1.1:
     dependencies:
       punycode: 2.3.1
@@ -6306,10 +5601,6 @@ snapshots:
       typescript: 5.9.3
 
   ts-interface-checker@0.1.13: {}
-
-  tslib@2.3.1: {}
-
-  tslib@2.7.0: {}
 
   tslib@2.8.1: {}
 
@@ -6360,8 +5651,6 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
 
-  type-fest@4.6.0: {}
-
   type-is@2.0.1:
     dependencies:
       content-type: 1.0.5
@@ -6383,10 +5672,6 @@ snapshots:
 
   ufo@1.6.3: {}
 
-  uncrypto@0.1.3: {}
-
-  undici-types@6.19.8: {}
-
   undici-types@7.16.0: {}
 
   undici-types@8.3.0:
@@ -6407,10 +5692,6 @@ snapshots:
       punycode: 2.3.1
 
   util-deprecate@1.0.2: {}
-
-  valibot@1.4.0(typescript@5.9.3):
-    optionalDependencies:
-      typescript: 5.9.3
 
   vary@1.1.2: {}
 
@@ -6488,8 +5769,6 @@ snapshots:
     dependencies:
       xml-name-validator: 5.0.0
 
-  webidl-conversions@3.0.1: {}
-
   webidl-conversions@7.0.0: {}
 
   whatwg-encoding@3.1.1:
@@ -6502,11 +5781,6 @@ snapshots:
     dependencies:
       tr46: 5.1.1
       webidl-conversions: 7.0.0
-
-  whatwg-url@5.0.0:
-    dependencies:
-      tr46: 0.0.3
-      webidl-conversions: 3.0.1
 
   which-module@2.0.1: {}
 

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "vite",
+  "installCommand": "pnpm install --frozen-lockfile",
+  "buildCommand": "pnpm --filter example-react-fiber-node-button-lab... build",
+  "outputDirectory": "examples/react-fiber-node-button-lab/dist",
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "Cross-Origin-Opener-Policy",
+          "value": "same-origin"
+        },
+        {
+          "key": "Cross-Origin-Embedder-Policy",
+          "value": "require-corp"
+        },
+        {
+          "key": "Cross-Origin-Resource-Policy",
+          "value": "same-origin"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- turn the existing React lab into a focused FiberNodeButton live preview backed by the real CKB testnet
- build the preview from the latest workspace @fiber-pay/react and SDK packages
- add root Vercel configuration, cross-origin isolation headers, and deployment documentation
- remove the external CCC playground dependencies and keep passkey plus password startup paths

## Validation

- pnpm format:check
- pnpm lint
- pnpm build
- pnpm typecheck
- pnpm test
- example-specific Biome, ESLint, and production build checks
- desktop and mobile browser smoke tests
- real testnet node start, component open, asset controls, and disconnect
- production preview COOP, COEP, and CORP header verification

No changeset is included because this is an examples-only chore.