### PR TITLE
chore: upgrade Fiber target to fnn v0.9.0 stable

### DIFF
--- a/.changeset/olive-donkeys-attack.md
+++ b/.changeset/olive-donkeys-attack.md
@@ -1,0 +1,8 @@
+---
+"@fiber-pay/sdk": minor
+"@fiber-pay/react": minor
+"@fiber-pay/node": minor
+"@fiber-pay/cli": minor
+---
+
+Upgrade the Fiber target to fnn v0.9.0 stable. Bumps `@nervosnetwork/fiber-js` to `~0.9.0`, adds the new `Stale` channel state (classified as pending in React components), the optional `payment_preimage` field on `PaymentInfo`, and the Admin-module `backup()` RPC method. New nodes and `fiber-pay node upgrade` now default to fnn v0.9.0.

--- a/.changeset/olive-donkeys-attack.md
+++ b/.changeset/olive-donkeys-attack.md
@@ -5,4 +5,6 @@
 "@fiber-pay/cli": minor
 ---
 
-Upgrade the Fiber target to fnn v0.9.0 stable. Bumps `@nervosnetwork/fiber-js` to `~0.9.0`, adds the new `Stale` channel state (classified as pending in React components), the optional `payment_preimage` field on `PaymentInfo`, and the Admin-module `backup()` RPC method. New nodes and `fiber-pay node upgrade` now default to fnn v0.9.0.
+Upgrade the Fiber target to fnn v0.9.0 stable. Bumps `@nervosnetwork/fiber-js` to `~0.9.0`, adds the new `Stale` channel state (classified as pending in React components), the optional `payment_preimage` field on `PaymentInfo`, and the Admin-module `backup()` RPC method (RPC-client-only; not on the shared `IFiberClient` interface). New nodes and `fiber-pay node upgrade` now default to fnn v0.9.0.
+
+Safety follow-ups for the new surface: the React panel never routes `Stale` channels to `abandon_channel` (they are funded and awaiting the post-restore passive audit), runtime payment alert payloads are field-whitelisted so `payment_preimage` is never emitted to alert backends, and CLI messages render the target version from `DEFAULT_FIBER_VERSION` instead of hardcoded strings.

--- a/.github/workflows/e2e-testnet-dual-node.yml
+++ b/.github/workflows/e2e-testnet-dual-node.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       fiber_binary_version:
-        description: 'Override Fiber binary version (e.g. v0.9.0-rc4). Leave empty to use default.'
+        description: 'Override Fiber binary version (e.g. v0.9.0). Leave empty to use default.'
         required: false
         default: ''
 

--- a/.github/workflows/e2e-wasm-dual-node.yml
+++ b/.github/workflows/e2e-wasm-dual-node.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       fiber_js_version:
-        description: 'Override @nervosnetwork/fiber-js version (e.g. 0.9.0-rc6). Leave empty to use workspace default.'
+        description: 'Override @nervosnetwork/fiber-js version (e.g. 0.9.0). Leave empty to use workspace default.'
         required: false
         default: ''
 

--- a/.github/workflows/wasm-smoke.yml
+++ b/.github/workflows/wasm-smoke.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
     inputs:
       fiber_js_version:
-        description: 'Override @nervosnetwork/fiber-js version (e.g. 0.9.0-rc6). Leave empty to use workspace default.'
+        description: 'Override @nervosnetwork/fiber-js version (e.g. 0.9.0). Leave empty to use workspace default.'
         required: false
         default: ''
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 AI-friendly toolchain for CKB Lightning on Fiber Network.
 
-Fiber target: `v0.9.0-rc7`
+Fiber target: `v0.9.0`
 
 https://retricsu.github.io/fiber-pay/
 

--- a/docs/develop.md
+++ b/docs/develop.md
@@ -238,7 +238,7 @@ Useful env overrides:
 
 - `SKIP_BUILD=1`
 - `SKIP_BINARY_DOWNLOAD=1`
-- `FIBER_BINARY_VERSION=v0.9.0-rc7`
+- `FIBER_BINARY_VERSION=v0.9.0`
 - `CHANNEL_FUNDING_CKB` (default `200`)
 - `INVOICE_AMOUNT_CKB` (default `1`, keep tiny for long-term reuse)
 - `MIN_FUNDING_BALANCE_CKB`

--- a/docs/develop.md
+++ b/docs/develop.md
@@ -21,6 +21,7 @@ This document is the single source of truth for project development and maintain
 		- [Notes](#notes)
 		- [Required GitHub secret](#required-github-secret)
 		- [Quick release checklist](#quick-release-checklist)
+	- [Fiber (fnn) version upgrade checklist](#fiber-fnn-version-upgrade-checklist)
 	- [Smoke script (no token consumption)](#smoke-script-no-token-consumption)
 	- [Canonical E2E script (single entry)](#canonical-e2e-script-single-entry)
 
@@ -173,6 +174,41 @@ Workflow file: `.github/workflows/release.yml`
 - commit and push updated versions/changelogs to `master`
 - create and push tag: `vX.Y.Z` (or `vX.Y.Z-rc.N`)
 - confirm `Release` workflow passes in GitHub Actions
+
+## Fiber (fnn) version upgrade checklist
+
+Version strings are scattered across user-facing text; a plain grep for the old
+version is necessary but not sufficient. When bumping the fnn target, walk this
+list:
+
+1. **Single source**: `packages/node/src/constants.ts` (`DEFAULT_FIBER_VERSION`).
+   Runtime code must interpolate it — never hardcode a version in new messages.
+2. **fiber-js dependency**: catalog entry in `pnpm-workspace.yaml` plus any
+   `peerDependencies` overrides, then re-resolve the lockfile and diff the
+   stable `.d.ts` against the previous rc for WASM API changes.
+3. **CLI user-visible text**: `packages/cli/src/commands/node.ts`,
+   `packages/cli/src/lib/node-start.ts`, `packages/cli/src/lib/node-upgrade.ts`,
+   `packages/cli/src/lib/node-version-policy.ts` — these should all interpolate
+   `DEFAULT_FIBER_VERSION`; grep for hardcoded `v0.` remnants anyway.
+4. **RPC surface delta** (upstream rpc/README diff between versions): new
+   `ChannelState` values → `packages/sdk/src/types/rpc.ts` enum,
+   `packages/cli/src/lib/format.ts` (`stateLabel` / `parseChannelState`), and
+   the React predicates in `packages/react/src/fiber-node-button/utils.ts`
+   (display vs. destructive-operation semantics — a "pending" state that is
+   funded must not route to `abandon_channel`); new RPC methods →
+   `packages/sdk/src/rpc/client.ts` (decide explicitly whether each belongs on
+   the shared `IFiberClient` interface); new response fields → check fan-out
+   sinks (runtime alert payloads are field-whitelisted for this reason).
+5. **Skill docs**: `skills/fiber-pay/SKILL.md` (description, node target, RPC
+   reference link, `Last updated` date) and `skills/fiber-pay/references/*.md`
+   runnable examples — historical migration notes keep old versions on purpose,
+   copy-paste-runnable examples must not.
+6. **Bundle-size notes**: `packages/react/README.md`,
+   `packages/sdk/README.md`,
+   `packages/react/docs/wasm-passkey-payment-component-quickstart.md` — re-measure
+   with the new fiber-js or keep the wording version-agnostic.
+7. **Workflows**: `.github/workflows/*smoke*`, `e2e-*` — confirm they pick the
+   version up from the constant rather than pinning their own.
 
 ## Smoke script (no token consumption)
 

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -1,6 +1,6 @@
 # @fiber-pay/agent
 
-AI-agent orchestration layer for Fiber Network (targeting Fiber `v0.9.0-rc7`).
+AI-agent orchestration layer for Fiber Network (targeting Fiber `v0.9.0`).
 
 > Status: Experimental. This package is currently **not recommended** for production use.
 > It has not been fully validated by end-to-end tests yet, and implementation quality is still rough.
@@ -141,7 +141,7 @@ See `src/mcp-tools.ts` for complete tool names and JSON schemas.
 ## Compatibility
 
 - Node.js: `>=20`
-- Fiber RPC semantics: aligned with Fiber `v0.9.0-rc7`
+- Fiber RPC semantics: aligned with Fiber `v0.9.0`
 
 ## Known gaps
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -20,7 +20,7 @@ fiber-pay agent call http://host:8402 --prompt "your question"
 
 ## UDT (User-Defined Token) Support
 
-The CLI supports UDT channels, invoices, payments, and rebalances on Fiber `v0.9.0-rc7`:
+The CLI supports UDT channels, invoices, payments, and rebalances on Fiber `v0.9.0`:
 
 ```bash
 # Open a UDT channel
@@ -44,5 +44,5 @@ See [docs/l402-agent-guide.md](./docs/l402-agent-guide.md) for L402 and agent de
 ## Compatibility
 
 - Node.js `>=20`
-- Fiber target: `v0.9.0-rc7`
+- Fiber target: `v0.9.0`
 

--- a/packages/cli/src/commands/node.ts
+++ b/packages/cli/src/commands/node.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_FIBER_VERSION } from '@fiber-pay/node';
 import { Command } from 'commander';
 import type { CliConfig } from '../lib/config.js';
 import { runNodeInfoCommand } from '../lib/node-info.js';
@@ -64,7 +65,10 @@ export function createNodeCommand(config: CliConfig): Command {
     .description(
       'Run migration-aware upgrade flow (managed binaries download+upgrade; custom binaries migrate-only)',
     )
-    .option('--version <version>', 'Target Fiber version (default: bundled default v0.9.0-rc4)')
+    .option(
+      '--version <version>',
+      `Target Fiber version (default: bundled default ${DEFAULT_FIBER_VERSION})`,
+    )
     .option('--no-backup', 'Skip creating a store backup before migration')
     .option('--check-only', 'Only check if migration is needed, do not migrate')
     .option('--json')

--- a/packages/cli/src/lib/format.ts
+++ b/packages/cli/src/lib/format.ts
@@ -121,6 +121,8 @@ export function stateLabel(state: ChannelState): string {
       return '🛑 Shutting Down';
     case ChannelState.Closed:
       return '❌ Closed';
+    case ChannelState.Stale:
+      return '⚠️ Stale (audit pending)';
     default:
       return state;
   }

--- a/packages/cli/src/lib/node-start.ts
+++ b/packages/cli/src/lib/node-start.ts
@@ -3,6 +3,7 @@ import { mkdirSync } from 'node:fs';
 import { join } from 'node:path';
 import {
   createKeyManager,
+  DEFAULT_FIBER_VERSION,
   ensureFiberBinary,
   type FiberNodeConfig,
   ProcessManager,
@@ -269,7 +270,7 @@ export async function runNodeStartCommand(
         message: `Fiber node exited during startup${details}`,
         recoverable: true,
         suggestion: isDbTooOld
-          ? 'The store is too old for fnn v0.9.0-rc4. Run `fiber-pay node upgrade` first.'
+          ? `The store is too old for fnn ${DEFAULT_FIBER_VERSION}. Run \`fiber-pay node upgrade\` first.`
           : 'Inspect fnn logs and verify config ports are free before retrying.',
         details: earlyStop ?? undefined,
       });

--- a/packages/cli/src/lib/node-upgrade.ts
+++ b/packages/cli/src/lib/node-upgrade.ts
@@ -2,7 +2,12 @@
  * Implementation of `fiber-pay node upgrade`.
  */
 
-import { LegacyMigration, resolveStorePath, storeExists } from '@fiber-pay/node';
+import {
+  DEFAULT_FIBER_VERSION,
+  LegacyMigration,
+  resolveStorePath,
+  storeExists,
+} from '@fiber-pay/node';
 import type { ResolvedBinaryPath } from './binary-path.js';
 import { getBinaryManagerInstallDirOrThrow, resolveBinaryPath } from './binary-path.js';
 import type { CliConfig } from './config.js';
@@ -265,7 +270,7 @@ async function runLegacyMigrationIfNeeded(
   }
 
   if (!json) {
-    console.log('🔄 Preparing store for fnn v0.9.0-rc4...');
+    console.log(`🔄 Preparing store for fnn ${DEFAULT_FIBER_VERSION}...`);
   }
 
   const legacy = new LegacyMigration('v0.8.1');

--- a/packages/cli/tests/node-version-policy.test.ts
+++ b/packages/cli/tests/node-version-policy.test.ts
@@ -43,8 +43,8 @@ describe('node version policy', () => {
 
     const decision = resolveManagedUpgradeVersion(manager);
 
-    expect(decision.targetTag).toBe('v0.9.0-rc7');
-    expect(decision.targetVersion).toBe('0.9.0-rc7');
+    expect(decision.targetTag).toBe('v0.9.0');
+    expect(decision.targetVersion).toBe('0.9.0');
     expect(decision.source).toBe('default');
   });
 });

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -17,4 +17,4 @@ import { createFiberNodeManager } from '@fiber-pay/node';
 ## Compatibility
 
 - Node.js `>=20`
-- Fiber target: `v0.9.0-rc7`
+- Fiber target: `v0.9.0`

--- a/packages/node/src/constants.ts
+++ b/packages/node/src/constants.ts
@@ -3,4 +3,4 @@
  */
 
 /** Default Fiber Network Node binary version used for downloads when no version is specified. */
-export const DEFAULT_FIBER_VERSION = 'v0.9.0-rc7';
+export const DEFAULT_FIBER_VERSION = 'v0.9.0';

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -52,9 +52,9 @@ set these headers on your web server or CDN (for example Nginx, Cloudflare, Verc
 
 ## Bundle Size Notes
 
-Browser Fiber WASM artifacts are large by nature. With `fiber-js` 0.9.0-rc4, the current
-`react-fiber-node-button-lab` production build includes an additional ~45.5 MB JS chunk
-(~13.4 MB gzip) for WASM/runtime assets.
+Browser Fiber WASM artifacts are large by nature. With `fiber-js` 0.9.0, the current
+`react-fiber-node-button-lab` production build includes an additional ~14.8 MB JS chunk
+(~6.8 MB gzip) for WASM/runtime assets (down from ~45.5 MB raw / ~13.4 MB gzip on 0.9.0-rc4).
 
 Recommended integration strategy:
 

--- a/packages/react/docs/wasm-passkey-payment-component-quickstart.md
+++ b/packages/react/docs/wasm-passkey-payment-component-quickstart.md
@@ -330,7 +330,7 @@ Use this path when you want to ship a functional payment panel quickly, then pro
 - Treat browser XSS hardening as top priority (CSP, script hygiene, strict dependency review).
 - Avoid exposing privileged backend tokens in browser bundles.
 - For browser multithreaded WASM runtime, keep COOP/COEP settings correctly configured.
-- Expect a large WASM-related bundle chunk (roughly ~45.5 MB raw, ~13.4 MB gzip with fiber-js 0.9.0-rc4 in the current React lab);
+- Expect a large WASM-related bundle chunk (roughly ~14.8 MB raw, ~6.8 MB gzip with fiber-js 0.9.0 in the current React lab, down from ~45.5 MB / ~13.4 MB on 0.9.0-rc4);
   use route-level split/lazy mounting for payment-heavy UI.
 
 ## 8) Reference Paths

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -43,7 +43,7 @@
   "peerDependencies": {
     "react": "^18.0.0 || ^19.0.0",
     "qrcode.react": "^4.0.0",
-    "@nervosnetwork/fiber-js": "~0.9.0-rc4"
+    "@nervosnetwork/fiber-js": "~0.9.0"
   },
   "peerDependenciesMeta": {
     "qrcode.react": {

--- a/packages/react/src/fiber-node-button/channels-tab.tsx
+++ b/packages/react/src/fiber-node-button/channels-tab.tsx
@@ -76,6 +76,7 @@ export function ChannelsTab({ state, fiber, onLog, renderAction, t }: ChannelsTa
     selectedCanClose,
     selectedIsClosing,
     selectedPending,
+    selectedStale,
     closeChannel,
   } = state;
 
@@ -297,9 +298,11 @@ export function ChannelsTab({ state, fiber, onLog, renderAction, t }: ChannelsTa
               defaultProps: {
                 id: 'close-channel',
                 channelId: selectedChannel.channel_id,
-                label: selectedPending
-                  ? t('actions.abandonPending', 'Abandon Pending')
-                  : t('actions.closeChannel', 'Close Channel'),
+                label: selectedStale
+                  ? t('actions.staleAuditPending', 'Stale (audit pending)')
+                  : selectedPending
+                    ? t('actions.abandonPending', 'Abandon Pending')
+                    : t('actions.closeChannel', 'Close Channel'),
                 loadingLabel: t('actions.closeChannel.loading', 'Closing...'),
                 disabled: !selectedCanClose || selectedIsClosing,
                 loading: selectedIsClosing,

--- a/packages/react/src/fiber-node-button/use-panel-state.ts
+++ b/packages/react/src/fiber-node-button/use-panel-state.ts
@@ -48,6 +48,7 @@ import type {
 } from './types.js';
 import {
   getChannelFilterState,
+  isAbandonableChannelState,
   isPendingChannelState,
   shorten,
   summarizeError,
@@ -153,6 +154,7 @@ export interface FiberNodeButtonPanelState {
   selectedChannel: Channel | null;
   selectedPending: boolean;
   selectedCanClose: boolean;
+  selectedStale: boolean;
   selectedIsClosing: boolean;
   forceCloseConfirmOpen: boolean;
   setForceCloseConfirmOpen: Dispatch<SetStateAction<boolean>>;
@@ -569,7 +571,17 @@ export function useFiberNodeButtonPanelState(
           return;
         }
 
-        if (isPendingChannelState(target.state.state_name)) {
+        // Stale channels are funded and awaiting the post-restore passive
+        // audit; upstream `abandon_channel` does not protect Stale, so refuse
+        // the close instead of destroying local state with funds inside.
+        if (target.state.state_name === ChannelState.Stale) {
+          setChannels(latest.channels);
+          flashStatus('Channel is awaiting a post-restore audit and cannot be closed yet.', 'info');
+          onLog?.(`Refused to close stale channel (audit pending): ${channelId}`);
+          return;
+        }
+
+        if (isAbandonableChannelState(target.state.state_name)) {
           const params: AbandonChannelParams = {
             channel_id: channelId as HexString,
           };
@@ -941,7 +953,10 @@ export function useFiberNodeButtonPanelState(
   const selectedCanClose =
     !!selectedChannel &&
     selectedState !== ChannelState.Closed &&
-    selectedState !== ChannelState.ShuttingDown;
+    selectedState !== ChannelState.ShuttingDown &&
+    // Stale: awaiting post-restore audit — neither shutdown nor abandon is safe.
+    selectedState !== ChannelState.Stale;
+  const selectedStale = selectedState === ChannelState.Stale;
   const selectedIsClosing = !!selectedChannel && closingChannelId === selectedChannel.channel_id;
 
   const connectorContext: FiberNodeButtonConnectorSectionContext = useMemo(
@@ -1029,6 +1044,7 @@ export function useFiberNodeButtonPanelState(
     selectedChannel,
     selectedPending,
     selectedCanClose,
+    selectedStale,
     selectedIsClosing,
     forceCloseConfirmOpen,
     setForceCloseConfirmOpen,

--- a/packages/react/src/fiber-node-button/utils.ts
+++ b/packages/react/src/fiber-node-button/utils.ts
@@ -39,6 +39,26 @@ export function isPendingChannelState(state: ChannelState): boolean {
   );
 }
 
+/**
+ * Pending states that may be closed via `abandon_channel` (unfunded channels
+ * that never went live).
+ *
+ * Deliberately narrower than {@link isPendingChannelState}: it excludes Stale.
+ * A Stale channel is already funded and merely awaiting the post-restore
+ * passive audit; upstream `abandon_channel` does not protect Stale, so calling
+ * it would destroy local channel state with funds still inside. Stale channels
+ * must never be routed to abandon — wait for the audit to settle instead.
+ */
+export function isAbandonableChannelState(state: ChannelState): boolean {
+  return (
+    state === ChannelState.NegotiatingFunding ||
+    state === ChannelState.CollaboratingFundingTx ||
+    state === ChannelState.SigningCommitment ||
+    state === ChannelState.AwaitingTxSignatures ||
+    state === ChannelState.AwaitingChannelReady
+  );
+}
+
 export function isClosedChannelState(state: ChannelState): boolean {
   return state === ChannelState.Closed || state === ChannelState.ShuttingDown;
 }

--- a/packages/react/src/fiber-node-button/utils.ts
+++ b/packages/react/src/fiber-node-button/utils.ts
@@ -32,7 +32,10 @@ export function isPendingChannelState(state: ChannelState): boolean {
     state === ChannelState.CollaboratingFundingTx ||
     state === ChannelState.SigningCommitment ||
     state === ChannelState.AwaitingTxSignatures ||
-    state === ChannelState.AwaitingChannelReady
+    state === ChannelState.AwaitingChannelReady ||
+    // Stale (fnn v0.9.0+): awaiting passive audit after a database restore,
+    // not usable until it settles back to a live state.
+    state === ChannelState.Stale
   );
 }
 

--- a/packages/react/tests/fiber-node-button.test.tsx
+++ b/packages/react/tests/fiber-node-button.test.tsx
@@ -242,6 +242,66 @@ describe('FiberNodeButton', () => {
     });
   });
 
+  it('refuses to close a stale channel instead of routing it to abandon', async () => {
+    const staleChannel = {
+      channel_id: '0xchannel',
+      is_public: false,
+      is_acceptor: false,
+      is_one_way: false,
+      channel_outpoint: null,
+      pubkey: '0xpeer',
+      funding_udt_type_script: null,
+      state: {
+        state_name: ChannelState.Stale,
+      },
+      local_balance: '0x5f5e100',
+      offered_tlc_balance: '0x0',
+      remote_balance: '0x3b9aca00',
+      received_tlc_balance: '0x0',
+      pending_tlcs: [],
+      latest_commitment_transaction_hash: null,
+      created_at: '0x1',
+      enabled: true,
+      tlc_expiry_delta: '0x0',
+      tlc_fee_proportional_millionths: '0x0',
+      shutdown_transaction_hash: null,
+    };
+
+    const node = createNodeMock();
+    node.listChannels = vi.fn(async () => ({ channels: [staleChannel] }));
+
+    const fiber = createFiberMock({
+      state: 'running',
+      isRunning: true,
+      node: node as unknown as UseFiberNodeResult['node'],
+      nodeInfo: { pubkey: '0x0123456789abcdef0123456789abcdef' } as UseFiberNodeResult['nodeInfo'],
+    });
+
+    render(<FiberNodeButton fiber={fiber} strategy="passkey" />);
+
+    fireEvent.click(screen.getByRole('button', { name: /0x012345/i }));
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Channels' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'pending (1)' })).toBeTruthy();
+    });
+
+    // The stale channel only lists under the pending filter; switching to it
+    // auto-selects the channel and reveals the detail panel.
+    fireEvent.click(screen.getByRole('button', { name: 'pending (1)' }));
+
+    // The close action is labelled for the stale state and disabled — it must
+    // never reach abandonChannel, which would destroy funded channel state.
+    await waitFor(() => {
+      const closeButton = screen.getByRole('button', { name: 'Stale (audit pending)' });
+      expect(closeButton.hasAttribute('disabled')).toBe(true);
+    });
+
+    expect(node.abandonChannel).not.toHaveBeenCalled();
+    expect(node.shutdownChannel).not.toHaveBeenCalled();
+  });
+
   it('creates UDT invoice with udt_type_script when asset is UDT', async () => {
     const node = createNodeMock();
     const fiber = createFiberMock({

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -1,6 +1,6 @@
 # @fiber-pay/runtime
 
-Runtime monitor + job orchestration for Fiber (`fnn v0.9.0-rc7`).
+Runtime monitor + job orchestration for Fiber (`fnn v0.9.0`).
 
 ## Quick start
 

--- a/packages/runtime/src/monitors/payment-tracker.ts
+++ b/packages/runtime/src/monitors/payment-tracker.ts
@@ -1,4 +1,4 @@
-import type { FiberRpcClient } from '@fiber-pay/sdk';
+import type { FiberRpcClient, PaymentInfo } from '@fiber-pay/sdk';
 import type { AlertManager } from '../alerts/alert-manager.js';
 import type { Store } from '../storage/types.js';
 import { BaseMonitor, type BaseMonitorHooks } from './base-monitor.js';
@@ -7,6 +7,24 @@ import { isExpectedTrackerError, isNotFoundError } from './tracker-utils.js';
 export interface PaymentTrackerConfig {
   intervalMs: number;
   completedItemTtlSeconds: number;
+}
+
+/**
+ * Field-whitelisted payment view for alert payloads.
+ *
+ * Alerts are fanned out to file (on by default), webhook, and websocket
+ * backends, so the full PaymentInfo must not be embedded: since fnn v0.9.0 it
+ * can carry `payment_preimage`, the cryptographic proof of payment, which
+ * should not be persisted to alert logs or pushed to external endpoints.
+ * Mirrors the whitelist used by payment-executor job results.
+ */
+function toAlertPaymentSummary(payment: PaymentInfo) {
+  return {
+    payment_hash: payment.payment_hash,
+    status: payment.status,
+    fee: payment.fee,
+    failed_error: payment.failed_error,
+  };
 }
 
 export class PaymentTracker extends BaseMonitor {
@@ -58,7 +76,7 @@ export class PaymentTracker extends BaseMonitor {
                 paymentHash: payment.paymentHash,
                 previousStatus,
                 currentStatus,
-                payment: next,
+                payment: toAlertPaymentSummary(next),
               },
             });
           }
@@ -72,7 +90,7 @@ export class PaymentTracker extends BaseMonitor {
                 paymentHash: payment.paymentHash,
                 previousStatus,
                 currentStatus,
-                payment: next,
+                payment: toAlertPaymentSummary(next),
               },
             });
           }

--- a/packages/runtime/tests/payment-tracker.test.ts
+++ b/packages/runtime/tests/payment-tracker.test.ts
@@ -106,6 +106,55 @@ describe('PaymentTracker', () => {
     await rm(dir, { recursive: true, force: true });
   });
 
+  it('strips payment_preimage from outgoing_payment_completed alert payloads', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'fiber-payment-tracker-'));
+    const store = new MemoryStore({
+      stateFilePath: join(dir, 'runtime-state.json'),
+      flushIntervalMs: 1000,
+      maxAlertHistory: 100,
+    });
+    store.addTrackedPayment('0xpay-success', 'Inflight');
+
+    const emitted: Alert[] = [];
+    const alerts = new AlertManager({
+      backends: [new CaptureAlertBackend(emitted)],
+      store,
+    });
+
+    const client = {
+      getPayment: async () => ({
+        payment_hash: '0xpay-success',
+        payment_preimage: '0xsecret-preimage',
+        status: 'Success',
+        fee: '0x1',
+        created_at: '0x0',
+        last_updated_at: '0x1',
+      }),
+    };
+
+    const tracker = new PaymentTracker({
+      client: client as unknown as FiberRpcClient,
+      store,
+      alerts,
+      config: {
+        intervalMs: 1000,
+        completedItemTtlSeconds: 60,
+      },
+    });
+
+    await (tracker as unknown as { poll: () => Promise<void> }).poll();
+
+    const completed = emitted.find((item) => item.type === 'outgoing_payment_completed');
+    expect(completed).toBeDefined();
+    expect(JSON.stringify(completed)).not.toContain('0xsecret-preimage');
+    expect(JSON.stringify(completed)).not.toContain('payment_preimage');
+    expect(completed?.data).toMatchObject({
+      paymentHash: '0xpay-success',
+      payment: { payment_hash: '0xpay-success', status: 'Success', fee: '0x1' },
+    });
+    await rm(dir, { recursive: true, force: true });
+  });
+
   it('marks payment as Failed when RPC not-found appears in error data payload', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'fiber-payment-tracker-'));
     const store = new MemoryStore({

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -86,7 +86,7 @@ Nginx, Cloudflare, or Vercel), not only in local dev tooling.
 ### Bundle Size Expectations
 
 The Fiber browser runtime is intentionally heavy. Expect a large WASM-related chunk in production builds
-(roughly ~45.5 MB raw and ~13.4 MB gzip with fiber-js 0.9.0-rc4 in the current React lab). Prefer route-level code splitting and lazy
+(roughly ~14.8 MB raw and ~6.8 MB gzip with fiber-js 0.9.0 in the current React lab, down from ~45.5 MB / ~13.4 MB on 0.9.0-rc4). Prefer route-level code splitting and lazy
 mounting so the chunk loads only when payment/node features are needed.
 
 `@fiber-pay/sdk/browser` also exports `FiberRpcClient` for migration compatibility.

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -222,4 +222,4 @@ if (balances.kind === 'udt') {
 ## Compatibility
 
 - Node.js `>=20`
-- Fiber target: `v0.9.0-rc7`
+- Fiber target: `v0.9.0`

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -50,7 +50,7 @@
     "zod": "^4.3.6"
   },
   "peerDependencies": {
-    "@nervosnetwork/fiber-js": "~0.9.0-rc4",
+    "@nervosnetwork/fiber-js": "~0.9.0",
     "express": "^4.0.0 || ^5.0.0"
   },
   "peerDependenciesMeta": {

--- a/packages/sdk/src/rpc/client.ts
+++ b/packages/sdk/src/rpc/client.ts
@@ -397,6 +397,21 @@ export class FiberRpcClient implements IFiberClient {
   }
 
   // ===========================================================================
+  // Admin Module
+  // ===========================================================================
+
+  /**
+   * Backup the node database (fnn v0.9.0+).
+   *
+   * Writes a backup of the node store to disk on the node host. After a
+   * restore, channels enter the `STALE` state until a passive audit with the
+   * peer completes.
+   */
+  async backup(): Promise<void> {
+    return this.call<void>('backup', []);
+  }
+
+  // ===========================================================================
   // Utility Methods
   // ===========================================================================
 

--- a/packages/sdk/src/rpc/client.ts
+++ b/packages/sdk/src/rpc/client.ts
@@ -406,6 +406,16 @@ export class FiberRpcClient implements IFiberClient {
    * Writes a backup of the node store to disk on the node host. After a
    * restore, channels enter the `STALE` state until a passive audit with the
    * peer completes.
+   *
+   * RPC-client-only capability: writing to the node host's disk is meaningless
+   * for `FiberBrowserNode` (in-browser WASM node), so this method is
+   * deliberately not part of the shared `IFiberClient` interface.
+   *
+   * Known upstream limitation (fnn v0.9.0): the Biscuit auth rule is registered
+   * under the key `backup_now` while the RPC method is named `backup`, so on
+   * nodes with authentication enabled the call is fail-closed rejected with
+   * "no rules for method". Use against a local (unauthenticated) RPC, or wait
+   * for the upstream fix.
    */
   async backup(): Promise<void> {
     return this.call<void>('backup', []);

--- a/packages/sdk/src/types/rpc.ts
+++ b/packages/sdk/src/types/rpc.ts
@@ -1,8 +1,8 @@
 /**
- * Fiber Network Node RPC Types (Fiber v0.9.0-rc4)
+ * Fiber Network Node RPC Types (Fiber v0.9.0)
  *
  * The types in this file are intended to align with the upstream RPC spec:
- * https://github.com/nervosnetwork/fiber/blob/v0.9.0-rc4/crates/fiber-lib/src/rpc/README.md
+ * https://github.com/nervosnetwork/fiber/blob/v0.9.0/crates/fiber-lib/src/rpc/README.md
  */
 
 // =============================================================================
@@ -135,6 +135,11 @@ export enum ChannelState {
   ChannelReady = 'CHANNEL_READY',
   ShuttingDown = 'SHUTTING_DOWN',
   Closed = 'CLOSED',
+  /**
+   * The channel state is potentially outdated (e.g., after a database restore).
+   * fnn v0.9.0+ performs a passive audit with the peer before resuming operations.
+   */
+  Stale = 'STALE',
 }
 
 /** Channel state flags are serialized as a pipe-delimited SCREAMING_SNAKE_CASE string. */
@@ -214,6 +219,8 @@ export interface SessionRoute {
 
 export interface PaymentInfo {
   payment_hash: PaymentHash;
+  /** The preimage learned from a successful payment attempt (fnn v0.9.0+). */
+  payment_preimage?: Hash256;
   status: PaymentStatus;
   created_at: HexString;
   last_updated_at: HexString;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,8 +7,8 @@ settings:
 catalogs:
   default:
     '@nervosnetwork/fiber-js':
-      specifier: ~0.9.0-rc4
-      version: 0.9.0-rc4
+      specifier: ~0.9.0
+      version: 0.9.0
 
 overrides:
   rollup@>=4.0.0 <4.59.0: '>=4.59.0'
@@ -58,7 +58,7 @@ importers:
         version: link:../../packages/sdk
       '@nervosnetwork/fiber-js':
         specifier: 'catalog:'
-        version: 0.9.0-rc4
+        version: 0.9.0
     devDependencies:
       playwright:
         specifier: ^1.55.0
@@ -71,7 +71,7 @@ importers:
     dependencies:
       '@nervosnetwork/fiber-js':
         specifier: 'catalog:'
-        version: 0.9.0-rc4
+        version: 0.9.0
     devDependencies:
       playwright:
         specifier: ^1.55.0
@@ -87,7 +87,7 @@ importers:
         version: link:../../packages/sdk
       '@nervosnetwork/fiber-js':
         specifier: 'catalog:'
-        version: 0.9.0-rc4
+        version: 0.9.0
       react:
         specifier: ^19.2.4
         version: 19.2.4
@@ -139,7 +139,7 @@ importers:
         version: link:../../packages/react
       '@nervosnetwork/fiber-js':
         specifier: 'catalog:'
-        version: 0.9.0-rc4
+        version: 0.9.0
       react:
         specifier: ^19.2.4
         version: 19.2.4
@@ -188,7 +188,7 @@ importers:
         version: link:../../packages/react
       '@nervosnetwork/fiber-js':
         specifier: 'catalog:'
-        version: 0.9.0-rc4
+        version: 0.9.0
       react:
         specifier: ^19.2.4
         version: 19.2.4
@@ -318,7 +318,7 @@ importers:
     devDependencies:
       '@nervosnetwork/fiber-js':
         specifier: 'catalog:'
-        version: 0.9.0-rc4
+        version: 0.9.0
       '@testing-library/react':
         specifier: ^16.3.0
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -345,8 +345,8 @@ importers:
   packages/sdk:
     dependencies:
       '@nervosnetwork/fiber-js':
-        specifier: ~0.9.0-rc4
-        version: 0.9.0-rc4
+        specifier: ~0.9.0
+        version: 0.9.0
       '@noble/hashes':
         specifier: ^2.0.1
         version: 2.0.1
@@ -1014,8 +1014,8 @@ packages:
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
 
-  '@nervosnetwork/fiber-js@0.9.0-rc4':
-    resolution: {integrity: sha512-JSM5Qt59UN0likBP+ZMaWlJ5WcATtUriplG9hp/0tLHbm41lF71i5R/cJMbiIgCozN9BMgi9+ReVJH/0YrD85Q==}
+  '@nervosnetwork/fiber-js@0.9.0':
+    resolution: {integrity: sha512-LQ7RtoLSZUY4lMEqDB16l/GemtxXjU/11oewZ2MJqY06r3l5hTNbwC/4xmNA7XjXN5SykdBfZx640eSMRVlNiw==}
 
   '@noble/hashes@2.0.1':
     resolution: {integrity: sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==}
@@ -3717,7 +3717,7 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
-  '@nervosnetwork/fiber-js@0.9.0-rc4':
+  '@nervosnetwork/fiber-js@0.9.0':
     dependencies:
       async-mutex: 0.5.0
       stream-browserify: 3.0.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,7 +4,7 @@ packages:
   - "e2e/*"
 
 catalog:
-  "@nervosnetwork/fiber-js": "~0.9.0-rc4"
+  "@nervosnetwork/fiber-js": "~0.9.0"
 
 onlyBuiltDependencies:
   - "better-sqlite3"

--- a/skills/fiber-pay/SKILL.md
+++ b/skills/fiber-pay/SKILL.md
@@ -7,7 +7,7 @@ description: Operate CKB Lightning payments through fiber-pay CLI, including UDT
 
 fiber-pay is an AI payment layer over Fiber Network for CKB Lightning. It provides an AI-friendly CLI to manage node lifecycle, channels, invoices, payments, UDT (User-Defined Token) support, and more.
 
-- Last updated: 2026-07-09
+- Last updated: 2026-08-13
 - Fiber node target: v0.9.0
 - Fiber RPC reference: https://github.com/nervosnetwork/fiber/blob/v0.9.0/crates/fiber-lib/src/rpc/README.md
 

--- a/skills/fiber-pay/SKILL.md
+++ b/skills/fiber-pay/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: fiber-pay
-description: Operate CKB Lightning payments through fiber-pay CLI, including UDT support. Use when tasks involve node lifecycle, channel management, invoice/payment flows, UDT operations, config tuning, or multi-node orchestration on Fiber Network v0.9.0-rc7.
+description: Operate CKB Lightning payments through fiber-pay CLI, including UDT support. Use when tasks involve node lifecycle, channel management, invoice/payment flows, UDT operations, config tuning, or multi-node orchestration on Fiber Network v0.9.0.
 ---
 
 # fiber-pay
@@ -8,8 +8,8 @@ description: Operate CKB Lightning payments through fiber-pay CLI, including UDT
 fiber-pay is an AI payment layer over Fiber Network for CKB Lightning. It provides an AI-friendly CLI to manage node lifecycle, channels, invoices, payments, UDT (User-Defined Token) support, and more.
 
 - Last updated: 2026-07-09
-- Fiber node target: v0.9.0-rc7
-- Fiber RPC reference: https://github.com/nervosnetwork/fiber/blob/v0.9.0-rc7/crates/fiber-lib/src/rpc/README.md
+- Fiber node target: v0.9.0
+- Fiber RPC reference: https://github.com/nervosnetwork/fiber/blob/v0.9.0/crates/fiber-lib/src/rpc/README.md
 
 ## Architecture
 

--- a/skills/fiber-pay/references/auth.md
+++ b/skills/fiber-pay/references/auth.md
@@ -4,8 +4,8 @@ This guide documents how `fiber-pay` works with Fiber RPC Biscuit authentication
 
 Upstream reference:
 
-- Fiber Biscuit auth doc: [docs/biscuit-auth.md](https://github.com/nervosnetwork/fiber/blob/v0.9.0-rc7/docs/biscuit-auth.md)
-- Fiber RPC reference: [crates/fiber-lib/src/rpc/README.md](https://github.com/nervosnetwork/fiber/blob/v0.9.0-rc7/crates/fiber-lib/src/rpc/README.md)
+- Fiber Biscuit auth doc: [docs/biscuit-auth.md](https://github.com/nervosnetwork/fiber/blob/v0.9.0/docs/biscuit-auth.md)
+- Fiber RPC reference: [crates/fiber-lib/src/rpc/README.md](https://github.com/nervosnetwork/fiber/blob/v0.9.0/crates/fiber-lib/src/rpc/README.md)
 
 ## Scope
 

--- a/skills/fiber-pay/references/config.md
+++ b/skills/fiber-pay/references/config.md
@@ -1,4 +1,4 @@
-# FNN Config Reference (v0.9.0-rc7)
+# FNN Config Reference (v0.9.0)
 
 - Structured reference for `config.yml` used by the Fiber Network Node (`fnn`). 
 - All values are set via `fiber-pay config set <path> <value>`.
@@ -140,8 +140,9 @@ Requires `cch` in `services`.
 | `cch.lnd_macaroon_path` | string | none | LND macaroon path |
 | `cch.wrapped_btc_type_script_args` | string | *required* | Wrapped BTC type script args |
 | `cch.expiry_delta_seconds` | number | `3600` | Order expiry delta (seconds) |
-| `cch.base_fee_sats` | number | `0` | Base fee per order (sats) |
-| `cch.fee_rate_per_million_sats` | number | `1` | Proportional fee |
+| `cch.base_fee_sats` | number | `100` | Base fee per order (sats) |
+| `cch.fee_rate_per_million_sats` | number | `3000` | Proportional fee |
+| `cch.max_outgoing_fee_percentage` | number | `80` | Max share of collected fee spent on outgoing routing (%) |
 | `cch.btc_final_tlc_expiry` | number | `36` | BTC final TLC expiry (seconds) |
 
 ---

--- a/skills/fiber-pay/references/fnn.reference.yml
+++ b/skills/fiber-pay/references/fnn.reference.yml
@@ -1,7 +1,7 @@
 # =============================================================================
 # Fiber Network Node (fnn) - Full Configuration Reference
 # =============================================================================
-# Version: v0.9.0-rc7
+# Version: v0.9.0
 #
 # Usage:
 #   fnn --config /path/to/config.yml
@@ -298,12 +298,16 @@ ckb:
 #   expiry_delta_seconds: 3600
 #
 #   # Base fee per cross-chain order, in satoshis
-#   # [default: 0]
-#   base_fee_sats: 0
+#   # [default: 100]
+#   base_fee_sats: 100
 #
 #   # Proportional fee per million satoshis
-#   # [default: 1]
-#   fee_rate_per_million_sats: 1
+#   # [default: 3000]
+#   fee_rate_per_million_sats: 3000
+#
+#   # Max share of the collected fee spendable on outgoing routing fees, in percent
+#   # [default: 80]
+#   max_outgoing_fee_percentage: 80
 #
 #   # Final TLC expiry for BTC network, in seconds
 #   # [default: 36]

--- a/skills/fiber-pay/references/upgrade.md
+++ b/skills/fiber-pay/references/upgrade.md
@@ -74,14 +74,20 @@ Recommended operator sequence:
 ## Programmatic API (`@fiber-pay/node`)
 
 ```typescript
-import { BinaryManager, LegacyMigration, resolveStorePath, storeExists } from '@fiber-pay/node';
+import {
+  BinaryManager,
+  DEFAULT_FIBER_VERSION,
+  LegacyMigration,
+  resolveStorePath,
+  storeExists,
+} from '@fiber-pay/node';
 import * as os from 'os';
 
 const dataDir = `${os.homedir()}/.fiber-pay`;
 const bm = new BinaryManager(`${dataDir}/bin`);
 
 // Download only the fnn binary (no fnn-migrate extracted)
-const info = await bm.download({ version: 'v0.9.0-rc4' });
+const info = await bm.download({ version: DEFAULT_FIBER_VERSION });
 
 // Run legacy migration if needed
 if (storeExists(dataDir)) {

--- a/skills/fiber-pay/references/upgrade.md
+++ b/skills/fiber-pay/references/upgrade.md
@@ -19,7 +19,7 @@ fiber-pay node stop
 
 # 2. Upgrade binary + prepare store
 fiber-pay node upgrade                    # latest version
-fiber-pay node upgrade --version v0.9.0-rc7   # specific version
+fiber-pay node upgrade --version v0.9.0   # specific version
 
 # custom binary path: migration-only (no auto-download)
 fiber-pay --binary-path /opt/fiber/custom/fnn node upgrade


### PR DESCRIPTION
## Summary

Upstream [nervosnetwork/fiber v0.9.0](https://github.com/nervosnetwork/fiber/releases/tag/v0.9.0) stable is out (2026-08-06). This PR moves fiber-pay off the rc line:

- **`@fiber-pay/node`**: `DEFAULT_FIBER_VERSION` `v0.9.0-rc7` → `v0.9.0` (fresh installs, `node upgrade` default, and CI smoke tests follow automatically). Release asset naming is unchanged, so `BinaryManager` works as-is.
- **`@nervosnetwork/fiber-js`**: catalog + peer ranges `~0.9.0-rc4` → `~0.9.0`; lockfile re-resolved to `0.9.0`. Verified the stable package's `.d.ts` is byte-identical to rc7 — no WASM API changes.

## Adaptations for the rc7 → 0.9.0 RPC diff

Checked the upstream diff ([v0.9.0-rc7...v0.9.0](https://github.com/nervosnetwork/fiber/compare/v0.9.0-rc7...v0.9.0), 62 commits); the user-facing surface changes are handled here:

- `ChannelState` gains **`Stale`** (`'STALE'`) — channels enter this after a database restore until a passive audit with the peer completes. Added to the SDK enum and classified as *pending* in the React `fiber-node-button` filter (upstream counts it as a pending state).
- `PaymentInfo` gains optional **`payment_preimage`** (returned by `send_payment` / `get_payment` / `send_payment_with_router` on success).
- RPC client gains **`backup()`** for the new `Admin` module.
- CCH fee defaults changed upstream: `base_fee_sats` 0→100, `fee_rate_per_million_sats` 1→3000, `max_outgoing_fee_percentage` →80 — skill config references updated to match.

No config-file breaking changes for fiber-pay users: mainnet `config.yml` only gained comments, testnet config is unchanged, and the legacy v0.8.1 `fnn-migrate` bridge path is unaffected.

## Drive-by fixes

- `fiber-pay node upgrade --help` now renders the bundled default from `DEFAULT_FIBER_VERSION` instead of a stale hardcoded `v0.9.0-rc4` string.
- Docs, skill references, and workflow-dispatch examples retargeted to `v0.9.0` (historical "since rc4" migration notes left as-is).

## Verification

- `pnpm install` clean, lockfile diff is exclusively the fiber-js bump
- `pnpm -r build`, `pnpm -r typecheck`, `pnpm lint` (biome, 179 files) all pass
- `pnpm -r test`: **682 tests pass** (sdk 258, cli 227, runtime 101, react 65, node 31), including the updated `node-version-policy` expectation
- Smoke: `node dist/cli.js node upgrade --help` prints `default: bundled default v0.9.0`

Not run locally: the actual fnn v0.9.0 binary download / e2e (sandbox network blocks github.com release downloads) — the testnet e2e workflow covers it.