### PR TITLE
fix(sdk): align Biscuit policy table with fnn v0.9.0

### DIFF
--- a/.changeset/biscuit-policy-fnn-v0-9-0.md
+++ b/.changeset/biscuit-policy-fnn-v0-9-0.md
@@ -1,0 +1,9 @@
+---
+"@fiber-pay/sdk": patch
+---
+
+Align the Biscuit policy table with fnn v0.9.0. `receive_btc` now requires `write("cch")` (was `read("cch")`), all dev RPCs (`commitment_signed`, `add_tlc`, `remove_tlc`, `check_channel_shutdown`, `submit_commitment_transaction`, plus newly covered `sign_external_funding_tx`) now require `write("dev")`, and `list_payments` (`read("payments")`) and `pprof` (`write("pprof")`) are now covered. Tokens minted from the previous table were rejected by fnn v0.9.0 nodes for `receive_btc` and every dev method.
+
+`collectBiscuitPermissions` and `renderBiscuitFactsForMethods` now also grant `read("cch")` whenever `write("cch")` is collected (opt out with `{ cchReadCompat: false }`): on fnn v0.9.0 a write-only cch token cannot call `get_cch_order`, and pre-v0.9.0 nodes still require `read("cch")` for `receive_btc`.
+
+`subscribe_store_changes` and `backup_now` remain deliberately unmintable: the former requires the node-internal `internal("store_changes")` scope, and the latter is registered upstream under a rule key (`backup_now`) that does not match the RPC method name (`backup`), so authenticated calls are fail-closed regardless of token contents.

--- a/docs/develop.md
+++ b/docs/develop.md
@@ -198,7 +198,10 @@ list:
    funded must not route to `abandon_channel`); new RPC methods →
    `packages/sdk/src/rpc/client.ts` (decide explicitly whether each belongs on
    the shared `IFiberClient` interface); new response fields → check fan-out
-   sinks (runtime alert payloads are field-whitelisted for this reason).
+   sinks (runtime alert payloads are field-whitelisted for this reason);
+   Biscuit auth rule changes (upstream `crates/fiber-lib/src/rpc/biscuit.rs`
+   and `docs/biscuit-auth.md`) → `packages/sdk/src/security/biscuit-policy.ts`
+   plus the `packages/sdk/tests/fixtures/fnn-biscuit-rules.ts` snapshot.
 5. **Skill docs**: `skills/fiber-pay/SKILL.md` (description, node target, RPC
    reference link, `Last updated` date) and `skills/fiber-pay/references/*.md`
    runnable examples — historical migration notes keep old versions on purpose,

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -18,6 +18,7 @@ export type {
   BiscuitAction,
   BiscuitMethodRule,
   BiscuitPermission,
+  CollectBiscuitPermissionsOptions,
 } from './security/biscuit-policy.js';
 // Security components
 export {

--- a/packages/sdk/src/security/biscuit-policy.ts
+++ b/packages/sdk/src/security/biscuit-policy.ts
@@ -3,6 +3,22 @@
  *
  * These helpers model the upstream RPC authorization rules and generate
  * token-side permission facts like `read("peers");` and `write("payments");`.
+ *
+ * The RULES table mirrors fnn v0.9.0 `build_rules()`
+ * (crates/fiber-lib/src/rpc/biscuit.rs @ v0.9.0, also documented in upstream
+ * docs/biscuit-auth.md), with two deliberate omissions:
+ *
+ * - `subscribe_store_changes`: upstream requires `internal("store_changes")`,
+ *   a node-internal scope that user-minted tokens must not carry.
+ * - `backup_now`: upstream registers the rule under the key `backup_now`
+ *   while the RPC method is named `backup`, so authenticated calls are
+ *   fail-closed regardless of token contents ("no rules for method").
+ *
+ * Biscuit `read` and `write` do not imply each other, so
+ * `collectBiscuitPermissions` by default also grants `read("cch")` whenever
+ * `write("cch")` is collected: on fnn v0.9.0 a write-only cch token cannot
+ * call `get_cch_order`, and on pre-v0.9.0 nodes `receive_btc` still requires
+ * `read("cch")`. Pass `{ cchReadCompat: false }` to opt out.
  */
 
 export type BiscuitAction = 'read' | 'write';
@@ -17,6 +33,17 @@ export interface BiscuitMethodRule {
   requiresChannelRight: boolean;
 }
 
+export interface CollectBiscuitPermissionsOptions {
+  /**
+   * Also grant `read("cch")` whenever `write("cch")` is collected.
+   *
+   * Defaults to true so that cch-mutating tokens can still query their own
+   * orders via `get_cch_order` (requires `read("cch")` on every fnn version)
+   * and keep working for `receive_btc` on pre-v0.9.0 nodes.
+   */
+  cchReadCompat?: boolean;
+}
+
 const RULES: Record<string, BiscuitMethodRule> = {
   // Cch
   send_btc: {
@@ -24,13 +51,15 @@ const RULES: Record<string, BiscuitMethodRule> = {
     requiresChannelRight: false,
   },
   receive_btc: {
-    permissions: [{ action: 'read', resource: 'cch' }],
+    permissions: [{ action: 'write', resource: 'cch' }],
     requiresChannelRight: false,
   },
   get_cch_order: {
     permissions: [{ action: 'read', resource: 'cch' }],
     requiresChannelRight: false,
   },
+  // Omitted vs upstream: subscribe_store_changes requires the node-internal
+  // internal("store_changes") scope, which user-minted tokens must not carry.
 
   // Channel
   open_channel: {
@@ -68,23 +97,33 @@ const RULES: Record<string, BiscuitMethodRule> = {
 
   // Dev
   commitment_signed: {
-    permissions: [{ action: 'write', resource: 'messages' }],
+    permissions: [{ action: 'write', resource: 'dev' }],
     requiresChannelRight: false,
   },
   add_tlc: {
-    permissions: [{ action: 'write', resource: 'channels' }],
+    permissions: [{ action: 'write', resource: 'dev' }],
     requiresChannelRight: false,
   },
   remove_tlc: {
-    permissions: [{ action: 'write', resource: 'channels' }],
+    permissions: [{ action: 'write', resource: 'dev' }],
     requiresChannelRight: false,
   },
   check_channel_shutdown: {
-    permissions: [{ action: 'write', resource: 'channels' }],
+    permissions: [{ action: 'write', resource: 'dev' }],
+    requiresChannelRight: false,
+  },
+  sign_external_funding_tx: {
+    permissions: [{ action: 'write', resource: 'dev' }],
     requiresChannelRight: false,
   },
   submit_commitment_transaction: {
-    permissions: [{ action: 'write', resource: 'chain' }],
+    permissions: [{ action: 'write', resource: 'dev' }],
+    requiresChannelRight: false,
+  },
+
+  // Pprof
+  pprof: {
+    permissions: [{ action: 'write', resource: 'pprof' }],
     requiresChannelRight: false,
   },
 
@@ -103,6 +142,9 @@ const RULES: Record<string, BiscuitMethodRule> = {
     permissions: [{ action: 'read', resource: 'node' }],
     requiresChannelRight: false,
   },
+  // Omitted vs upstream: backup_now (write("node")) is registered under a
+  // rule key that does not match the RPC method name (`backup`), so
+  // authenticated calls are fail-closed regardless of token contents.
 
   // Invoice
   new_invoice: {
@@ -132,6 +174,10 @@ const RULES: Record<string, BiscuitMethodRule> = {
     requiresChannelRight: false,
   },
   get_payment: {
+    permissions: [{ action: 'read', resource: 'payments' }],
+    requiresChannelRight: false,
+  },
+  list_payments: {
     permissions: [{ action: 'read', resource: 'payments' }],
     requiresChannelRight: false,
   },
@@ -197,7 +243,11 @@ export function getBiscuitRuleForMethod(method: string): BiscuitMethodRule | und
   return RULES[method];
 }
 
-export function collectBiscuitPermissions(methods: string[]): BiscuitPermission[] {
+export function collectBiscuitPermissions(
+  methods: string[],
+  options: CollectBiscuitPermissionsOptions = {},
+): BiscuitPermission[] {
+  const { cchReadCompat = true } = options;
   const dedup = new Map<string, BiscuitPermission>();
 
   for (const method of methods) {
@@ -212,6 +262,10 @@ export function collectBiscuitPermissions(methods: string[]): BiscuitPermission[
     }
   }
 
+  if (cchReadCompat && dedup.has('write:cch') && !dedup.has('read:cch')) {
+    dedup.set('read:cch', { action: 'read', resource: 'cch' });
+  }
+
   return [...dedup.values()].sort((a, b) => {
     if (a.action === b.action) {
       return a.resource.localeCompare(b.resource);
@@ -224,8 +278,11 @@ export function renderBiscuitPermissionFacts(permissions: BiscuitPermission[]): 
   return permissions.map((p) => `${p.action}("${escapeDatalogString(p.resource)}");`).join('\n');
 }
 
-export function renderBiscuitFactsForMethods(methods: string[]): string {
-  return renderBiscuitPermissionFacts(collectBiscuitPermissions(methods));
+export function renderBiscuitFactsForMethods(
+  methods: string[],
+  options: CollectBiscuitPermissionsOptions = {},
+): string {
+  return renderBiscuitPermissionFacts(collectBiscuitPermissions(methods, options));
 }
 
 export function listSupportedBiscuitMethods(): string[] {

--- a/packages/sdk/tests/biscuit-policy.test.ts
+++ b/packages/sdk/tests/biscuit-policy.test.ts
@@ -5,7 +5,9 @@ import {
   renderBiscuitFactsForMethods,
   renderBiscuitPermissionFacts,
 } from '../src/security/biscuit-policy.js';
+import type { BiscuitMethodRule } from '../src/security/biscuit-policy.js';
 import { describe, expect, it } from 'vitest';
+import { FNN_V0_9_0_RULES } from './fixtures/fnn-biscuit-rules.js';
 
 describe('biscuit policy helper', () => {
   it('returns rule for known method', () => {
@@ -75,5 +77,72 @@ describe('biscuit policy helper', () => {
     expect(openRule?.requiresChannelRight).toBe(false);
     expect(submitRule?.permissions).toEqual([{ action: 'write', resource: 'channels' }]);
     expect(submitRule?.requiresChannelRight).toBe(false);
+  });
+
+  it('requires write("cch") for receive_btc (fnn v0.9.0)', () => {
+    const rule = getBiscuitRuleForMethod('receive_btc');
+    expect(rule?.permissions).toEqual([{ action: 'write', resource: 'cch' }]);
+  });
+
+  it('scopes dev methods to write("dev") (fnn v0.9.0)', () => {
+    const devMethods = [
+      'commitment_signed',
+      'add_tlc',
+      'remove_tlc',
+      'check_channel_shutdown',
+      'sign_external_funding_tx',
+      'submit_commitment_transaction',
+    ];
+
+    for (const method of devMethods) {
+      expect(getBiscuitRuleForMethod(method)?.permissions).toEqual([
+        { action: 'write', resource: 'dev' },
+      ]);
+    }
+  });
+
+  it('grants read("cch") alongside write("cch") by default', () => {
+    // fnn v0.9.0: get_cch_order still needs read("cch"), and pre-v0.9.0 nodes
+    // require read("cch") for receive_btc — a write-only cch token is broken
+    // in practice on both.
+    expect(collectBiscuitPermissions(['receive_btc'])).toEqual([
+      { action: 'read', resource: 'cch' },
+      { action: 'write', resource: 'cch' },
+    ]);
+    expect(renderBiscuitFactsForMethods(['send_btc'])).toBe('read("cch");\nwrite("cch");');
+  });
+
+  it('can opt out of the cch read compat grant', () => {
+    expect(collectBiscuitPermissions(['receive_btc'], { cchReadCompat: false })).toEqual([
+      { action: 'write', resource: 'cch' },
+    ]);
+    expect(renderBiscuitFactsForMethods(['send_btc'], { cchReadCompat: false })).toBe(
+      'write("cch");',
+    );
+  });
+
+  it('does not add write("cch") for read-only cch methods', () => {
+    expect(collectBiscuitPermissions(['get_cch_order'])).toEqual([
+      { action: 'read', resource: 'cch' },
+    ]);
+  });
+
+  it('deliberately omits non-mintable or fail-closed upstream methods', () => {
+    // subscribe_store_changes requires the node-internal
+    // internal("store_changes") scope; backup_now is registered upstream
+    // under a rule key that does not match the RPC method name (`backup`).
+    expect(getBiscuitRuleForMethod('subscribe_store_changes')).toBeUndefined();
+    expect(getBiscuitRuleForMethod('backup_now')).toBeUndefined();
+    expect(getBiscuitRuleForMethod('backup')).toBeUndefined();
+  });
+
+  it('RULES mirrors the fnn v0.9.0 upstream rule table', () => {
+    const actual: Record<string, BiscuitMethodRule> = {};
+    for (const method of listSupportedBiscuitMethods()) {
+      const rule = getBiscuitRuleForMethod(method);
+      if (rule) actual[method] = rule;
+    }
+
+    expect(actual).toEqual(FNN_V0_9_0_RULES);
   });
 });

--- a/packages/sdk/tests/fixtures/fnn-biscuit-rules.ts
+++ b/packages/sdk/tests/fixtures/fnn-biscuit-rules.ts
@@ -1,0 +1,91 @@
+/**
+ * Expected SDK Biscuit rule table, transcribed from fnn v0.9.0
+ * `build_rules()` (crates/fiber-lib/src/rpc/biscuit.rs @ v0.9.0, also
+ * documented in upstream docs/biscuit-auth.md).
+ *
+ * Deliberate omissions vs the upstream table:
+ * - `subscribe_store_changes` — upstream requires `internal("store_changes")`,
+ *   a node-internal scope that user-minted tokens must not carry.
+ * - `backup_now` — upstream registers the rule under the key `backup_now`
+ *   while the RPC method is named `backup`, so authenticated calls are
+ *   fail-closed regardless of token contents ("no rules for method").
+ *
+ * `requiresChannelRight` is SDK-side modeling (upstream tracks a related but
+ * different `require_rpc_context` flag for server-side node_id injection);
+ * it is true only for the channel-scoped watchtower methods.
+ *
+ * When bumping the fnn target, re-transcribe this file from the new tag and
+ * update `RULES` in `src/security/biscuit-policy.ts` to match.
+ */
+import type { BiscuitMethodRule } from '../../src/security/biscuit-policy.js';
+
+function rule(
+  action: 'read' | 'write',
+  resource: string,
+  requiresChannelRight = false,
+): BiscuitMethodRule {
+  return { permissions: [{ action, resource }], requiresChannelRight };
+}
+
+export const FNN_V0_9_0_RULES: Record<string, BiscuitMethodRule> = {
+  // Cch
+  send_btc: rule('write', 'cch'),
+  receive_btc: rule('write', 'cch'),
+  get_cch_order: rule('read', 'cch'),
+
+  // Channel
+  open_channel: rule('write', 'channels'),
+  accept_channel: rule('write', 'channels'),
+  abandon_channel: rule('write', 'channels'),
+  list_channels: rule('read', 'channels'),
+  shutdown_channel: rule('write', 'channels'),
+  update_channel: rule('write', 'channels'),
+  open_channel_with_external_funding: rule('write', 'channels'),
+  submit_signed_funding_tx: rule('write', 'channels'),
+
+  // Dev
+  commitment_signed: rule('write', 'dev'),
+  add_tlc: rule('write', 'dev'),
+  remove_tlc: rule('write', 'dev'),
+  check_channel_shutdown: rule('write', 'dev'),
+  sign_external_funding_tx: rule('write', 'dev'),
+  submit_commitment_transaction: rule('write', 'dev'),
+
+  // Pprof
+  pprof: rule('write', 'pprof'),
+
+  // Graph
+  graph_nodes: rule('read', 'graph'),
+  graph_channels: rule('read', 'graph'),
+
+  // Info
+  node_info: rule('read', 'node'),
+
+  // Invoice
+  new_invoice: rule('write', 'invoices'),
+  parse_invoice: rule('read', 'invoices'),
+  get_invoice: rule('read', 'invoices'),
+  cancel_invoice: rule('write', 'invoices'),
+  settle_invoice: rule('write', 'invoices'),
+
+  // Payment
+  send_payment: rule('write', 'payments'),
+  get_payment: rule('read', 'payments'),
+  list_payments: rule('read', 'payments'),
+  build_router: rule('read', 'payments'),
+  send_payment_with_router: rule('write', 'payments'),
+
+  // Peer
+  connect_peer: rule('write', 'peers'),
+  disconnect_peer: rule('write', 'peers'),
+  list_peers: rule('read', 'peers'),
+
+  // Watchtower
+  create_watch_channel: rule('write', 'watchtower', true),
+  remove_watch_channel: rule('write', 'watchtower', true),
+  update_revocation: rule('write', 'watchtower', true),
+  update_local_settlement: rule('write', 'watchtower', true),
+  update_pending_remote_settlement: rule('write', 'watchtower', true),
+  create_preimage: rule('write', 'watchtower'),
+  remove_preimage: rule('write', 'watchtower'),
+};


### PR DESCRIPTION
Fixes #195

## What

Aligns the SDK Biscuit policy table (`packages/sdk/src/security/biscuit-policy.ts`) with fnn v0.9.0's `build_rules()` (`crates/fiber-lib/src/rpc/biscuit.rs` @ `v0.9.0`):

- **`receive_btc` → `write("cch")`** (was `read("cch")`). Upstream change: nervosnetwork/fiber@`287f3372`, first shipped in fnn v0.9.0. Tokens minted from the old rule are rejected by v0.9.0 nodes.
- **Dev RPCs → `write("dev")`** (upstream PR nervosnetwork/fiber#1432): `commitment_signed`, `add_tlc`, `remove_tlc`, `check_channel_shutdown`, `submit_commitment_transaction` (was `write("messages")` / `write("channels")` / `write("chain")`), plus newly covered `sign_external_funding_tx`.
- **Newly covered methods**: `list_payments` (`read("payments")`) and `pprof` (`write("pprof")`).
- **cch read-compat (default on)**: `collectBiscuitPermissions` / `renderBiscuitFactsForMethods` now grant `read("cch")` whenever `write("cch")` is collected. Biscuit `read`/`write` don't imply each other: on fnn v0.9.0 a write-only cch token cannot call `get_cch_order`, and on pre-v0.9.0 nodes `receive_btc` still requires `read("cch")`. Opt out with `{ cchReadCompat: false }`.

## Deliberate omissions (documented in code + fixture)

- `subscribe_store_changes` — upstream requires `internal("store_changes")` (nervosnetwork/fiber@`3cec9b18`), a node-internal scope user-minted tokens must not carry.
- `backup_now` — upstream registers the rule under key `backup_now` while the RPC method is named `backup`, so authenticated calls are fail-closed regardless of token contents (already noted in `client.ts` `backup()` docstring).

## Tests

- New snapshot fixture `packages/sdk/tests/fixtures/fnn-biscuit-rules.ts` transcribed from the fnn v0.9.0 tag; a test asserts `RULES` matches it exactly, so future upstream drift fails loudly.
- New cases: `receive_btc` write rule, dev-scope rules, cch read-compat default + opt-out, read-only cch methods stay read-only, omitted methods stay absent.
- `docs/develop.md` fnn version-upgrade checklist now lists `biscuit-policy.ts` + the fixture (this drift slipped through the v0.9.0 bump in #192).

## Validation

`pnpm format:check`, `pnpm lint`, `pnpm build`, `pnpm typecheck`, `pnpm test` — all pass (SDK 265/265, repo-wide green).

Out of scope per issue discussion: multi-version rule tables (fnn 0.8 vs 0.9) — deferred until multi-version node support is actually needed.
